### PR TITLE
Fixed not running performance test

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
@@ -11,10 +11,10 @@ abstract class PHPCRFunctionalTestCase extends \PHPUnit_Framework_TestCase
         $paths = __DIR__ . "/../../Models";
         $metaDriver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver($reader, $paths);
 
-        $url = isset($_GLOBALS['DOCTRINE_PHPCR_REPOSITORY']) ? $_GLOBALS['DOCTRINE_PHPCR_REPOSITORY'] : 'http://127.0.0.1:8080/server/';
-        $workspace = isset($_GLOBALS['DOCTRINE_PHPCR_WORKSPACE']) ? $_GLOBALS['DOCTRINE_PHPCR_WORKSPACE'] : 'tests';
-        $user = isset($_GLOBALS['DOCTRINE_PHPCR_USER']) ? $_GLOBALS['DOCTRINE_PHPCR_USER'] : '';
-        $pass = isset($_GLOBALS['DOCTRINE_PHPCR_PASS']) ? $_GLOBALS['DOCTRINE_PHPCR_PASS'] : '';
+        $url = isset($GLOBALS['DOCTRINE_PHPCR_REPOSITORY']) ? $GLOBALS['DOCTRINE_PHPCR_REPOSITORY'] : 'http://127.0.0.1:8080/server/';
+        $workspace = isset($GLOBALS['DOCTRINE_PHPCR_WORKSPACE']) ? $GLOBALS['DOCTRINE_PHPCR_WORKSPACE'] : 'tests';
+        $user = isset($GLOBALS['DOCTRINE_PHPCR_USER']) ? $GLOBALS['DOCTRINE_PHPCR_USER'] : '';
+        $pass = isset($GLOBALS['DOCTRINE_PHPCR_PASS']) ? $GLOBALS['DOCTRINE_PHPCR_PASS'] : '';
 
         $repository = new \Jackalope\Repository(new \Jackalope\Factory, $url);
         $credentials = new \PHPCR\SimpleCredentials($user, $pass);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Performance/InsertPerformanceTest.php
@@ -4,18 +4,27 @@ namespace Doctrine\Tests\ODM\PHPCR\Performance;
 
 class InsertPerformanceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 {
-    public function testInsert2000Documents()
+    protected $count = 100;
+
+    public function setup()
     {
+        $this->dm = $this->createDocumentManager();
+        $this->node = $this->resetFunctionalNode($this->dm);
+        $this->count = isset($GLOBALS['DOCTRINE_PHPCR_PERFORMANCE_COUNT']) ? $GLOBALS['DOCTRINE_PHPCR_PERFORMANCE_COUNT'] : 100;
+    }
+
+    public function testInsertDocuments()
+    {
+
         if (\extension_loaded('xdebug')) {
             $this->markTestSkipped('Performance-Testing with xdebug enabled makes no sense.');
         }
 
-        $n = 30;
         $dm = $this->createDocumentManager();
 
         $s = microtime(true);
 
-        for($i = 0; $i < $n; $i++) {
+        for($i = 0; $i < $this->count; $i++) {
             $user = new \Doctrine\Tests\Models\CMS\CmsUser();
             $user->name = "Benjamin";
             $user->username = "beberlei";
@@ -28,6 +37,6 @@ class InsertPerformanceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
 
         $diff = microtime(true) - $s;
 
-        $this->assertTrue($diff < 1.0, "Inserting " . $n . " documents shouldn't take longer than one second, took " . $diff . " seconds.");
+        $this->assertTrue($diff < 1.0, "Inserting " . $this->count . " documents shouldn't take longer than one second, took " . $diff . " seconds.");
     }
 }

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -5,6 +5,9 @@
         <var name="DOCTRINE_PHPCR_PASS" value="" />
         <!-- to create the "tests" workspace see http://www.eppelheimer.com/clients/day/jackrabbit/site/apache/faq.html#create-workspace -->
         <var name="DOCTRINE_PHPCR_WORKSPACE" value="tests" />
+        <!-- to adjust performance results to your specific hardware, use integers only. -->
+        <!-- the InsertPerformanceTest tries to insert count nodes in one second -->
+        <var name="DOCTRINE_PHPCR_PERFORMANCE_COUNT" value="100" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
Called a undefined function and had unrealistic performance
expectations.
But now you can just run phpunit from the tests folder.
