### PR TITLE
Lazyload ReferenceMany

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/ReferenceManyCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ReferenceManyCollection.php
@@ -13,7 +13,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 class ReferenceManyCollection extends MultivaluePropertyCollection
 {
 
-    private $session;
     private $referencedDocUUIDs;
     private $targetDocument = null;
     
@@ -21,14 +20,12 @@ class ReferenceManyCollection extends MultivaluePropertyCollection
      * Creates a new persistent collection.
      *
      * @param DocumentManager $dm The DocumentManager the collection will be associated with.
-     * @param \PHPCR\SessionInterface $session The current session
      * @param array $referencedDocUUIDs An array of referenced UUIDs
      * @param string $targetDocument the objectname of the target documents
      */
-    public function __construct(DocumentManager $dm, \PHPCR\SessionInterface $session, array $referencedDocUUIDs, $targetDocument)
+    public function __construct(DocumentManager $dm, array $referencedDocUUIDs, $targetDocument)
     {
         $this->dm = $dm;
-        $this->session = $session;
         $this->referencedDocUUIDs = $referencedDocUUIDs;
         $this->targetDocument = $targetDocument;
     }
@@ -43,7 +40,7 @@ class ReferenceManyCollection extends MultivaluePropertyCollection
             $this->initialized = true;
 
             $referencedDocs = array();
-            $referencedNodes = $this->session->getNodesByIdentifier($this->referencedDocUUIDs);
+            $referencedNodes = $this->dm->getPhpcrSession()->getNodesByIdentifier($this->referencedDocUUIDs);
             $uow = $this->dm->getUnitOfWork();
             foreach ($referencedNodes as $referencedNode) {
                 $referencedClass = $this->targetDocument ? $this->dm->getMetadataFactory()->getMetadataFor(ltrim($this->targetDocument, '\\'))->name : null;

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -302,7 +302,7 @@ class UnitOfWork
                     $referencedDocUUIDs[] = $uuid;
                 }
                 if (count($referencedDocUUIDs) > 0) {
-                    $coll = new ReferenceManyCollection($this->dm, $this->session, $referencedDocUUIDs, $assocOptions['targetDocument']);
+                    $coll = new ReferenceManyCollection($this->dm, $referencedDocUUIDs, $assocOptions['targetDocument']);
                     $documentState[$class->associationsMappings[$assocName]['fieldName']] = $coll;
                 }
             }


### PR DESCRIPTION
This implements lazy loading for MANY_TO_MANY references via the ReferenceManyCollection. The referenced documents are only loaded when actually accessed

This fixes http://www.doctrine-project.org/jira/browse/PHPCR-52

MANY_TO_ONE references are still missing. to be done, I opened a issue for that, see 
http://www.doctrine-project.org/jira/browse/PHPCR-54
