### PR TITLE
Prevent duplicated storage of properties in jackrabbit

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -596,8 +596,10 @@ class UnitOfWork
                 if ($class->isCollectionValuedAssociation($fieldName)) {
                     if (!$fieldValue instanceof PersistentCollection) {
                         // if its not a persistent collection and the original value changed. otherwise it could just be null
-                        $changed = true;
-                        break;
+                        if($this->originalData[$oid][$fieldName] !== $fieldValue) {
+                            $changed = true;
+                            break;
+                        }
                     } elseif ($fieldValue->changed()) {
                         $this->visitedCollections[] = $fieldValue;
                         $changed = true;


### PR DESCRIPTION
At the moment the UnityOfWork will re schedule nodes to be inserted in Jackrabbit even if they have been inserted already in that session. That means when importing data successively into JCR the number of curl_exec calls will virtually explode… for example two articles that take 51 curl requests each when imported separately; if imported combined it will take over 300 curl requests. Things get worse as we import more and more articles.

The problem seems to be related to how the UnityOfWork::computeChangeSet method works. 

At the moments there's a TODO left by Jordi that says "// TODO coll shold be a new PersistentCollection":
https://github.com/doctrine/phpcr-odm/blob/master/lib/Doctrine/ODM/PHPCR/UnitOfWork.php#L567

Then further down there's an conditional `if (!$fieldValue instanceof PersistentCollection) {` that seems to fail so it re-schedules the node as changed:
https://github.com/doctrine/phpcr-odm/blob/master/lib/Doctrine/ODM/PHPCR/UnitOfWork.php#L602

I added a very ugly and quick hack around it, but I think someone that understands what the code is doing should be able to provide a proper fix.

I would like to provide tests but the test environment is not working properly on my machine after I checked out the project and its submodules.
