### PR TITLE
Add a method to return the node of the given document

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -1045,4 +1045,25 @@ class DocumentManager implements ObjectManager
 
         $this->unitOfWork->initializeObject($document);
     }
+    
+    /**
+     * Return the node of the given object
+     * 
+     * @param object $document
+     * 
+     * @return \PHPCR\NodeInterface
+     * 
+     * @throws \InvalidArgumentException if the document is not an object
+     * @throws \PHPCR\PHPCRException if the document is not managed
+     */
+    public function getNodeForDocument($document)
+    {
+        if (!is_object($document)) {
+            throw new \InvalidArgumentException('Parameter $document needs to be an object, '.gettype($document).' given');
+        }
+        
+        $path = $this->unitOfWork->getDocumentId($document);
+        
+        return $this->session->getNode($path);
+    }
 }


### PR DESCRIPTION
A public method "getNodeForDocument" that takes one argument, the document, and returns its node.

Related to this comment: https://github.com/doctrine/DoctrinePHPCRBundle/issues/2#issuecomment-11979864
