### PR TITLE
fixes fatal error in ClassMetadataFactory

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -117,7 +117,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * {@inheritdoc}
      */
-    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
+    protected function doLoadMetadata($class, $parent, $rootEntityFound)
     {
         if ($parent) {
             $this->addInheritedFields($class, $parent);


### PR DESCRIPTION
"Fatal error: Declaration of Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory::doLoadMetadata() must be compatible with that of Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory::doLoadMetadata()"
