### PR TITLE
Added validation check for translatble properties

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -351,6 +351,22 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
+     * Validate translatable fields - ensure that the document has a
+     * translator strategy in place.
+     *
+     * @throws MappingException
+     * @return void
+     */
+    public function validateTranslatables()
+    {
+        if (count($this->translatableFields) > 0) {
+            if (null === $this->translator) {
+                throw MappingException::noTranslatorStrategy($this->name, $this->translatableFields);
+            }
+        }
+    }
+
+    /**
      * Validate lifecycle callbacks
      *
      * @param \Doctrine\Common\Persistence\Mapping\ReflectionService $reflService

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -213,6 +213,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         $class->validateIdentifier();
         $class->validateAssocations();
         $class->validateLifecycleCallbacks($this->getReflectionService());
+        $class->validateTranslatables();
 
         // verify inheritance
         // TODO

--- a/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
@@ -128,4 +128,9 @@ class MappingException extends \Exception
     {
         return new self("Document '" . $className . "' has no method '" . $methodName . "' to be registered as lifecycle callback.");
     }
+
+    public static function noTranslatorStrategy($className, $fieldNames)
+    {
+        return new self("Document '" .$className."' does not have a translation strategy, but the fields ('".implode(', ', $fieldNames)."' have been set as translatable.");
+    }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -109,4 +109,17 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('full', $meta->versionable);
         $this->assertEquals('Barfoo', $meta->customRepositoryClassName);
     }
+
+    /**
+     * @expectedException Doctrine\ODM\PHPCR\Mapping\MappingException
+     */
+    public function testValidateTranslatableNoStrategy()
+    {
+        $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObjectNoStrategy');
+    }
+
+    public function testValidateTranslatable()
+    {
+        $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObject');
+    }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/TranslatorMappingObjectNoStrategy.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/TranslatorMappingObjectNoStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * An invalid class with translated fields but no translator
+ *
+ * @PHPCRODM\Document()
+ */
+class TranslatorMappingObjectNoStrategy
+{
+    /**
+     * The language this document currently is in
+     * @PHPCRODM\Locale
+     */
+    private $doclocale;
+
+    /**
+     * Untranslated property
+     * @PHPCRODM\Date
+     */
+    private $publishDate;
+
+    /**
+     * Translated property
+     * @PHPCRODM\String(translated=true)
+     */
+    private $topic;
+
+    /**
+     * Language specific image
+     * @PHPCRODM\Binary(translated=true)
+     */
+    private $image;
+}


### PR DESCRIPTION
- Check to see that the "translator" attribute has been set on the
  document, if not throw an exception.
