### PR TITLE
adding a findOne method without class to document manager

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -305,6 +305,21 @@ class DocumentManager implements ObjectManager
     }
 
     /**
+     * Convenience method not part of the common interface to get a document.
+     *
+     * PHPCR-ODM does not need the document class in order to be able to load a
+     * document. This method is equivalent to calling find(null, $id);
+     *
+     * @param string $id
+     *
+     * @return object
+     */
+    public function findOne($id)
+    {
+        return $this->find(null, $id);
+    }
+
+    /**
      * Finds many documents by id.
      *
      * @param null|string $className


### PR DESCRIPTION
this was a simplification proposer by @beberlei at the symfony hackday. having to pass `null` as first parameter everywhere is awkward. we can't change the `find` method though, as it is part of the interface.

we should also think whether we could offer simplified methods for findMany and findTranslation. having a different order in findMany than in find seems bad though and would pose problems if findMany would ever be moved into the interface, so not really sure if/how we want to do that. for findTranslation i think changing the order to have $className = null as last paramter after the $fallback = true param would sound ok to me, as the method signature its quite different anyway.
