### PR TITLE
Removed "array $nonSuperclassParents" from doLoadMetaData attribute list...

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -117,7 +117,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * {@inheritdoc}
      */
-    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
+    protected function doLoadMetadata($class, $parent, $rootEntityFound)
     {
         if ($parent) {
             $this->addInheritedFields($class, $parent);


### PR DESCRIPTION
..., for it to match the abstract method signature from the parent class "Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory"
