### PR TITLE
Make sure annotations for build in documents are loaded

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
@@ -81,6 +81,7 @@ class AnnotationDriver implements Driver
      */
     public function __construct(Reader $reader, $paths = null)
     {
+        $this->addPaths(array(__DIR__.'/../../Document'));
         $this->reader = $reader;
         if ($paths) {
             $this->addPaths((array) $paths);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
@@ -16,6 +16,17 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $annotationDriver->loadMetadataForClass('stdClass', $cm);
     }
 
+    public function testLoadMetadataForBuiltinClasses()
+    {
+        $rightClassName = 'Doctrine\ODM\PHPCR\Document\File';
+        $this->ensureIsLoaded($rightClassName);
+
+        $annotationDriver = $this->loadDriverForBuiltinDocuments();
+        $classes = $annotationDriver->getAllClassNames();
+
+        $this->assertContains($rightClassName, $classes);
+    }
+
     public function testGetAllClassNamesIsIdempotent()
     {
         $annotationDriver = $this->loadDriverForCMSDocuments();
@@ -50,6 +61,13 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     }
 
     protected function loadDriverForCMSDocuments()
+    {
+        $annotationDriver = $this->loadDriver();
+        $annotationDriver->addPaths(array(__DIR__ . '/../../../../../Doctrine/Tests/Models/CMS'));
+        return $annotationDriver;
+    }
+
+    protected function loadDriverForBuiltinDocuments()
     {
         $annotationDriver = $this->loadDriver();
         $annotationDriver->addPaths(array(__DIR__ . '/../../../../../Doctrine/Tests/Models/CMS'));

--- a/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
@@ -10,7 +10,6 @@ abstract class PHPCRFunctionalTestCase extends \PHPUnit_Framework_TestCase
 
         $paths = array();
         $paths[] = __DIR__ . "/../../Models";
-        $paths[] = __DIR__ . "/../../../../../lib/Doctrine/ODM/PHPCR/Document";
         $metaDriver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver($reader, $paths);
 
         $factoryclass = isset($GLOBALS['DOCTRINE_PHPCR_FACTORY']) ?


### PR DESCRIPTION
Requires client code to use the AnnotationDriver, optionally implement
mapping for yml and xml for built in documents and make those drivers
require these definitions as well.
## 

This is an alternative fix for https://github.com/symfony-cmf/cmf-sandbox/issues/20 which looks "cleaner" to me. Still this will not be sufficient when you use other mappings than annotations
