### PR TITLE
new persistent collection class for reference many properties

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/ReferenceManyCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ReferenceManyCollection.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\ODM\PHPCR;
+
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * Property collection class
+ *
+ * This class stores all documents or their proxies referenced by a reference many property 
+ */
+class ReferenceManyCollection extends PersistentCollection
+{
+    public function __construct(Collection $coll, $isDirty = false)
+    {
+        $this->coll = $coll;
+        $this->isDirty = $isDirty;
+        $this->initialized = true;
+    }
+
+    /**
+     * Just there to fulfill the interface requirements of PersistentCollection
+     */
+    public function initialize()
+    {
+        $this->initialized = true;
+    }
+}
+

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -109,7 +109,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     /**
      * @expectedException Doctrine\ODM\PHPCR\PHPCRException
-     * @expectedExceptionMessage Referenced document is not stored correctly in a reference-many property. Use array notation.
+     * @expectedExceptionMessage Referenced document is not stored correctly in a reference-many property. Use array notation or a ReferenceManyCollection.
      */
     public function testCreateManyNoArrayError()
     {
@@ -128,7 +128,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     /**
      * @expectedException Doctrine\ODM\PHPCR\PHPCRException
-     * @expectedExceptionMessage Referenced document is not stored correctly in a reference-one property. Don't use array notation.
+     * @expectedExceptionMessage Referenced document is not stored correctly in a reference-one property. Don't use array notation or a ReferenceManyCollection.
      */
     public function testCreateOneArrayError()
     {


### PR DESCRIPTION
this brings a new persistent collection to store all documents or their proxies referenced by a reference-many-property

while doing this the following came up to my mind:
wouldn't it be better to handle reference-many-properties like other multivalued properties and make use of the MultivaluePropertyCollection, too?

Or are references “special enough” to get a separate treatment?
