### PR TITLE
suggests => suggest (minor change for composer validation)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "symfony/yaml": ">=2.0.0,<2.2.0-dev"
     },
-    "suggests":{
+    "suggest":{
         "symfony/yaml":">=2.0.0,<2.2.0-dev",
         "jackalope/jackalope-doctrine-dbal":"dev-master",
         "jackalope/jackalope-jackrabbit":"1.0.*",


### PR DESCRIPTION
While working on getting `bin/phpcr` running from a vendor I noticed that Composer validate was complaining about the `suggests` key. Updated to `suggest` as specified in the Composer [schema docs](http://getcomposer.org/doc/04-schema.md#suggest).
