### PR TITLE
Add missing type casts for versionable and referenceable in XML driver

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
@@ -69,11 +69,11 @@ class XmlDriver extends FileDriver
             }
 
             if (isset($xmlRoot['versionable']) && $xmlRoot['versionable'] !== 'false') {
-                $class->setVersioned($xmlRoot['versionable']);
+                $class->setVersioned((string)$xmlRoot['versionable']);
             }
 
             if (isset($xmlRoot['referenceable']) && $xmlRoot['referenceable'] !== 'false') {
-                $class->setReferenceable($xmlRoot['referenceable']);
+                $class->setReferenceable((bool)$xmlRoot['referenceable']);
             }
 
             $class->setNodeType(isset($xmlRoot['nodeType']) ? (string) $xmlRoot['nodeType'] : 'nt:unstructured');


### PR DESCRIPTION
While working on a test case for referenceable I noticed that the XML driver didn't type cast the Simple XML object for versionable and referenceable.
