### PR TITLE
Remove redundant function in Doctrine\ODM\PHPCR\Mapping\ClassMetadata

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -344,7 +344,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * Registers a custom repository class for the document class.
      *
-     * @param string $mapperClassName  The class name of the custom mapper.
+     * @param string $repositoryClassName  The class name of the custom repository.
      */
     public function setCustomRepositoryClassName($repositoryClassName)
     {
@@ -423,16 +423,6 @@ class ClassMetadata implements ClassMetadataInterface
     public function setNodeType($nodeType)
     {
         $this->nodeType = $nodeType;
-    }
-
-    /**
-     * Registers a custom repository class for the document class.
-     *
-     * @param string $mapperClassName  The class name of the custom mapper.
-     */
-    public function setCustomRepositoryClass($repositoryClassName)
-    {
-        $this->customRepositoryClassName = $repositoryClassName;
     }
 
     /**


### PR DESCRIPTION
I'm not sure about this one, but the function setCustomRepositoryClass is a duplicate of setCustomRepositoryClassName. Only the last one is used in the drivers.
From my investigation the duplicate showed up in 42e9550 when ClassMetadata was renamed ClassMetadataInfo (and then later renamed back again...)
