### PR TITLE
Fix loading translated fields

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2492,8 +2492,11 @@ class UnitOfWork
 
         $oid = spl_object_hash($document);
 
+        $localesToTry = array();
+
         if (null === $locale) {
-            $localeUsed = $this->dm->getLocaleChooserStrategy()->getDefaultLocale();
+            $defaultLocale = $this->dm->getLocaleChooserStrategy()->getDefaultLocale();
+            $localesToTry = array($defaultLocale);
         } else {
             // Determine which languages we will try to load
             if (!$fallback) {
@@ -2501,15 +2504,16 @@ class UnitOfWork
             } else {
                 $localesToTry = $this->getFallbackLocales($document, $metadata, $locale);
             }
+        }
 
-            $node = $this->session->getNode($this->getDocumentId($oid));
-            $strategy = $this->dm->getTranslationStrategy($metadata->translator);
+        // Load translated fields for current locale
+        $node = $this->session->getNode($this->getDocumentId($oid));
+        $strategy = $this->dm->getTranslationStrategy($metadata->translator);
 
-            foreach ($localesToTry as $desiredLocale) {
-                if ($strategy->loadTranslation($document, $node, $metadata, $desiredLocale)) {
-                    $localeUsed = $desiredLocale;
-                    break;
-                }
+        foreach ($localesToTry as $desiredLocale) {
+            if ($strategy->loadTranslation($document, $node, $metadata, $desiredLocale)) {
+                $localeUsed = $desiredLocale;
+                break;
             }
         }
 


### PR DESCRIPTION
There was a problem while loading an document with locale based properties. In the current master branch these properties are always null and unloaded.

So I change the doLoadTranslation to always call locale chooser strategie's loadTranslation method, not matter if we got an locale parameter or run into fallback case.

Unfortunality I wasn't able to add such a test case. But it works. ;-)
