### PR TITLE
[wip] fix namespace to follow convention (PHPCR-42)

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Tests\ODM\PHPCR\Functional;
+namespace Doctrine\Tests\ODM\PHPCR\Functional\Mapping;
 
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface,
     Doctrine\ODM\PHPCR\DocumentRepository,
@@ -78,17 +78,17 @@ class MappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     public function testIdStrategy()
     {
-        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\ParentIdStrategy');
+        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\ParentIdStrategy');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_PARENT, $metadata->idGenerator, 'parentId');
-        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\ParentIdStrategyDifferentOrder');
+        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\ParentIdStrategyDifferentOrder');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_PARENT, $metadata->idGenerator, 'parentId2');
-        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\AssignedIdStrategy');
+        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AssignedIdStrategy');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_ASSIGNED, $metadata->idGenerator, 'assigned');
-        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\RepositoryIdStrategy');
+        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\RepositoryIdStrategy');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_REPOSITORY, $metadata->idGenerator, 'repository');
-        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\AutoAssignedIdStrategy');
+        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AutoAssignedIdStrategy');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_ASSIGNED, $metadata->idGenerator, 'autoassigned');
-        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\StandardCase');
+        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\StandardCase');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_ASSIGNED, $metadata->idGenerator, 'standardcase');
     }
 


### PR DESCRIPTION
hi @dbu, @lsmith, @ocramius i gave thought to this and did some corrections https://github.com/doctrine/phpcr-odm/pull/133
however I am totally disoriented as i see two Mapping folders as follows:
1. https://github.com/doctrine/phpcr-odm/tree/master/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping
   There is only 1 class here with a TODO which i found not very clear about what to do next
2. https://github.com/doctrine/phpcr-odm/tree/master/tests/Doctrine/Tests/ODM/PHPCR/Mapping
   These set of classes was already refactored by someone else before I came in and I guess the work is done

I check the coverage as you said on the annotation driver class so it basically lacks the lifecycle callbacks usage, but where to put these tests in as i am confused

``` sh
     160               0 :                     if ($annot instanceof ODM\PrePersist) {                                                          
     161               0 :                         $metadata->addLifecycleCallback($method->getName(), Event::prePersist);                      
     162               0 :                     } elseif ($annot instanceof  ODM\PostPersist) {                                                  
     163               0 :                         $metadata->addLifecycleCallback($method->getName(), Event::postPersist);                     
     164               0 :                     } elseif ($annot instanceof ODM\PreUpdate) {                                                     
     165               0 :                         $metadata->addLifecycleCallback($method->getName(), Event::preUpdate);                       
     166               0 :                     } elseif ($annot instanceof ODM\PostUpdate) {                                                    
     167               0 :                         $metadata->addLifecycleCallback($method->getName(), Event::postUpdate);                      
     168               0 :                     } elseif ($annot instanceof ODM\PreRemove) {                                                     
     169               0 :                         $metadata->addLifecycleCallback($method->getName(), Event::preRemove);                       
     170               0 :                     } elseif ($annot instanceof ODM\PostRemove) {                                                    
     171               0 :                         $metadata->addLifecycleCallback($method->getName(), Event::postRemove);                      
     172               0 :                     } elseif ($annot instanceof  ODM\PostLoad) {                                                     
     173               0 :                         $metadata->addLifecycleCallback($method->getName(), Event::postLoad);                        
     174               0 :                     }                                                                                                
```

Also i am not very familiar with the schema of the annotation driver how to test so any explanation or help pointers would be great, thanks
