### PR TITLE
targetDocument is not always available.

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -336,7 +336,8 @@ class UnitOfWork
                 }
 
                 if (count($referencedNodes) > 0) {
-                    $coll = new ReferenceManyCollection($this->dm, $referencedNodes, $assocOptions['targetDocument']);
+                    $targetDocument = isset($assocOptions['targetDocument']) ? $assocOptions['targetDocument'] : null;
+                    $coll = new ReferenceManyCollection($this->dm, $referencedNodes, $targetDocument);
                     $documentState[$class->associationsMappings[$assocName]['fieldName']] = $coll;
                 }
             }


### PR DESCRIPTION
The [documentation](http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/association-mapping.html#reference-other-documents) implied that `targetDocument` was optional but this was causing an undefined index notice when `targetDocument` is not specified. 
