### PR TITLE
Reference issue

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1882,15 +1882,12 @@ class UnitOfWork
         }
 
         $node->addMixin('mix:versionable');
-        if (!$node->isNodeType('mix:referenceable')) {
-            $node->addMixin('mix:referenceable');
-        }
     }
 
     protected function setMixins(Mapping\ClassMetadata $metadata, NodeInterface $node)
     {
         if ($metadata->versionable === 'full') {
-            $this->checkFullVersioning($metadata, $node);
+            $node->addMixin('mix:versionable');
         } else {
             if ($metadata->versionable === 'simple') {
                 $node->addMixin('mix:simpleVersionable');


### PR DESCRIPTION
i have done the changes for 2 reasons:
1) centralizing the mixin logic
2) handle the case if a phpcr implementation doesn't know about `mix:versionable` and therefore not know that it extends `mix:referenceable` (not sure if this is even possible @dbu)

note the original reason for working on this was to try and make midgard happy again with the recent changes to the reference handling (@bergie)
