### PR TITLE
do not attempt to make a node versionable if the phpcr session does not support it

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -448,6 +448,24 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertNotNull($user);
         $this->assertEquals($user->parameters->toArray(), $assocArray);
     }
+
+    public function testVersionedDocument()
+    {
+        $user = new VersionTestObj();
+        $user->username = "test";
+        $user->numbers = array(1, 2, 3);
+        $user->id = '/functional/test';
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $userNew = $this->dm->find($this->type, '/functional/test');
+
+        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertEquals($user->username, $userNew->username);
+        $this->assertEquals($user->numbers->toArray(), $userNew->numbers->toArray());
+    }
 }
 
 /**
@@ -536,3 +554,25 @@ class TeamUser extends User
     public $parent;
 }
 
+/**
+ * @PHPCRODM\Document(versionable="full")
+ */
+class VersionTestObj
+{
+    /** @PHPCRODM\Id */
+    public $id;
+    /** @PHPCRODM\Node */
+    public $node;
+
+    /** @PHPCRODM\VersionName */
+    public $versionName;
+
+    /** @PHPCRODM\VersionCreated */
+    public $versionCreated;
+
+    /** @PHPCRODM\String(name="username") */
+    public $username;
+
+    /** @PHPCRODM\Int(name="numbers", multivalue=true) */
+    public $numbers;
+}


### PR DESCRIPTION
fixes http://doctrine-project.org/jira/browse/PHPCR-47

the idea is that applications can mark documents as versionable, but then dynamically decide if they can use the version API calls based on the capabilities of the PHPCR implementation.
