### PR TITLE
Fix metadata loading of builtin documents

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Configuration.php
+++ b/lib/Doctrine/ODM/PHPCR/Configuration.php
@@ -20,6 +20,7 @@
 namespace Doctrine\ODM\PHPCR;
 
 use Doctrine\ODM\PHPCR\Mapping\Driver\Driver;
+use Doctrine\ODM\PHPCR\Mapping\Driver\BuiltinDocumentsDriver;
 use Doctrine\ODM\PHPCR\DocumentNameMapperInterface;
 
 /**
@@ -132,7 +133,7 @@ class Configuration
      */
     public function setMetadataDriverImpl(Driver $driverImpl)
     {
-        $this->attributes['metadataDriverImpl'] = $driverImpl;
+        $this->attributes['metadataDriverImpl'] = new BuiltinDocumentsDriver($driverImpl);
     }
 
     /**

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/BuiltinDocumentsDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/BuiltinDocumentsDriver.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Doctrine\ODM\PHPCR\Mapping\Driver;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
+use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
+
+/**
+ * The BuiltinDocumentsDriver is used internally to make sure
+ * that the mapping for the built-in documents can be loaded
+ *
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link        www.doctrine-project.org
+ * @since       1.0
+ * @author      Uwe Jäger <uwej711e@googlemail.com>
+ */
+class BuiltinDocumentsDriver implements Driver
+{
+    /**
+     * namespace of built-in documents
+     */
+    const NAME_SPACE = 'Doctrine\ODM\PHPCR\Document';
+
+    /**
+     * @var Driver
+     */
+    private $wrappedDriver;
+
+    /**
+     * @var Driver
+     */
+    private $builtinDriver;
+
+    /**
+     * Create with a driver to wrap
+     *
+     * @param Driver $nestedDriver
+     * @param string $namespace
+     */
+    public function __construct(Driver $wrappedDriver)
+    {
+        $this->wrappedDriver = $wrappedDriver;
+
+        $reader = new AnnotationReader();
+        $this->builtinDriver = new AnnotationDriver($reader, array(realpath(__DIR__.'/../../Document')));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadMetadataForClass($className, ClassMetadata $class)
+    {
+        if (strpos($className, self::NAME_SPACE) === 0) {
+            $this->builtinDriver->loadMetadataForClass($className, $class);
+            return;
+        }
+
+        $this->wrappedDriver->loadMetadataForClass($className, $class);
+    }
+
+
+    /**
+     * Gets the names of all mapped classes known to this driver.
+     *
+     * @return array The names of all mapped classes known to this driver.
+     */
+    public function getAllClassNames()
+    {
+        $classNames = array();
+        $classNames = array_merge($classNames, $this->builtinDriver->getAllClassNames());
+        $classNames = array_merge($classNames, $this->wrappedDriver->getAllClassNames());
+        return $classNames;
+    }
+
+    /**
+     * Whether the class with the specified name should have its metadata loaded.
+     *
+     * This is only the case for non-transient classes either mapped as an Document or MappedSuperclass.
+     *
+     * @param string $className
+     * @return boolean
+     */
+    public function isTransient($className)
+    {
+        if (strpos($className, self::NAME_SPACE) === 0) {
+            return $this->builtinDriver->isTransient($className);
+        }
+
+        return $this->wrappedDriver->isTransient($className);
+    }
+}

--- a/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
@@ -10,7 +10,6 @@ abstract class PHPCRFunctionalTestCase extends \PHPUnit_Framework_TestCase
 
         $paths = array();
         $paths[] = __DIR__ . "/../../Models";
-        $paths[] = __DIR__ . "/../../../../../lib/Doctrine/ODM/PHPCR/Document";
         $metaDriver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver($reader, $paths);
 
         $factoryclass = isset($GLOBALS['DOCTRINE_PHPCR_FACTORY']) ?


### PR DESCRIPTION
The wrapped metadata driver ensures that metadata for the builtin
documents is loaded. Still the DoctrineAnnotations need to be registered
with the AnnotationRegistry.

see https://github.com/symfony-cmf/cmf-sandbox/issues/20
