### PR TITLE
Add referenceable to YamlDriver

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
@@ -72,6 +72,10 @@ class YamlDriver extends FileDriver
                 $class->setVersioned($element['versionable']);
             }
 
+            if (isset($element['referenceable']) && $element['referenceable'] !== 'false') {
+                $class->setReferenceable($element['referenceable']);
+            }
+
             $class->setNodeType(isset($element['nodeType']) ? $element['nodeType'] : 'nt:unstructured');
         } elseif ($element['type'] === 'mappedSuperclass') {
             $class->isMappedSuperclass = true;


### PR DESCRIPTION
I noticed that the YamlDriver was missing the referenceable keyword. So I copied the definition from the XmlDriver.
