### PR TITLE
UoW::getPredecessor() use the version manager instead of jackalope intern

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -815,8 +815,8 @@ class UnitOfWork
     {
         $path = $this->documentIds[spl_object_hash($document)];
         $session = $this->dm->getPhpcrSession();
-        $node = $session->getNode($path, 'Version\Version');
-        return $node->getPredecessors();
+        $vm = $session->getWorkspace()->getVersionManager();
+        return $vm->getBaseVersion($path)->getPredecessors();
     }
 
     /**


### PR DESCRIPTION
UoW::getPredecessor() use the version manager instead of jackalope internal features

Allows reverting https://github.com/jackalope/jackalope/commit/ad87958cc3fa4b9cfc0868eac348b2ba9f7d60bb
