### PR TITLE
allow move to work with missing leading '/' as find does

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -603,6 +603,10 @@ class DocumentManager implements ObjectManager
             throw new \InvalidArgumentException(gettype($document));
         }
 
+        if (strpos($targetPath, '/') !== 0) {
+            $targetPath = '/'.$targetPath;
+        }
+
         $this->errorIfClosed();
         $this->unitOfWork->scheduleMove($document, $targetPath);
     }


### PR DESCRIPTION
Makes the admin's tree move work (partly, reorder doesn't work yet) again. 
