### PR TITLE
Update lib/Doctrine/ODM/PHPCR/UnitOfWork.php

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1121,6 +1121,13 @@ class UnitOfWork
      */
     public function persistNew($class, $document, $overrideIdGenerator = null, $parent = null)
     {
+        if (isset($class->lifecycleCallbacks[Event::prePersist])) {
+            $class->invokeLifecycleCallbacks(Event::prePersist, $document);
+        }
+        if ($this->evm->hasListeners(Event::prePersist)) {
+            $this->evm->dispatchEvent(Event::prePersist, new LifecycleEventArgs($document, $this->dm));
+        }
+        
         $generator = $overrideIdGenerator ? $overrideIdGenerator : $class->idGenerator;
 
         $id = $this->getIdGenerator($generator)->generate($document, $class, $this->dm, $parent);
@@ -1128,13 +1135,6 @@ class UnitOfWork
 
         if ($generator !== ClassMetadata::GENERATOR_TYPE_ASSIGNED) {
             $class->setIdentifierValue($document, $id);
-        }
-
-        if (isset($class->lifecycleCallbacks[Event::prePersist])) {
-            $class->invokeLifecycleCallbacks(Event::prePersist, $document);
-        }
-        if ($this->evm->hasListeners(Event::prePersist)) {
-            $this->evm->dispatchEvent(Event::prePersist, new LifecycleEventArgs($document, $this->dm));
         }
     }
 


### PR DESCRIPTION
changed execution order in the persistNew function so any lifecycle events get called before the id generator logic is executed. This enables you to set the id/path of a node using a prePersist event.
Test run successfully. 
