### PR TITLE
totally refactored the ClassMetadata class to store all mappings in a single array

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Id/ParentIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/ParentIdGenerator.php
@@ -32,7 +32,7 @@ class ParentIdGenerator extends IdGenerator
      */
     public function generate($document, ClassMetadata $cm, DocumentManager $dm)
     {
-        $parent = $cm->getFieldValue($document, $cm->parentMapping['fieldName']);
+        $parent = $cm->getFieldValue($document, $cm->parentMapping);
         $name = $cm->getFieldValue($document, $cm->nodename);
         $id = $cm->getFieldValue($document, $cm->identifier);
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
@@ -32,7 +32,17 @@ class MappingException extends \Exception
 {
     public static function classNotFound($className)
     {
-        return new self("The class: '$className'. could not be found");
+        return new self("The class '$className' could not be found");
+    }
+
+    public static function fieldNotFound($className, $fieldName)
+    {
+        return new self("The class '$className' does not have a field mapping for '$fieldName'");
+    }
+
+    public static function associationNotFound($className, $fieldName)
+    {
+        return new self("The class '$className' does not have a association mapping for '$fieldName'");
     }
 
     public static function classIsNotAValidDocument($className)

--- a/lib/Doctrine/ODM/PHPCR/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Proxy/ProxyFactory.php
@@ -19,9 +19,9 @@
 
 namespace Doctrine\ODM\PHPCR\Proxy;
 
-use Doctrine\ODM\PHPCR\DocumentManager,
-    Doctrine\ODM\PHPCR\Mapping\ClassMetadata,
-    Doctrine\Common\Util\ClassUtils;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\Common\Util\ClassUtils;
 
 /**
  * This factory is used to create proxy objects for entities at runtime.
@@ -78,7 +78,7 @@ class ProxyFactory
     {
         $fqn = ClassUtils::generateProxyClassName($className, $this->proxyNamespace);
 
-        if (! class_exists($fqn, false)) {
+        if (!class_exists($fqn, false)) {
             $fileName = $this->getProxyFileName($className);
             if ($this->autoGenerate) {
                 $this->generateProxyClass($this->dm->getClassMetadata($className), $fileName, self::$proxyClassTemplate);
@@ -184,42 +184,7 @@ class ProxyFactory
      */
     private function getUnsetAttributes(ClassMetadata $class)
     {
-        $attributes = array();
-        foreach ($class->fieldMappings as $field) {
-            $attributes[] = $field['fieldName'];
-        }
-
-        foreach ($class->associationsMappings as $field) {
-            $attributes[] = $field['fieldName'];
-        }
-
-        foreach ($class->referrersMappings as $field) {
-            $attributes[] = $field['fieldName'];
-        }
-
-        foreach ($class->childrenMappings as $field) {
-            $attributes[] = $field['fieldName'];
-        }
-
-        foreach ($class->childMappings as $field) {
-            $attributes[] = $field['fieldName'];
-        }
-
-        if ($class->parentMapping) {
-            $attributes[] = $class->parentMapping['fieldName'];
-        }
-
-        if ($class->node) {
-            $attributes[] = $class->node;
-        }
-
-        if ($class->nodename) {
-            $attributes[] = $class->nodename;
-        }
-
-        $attributes[] = $class->identifier;
-
-        return $attributes;
+        return array_keys($class->mappings);
     }
 
     /**
@@ -302,8 +267,8 @@ class ProxyFactory
             $sleepImpl .= "return array('__isInitialized__', ";
 
             $properties = array();
-            foreach ($class->fieldMappings as $name => $prop) {
-                $properties[] = "'$name'";
+            foreach ($class->fieldMappings as $fieldName) {
+                $properties[] = "'$fieldName'";
             }
 
             $sleepImpl .= implode(',', $properties) . ');';

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
@@ -17,13 +17,13 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $class->associationsMappings['groups']['cascade'] = ClassMetadata::CASCADE_PERSIST;
+        $class->mappings['groups']['cascade'] = ClassMetadata::CASCADE_PERSIST;
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
-        $class->associationsMappings['users']['cascade'] = ClassMetadata::CASCADE_PERSIST;
+        $class->mappings['users']['cascade'] = ClassMetadata::CASCADE_PERSIST;
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle');
-        $class->associationsMappings['user']['cascade'] = ClassMetadata::CASCADE_PERSIST;
+        $class->mappings['user']['cascade'] = ClassMetadata::CASCADE_PERSIST;
     }
 
     public function testCascadePersistCollection()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRefreshTest.php
@@ -17,13 +17,13 @@ class CascadeRefreshTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $class->associationsMappings['groups']['cascade'] = ClassMetadata::CASCADE_REFRESH;
+        $class->mappings['groups']['cascade'] = ClassMetadata::CASCADE_REFRESH;
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
-        $class->associationsMappings['users']['cascade'] = ClassMetadata::CASCADE_REFRESH;
+        $class->mappings['users']['cascade'] = ClassMetadata::CASCADE_REFRESH;
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle');
-        $class->associationsMappings['user']['cascade'] = ClassMetadata::CASCADE_REFRESH;
+        $class->mappings['user']['cascade'] = ClassMetadata::CASCADE_REFRESH;
     }
 
     public function testCascadeRefresh()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRemoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRemoveTest.php
@@ -17,13 +17,13 @@ class CascadeRemoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCas
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $class->associationsMappings['groups']['cascade'] = ClassMetadata::CASCADE_REMOVE;
+        $class->mappings['groups']['cascade'] = ClassMetadata::CASCADE_REMOVE;
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
-        $class->associationsMappings['users']['cascade'] = ClassMetadata::CASCADE_REMOVE;
+        $class->mappings['users']['cascade'] = ClassMetadata::CASCADE_REMOVE;
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle');
-        $class->associationsMappings['user']['cascade'] = ClassMetadata::CASCADE_REMOVE;
+        $class->mappings['user']['cascade'] = ClassMetadata::CASCADE_REMOVE;
     }
 
     public function testCascadeRemoveBidirectionalFromOwningSide()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
@@ -2,8 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Mapping;
 
-use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface,
-    Doctrine\ODM\PHPCR\DocumentRepository,
+use Doctrine\ODM\PHPCR\DocumentRepository,
     Doctrine\ODM\PHPCR\Mapping\ClassMetadata,
     Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM,
     Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
@@ -11,7 +10,7 @@ use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface,
 /**
  * @group functional
  */
-class MappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 {
     /**
      * @var \Doctrine\ODM\PHPCR\DocumentManager
@@ -56,7 +55,7 @@ class MappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->persist($second);
     }
 
-    public function testSecoundLevelOverwrite()
+    public function testSecondLevelOverwrite()
     {
         $localePrefs = array(
             'en' => array('en', 'de'),

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
@@ -66,14 +66,14 @@ class TranslationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     /**
      * Assertion shortcut:
      * Check the given $metadata contain a field mapping for $field that contains the $key and having the value $expectedValue.
-     * @param $expectedValue The expected value
+     * @param string $expectedValue The expected value
      * @param \Doctrine\ODM\PHPCR\Mapping\ClassMetadata $metadata The class metadata to test
-     * @param $field The name of the field's mapping to test
-     * @param $key The key expected to be in the field mapping
+     * @param string $field The name of the field's mapping to test
+     * @param string $key The key expected to be in the field mapping
      */
     protected function assertFieldMetadataEquals($expectedValue, ClassMetadata $metadata, $field, $key)
     {
-        $mapping = $metadata->getFieldMapping($field);
+        $mapping = $metadata->mappings[$field];
         $this->assertInternalType('array', $mapping);
         $this->assertTrue(array_key_exists($key, $mapping));
         $this->assertEquals($expectedValue, $mapping[$key]);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/ParentIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/ParentIdGeneratorTest.php
@@ -113,7 +113,7 @@ class ParentClassMetadataProxy extends ClassMetadata
     public function getFieldValue($document, $field)
     {
         switch ($field) {
-            case $this->parentMapping['fieldName']:
+            case $this->parentMapping:
                 return $this->_parent;
             case $this->nodename:
                 return $this->_nodename;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -97,30 +97,30 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
     public function testFieldMappings($class)
     {
         $this->assertCount(12, $class->fieldMappings);
-        $this->assertTrue(isset($class->fieldMappings['string']));
-        $this->assertEquals('string', $class->fieldMappings['string']['type']);
-        $this->assertTrue(isset($class->fieldMappings['binary']));
-        $this->assertEquals('binary', $class->fieldMappings['binary']['type']);
-        $this->assertTrue(isset($class->fieldMappings['long']));
-        $this->assertEquals('long', $class->fieldMappings['long']['type']);
-        $this->assertTrue(isset($class->fieldMappings['int']));
-        $this->assertEquals('long', $class->fieldMappings['int']['type']);
-        $this->assertTrue(isset($class->fieldMappings['decimal']));
-        $this->assertEquals('decimal', $class->fieldMappings['decimal']['type']);
-        $this->assertTrue(isset($class->fieldMappings['double']));
-        $this->assertEquals('double', $class->fieldMappings['double']['type']);
-        $this->assertTrue(isset($class->fieldMappings['float']));
-        $this->assertEquals('double', $class->fieldMappings['float']['type']);
-        $this->assertTrue(isset($class->fieldMappings['date']));
-        $this->assertEquals('date', $class->fieldMappings['date']['type']);
-        $this->assertTrue(isset($class->fieldMappings['boolean']));
-        $this->assertEquals('boolean', $class->fieldMappings['boolean']['type']);
-        $this->assertTrue(isset($class->fieldMappings['name']));
-        $this->assertEquals('name', $class->fieldMappings['name']['type']);
-        $this->assertTrue(isset($class->fieldMappings['path']));
-        $this->assertEquals('path', $class->fieldMappings['path']['type']);
-        $this->assertTrue(isset($class->fieldMappings['uri']));
-        $this->assertEquals('uri', $class->fieldMappings['uri']['type']);
+        $this->assertTrue(isset($class->mappings['string']));
+        $this->assertEquals('string', $class->mappings['string']['type']);
+        $this->assertTrue(isset($class->mappings['binary']));
+        $this->assertEquals('binary', $class->mappings['binary']['type']);
+        $this->assertTrue(isset($class->mappings['long']));
+        $this->assertEquals('long', $class->mappings['long']['type']);
+        $this->assertTrue(isset($class->mappings['int']));
+        $this->assertEquals('long', $class->mappings['int']['type']);
+        $this->assertTrue(isset($class->mappings['decimal']));
+        $this->assertEquals('decimal', $class->mappings['decimal']['type']);
+        $this->assertTrue(isset($class->mappings['double']));
+        $this->assertEquals('double', $class->mappings['double']['type']);
+        $this->assertTrue(isset($class->mappings['float']));
+        $this->assertEquals('double', $class->mappings['float']['type']);
+        $this->assertTrue(isset($class->mappings['date']));
+        $this->assertEquals('date', $class->mappings['date']['type']);
+        $this->assertTrue(isset($class->mappings['boolean']));
+        $this->assertEquals('boolean', $class->mappings['boolean']['type']);
+        $this->assertTrue(isset($class->mappings['name']));
+        $this->assertEquals('name', $class->mappings['name']['type']);
+        $this->assertTrue(isset($class->mappings['path']));
+        $this->assertEquals('path', $class->mappings['path']['type']);
+        $this->assertTrue(isset($class->mappings['uri']));
+        $this->assertEquals('uri', $class->mappings['uri']['type']);
 
         return $class;
     }
@@ -142,8 +142,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringFieldMappings($class)
     {
-        $this->assertEquals('string', $class->fieldMappings['string']['name']);
-        $this->assertEquals('string', $class->fieldMappings['string']['type']);
+        $this->assertEquals('string', $class->mappings['string']['name']);
+        $this->assertEquals('string', $class->mappings['string']['type']);
 
         return $class;
     }
@@ -154,8 +154,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testBinaryFieldMappings($class)
     {
-        $this->assertEquals('binary', $class->fieldMappings['binary']['name']);
-        $this->assertEquals('binary', $class->fieldMappings['binary']['type']);
+        $this->assertEquals('binary', $class->mappings['binary']['name']);
+        $this->assertEquals('binary', $class->mappings['binary']['type']);
 
         return $class;
     }
@@ -166,8 +166,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testLongFieldMappings($class)
     {
-        $this->assertEquals('long', $class->fieldMappings['long']['name']);
-        $this->assertEquals('long', $class->fieldMappings['long']['type']);
+        $this->assertEquals('long', $class->mappings['long']['name']);
+        $this->assertEquals('long', $class->mappings['long']['type']);
 
         return $class;
     }
@@ -178,8 +178,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testIntFieldMappings($class)
     {
-        $this->assertEquals('int', $class->fieldMappings['int']['name']);
-        $this->assertEquals('long', $class->fieldMappings['int']['type']);
+        $this->assertEquals('int', $class->mappings['int']['name']);
+        $this->assertEquals('long', $class->mappings['int']['type']);
 
         return $class;
     }
@@ -190,8 +190,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecimalFieldMappings($class)
     {
-        $this->assertEquals('decimal', $class->fieldMappings['decimal']['name']);
-        $this->assertEquals('decimal', $class->fieldMappings['decimal']['type']);
+        $this->assertEquals('decimal', $class->mappings['decimal']['name']);
+        $this->assertEquals('decimal', $class->mappings['decimal']['type']);
 
         return $class;
     }
@@ -202,8 +202,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testDoubleFieldMappings($class)
     {
-        $this->assertEquals('double', $class->fieldMappings['double']['name']);
-        $this->assertEquals('double', $class->fieldMappings['double']['type']);
+        $this->assertEquals('double', $class->mappings['double']['name']);
+        $this->assertEquals('double', $class->mappings['double']['type']);
 
         return $class;
     }
@@ -214,8 +214,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testFloatFieldMappings($class)
     {
-        $this->assertEquals('float', $class->fieldMappings['float']['name']);
-        $this->assertEquals('double', $class->fieldMappings['float']['type']);
+        $this->assertEquals('float', $class->mappings['float']['name']);
+        $this->assertEquals('double', $class->mappings['float']['type']);
 
         return $class;
     }
@@ -226,8 +226,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testDateFieldMappings($class)
     {
-        $this->assertEquals('date', $class->fieldMappings['date']['name']);
-        $this->assertEquals('date', $class->fieldMappings['date']['type']);
+        $this->assertEquals('date', $class->mappings['date']['name']);
+        $this->assertEquals('date', $class->mappings['date']['type']);
 
         return $class;
     }
@@ -238,8 +238,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testBooleanFieldMappings($class)
     {
-        $this->assertEquals('boolean', $class->fieldMappings['boolean']['name']);
-        $this->assertEquals('boolean', $class->fieldMappings['boolean']['type']);
+        $this->assertEquals('boolean', $class->mappings['boolean']['name']);
+        $this->assertEquals('boolean', $class->mappings['boolean']['type']);
 
         return $class;
     }
@@ -250,8 +250,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testNameFieldMappings($class)
     {
-        $this->assertEquals('name', $class->fieldMappings['name']['name']);
-        $this->assertEquals('name', $class->fieldMappings['name']['type']);
+        $this->assertEquals('name', $class->mappings['name']['name']);
+        $this->assertEquals('name', $class->mappings['name']['type']);
 
         return $class;
     }
@@ -262,8 +262,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testPathFieldMappings($class)
     {
-        $this->assertEquals('path', $class->fieldMappings['path']['name']);
-        $this->assertEquals('path', $class->fieldMappings['path']['type']);
+        $this->assertEquals('path', $class->mappings['path']['name']);
+        $this->assertEquals('path', $class->mappings['path']['type']);
 
         return $class;
     }
@@ -274,8 +274,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testUriFieldMappings($class)
     {
-        $this->assertEquals('uri', $class->fieldMappings['uri']['name']);
-        $this->assertEquals('uri', $class->fieldMappings['uri']['type']);
+        $this->assertEquals('uri', $class->mappings['uri']['name']);
+        $this->assertEquals('uri', $class->mappings['uri']['type']);
 
         return $class;
     }
@@ -311,15 +311,15 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
     public function testParentDocumentMapping($class)
     {
         $this->assertTrue(isset($class->parentMapping));
-        $this->assertEquals('parent', $class->parentMapping['fieldName']);
+        $this->assertEquals('parent', $class->parentMapping);
     }
 
     public function testParentWithPrivatePropertyMapping()
     {
         $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ParentWithPrivatePropertyObject';
         $class = $this->loadMetadataForClassname($className);
-        $this->assertEquals('foo', $class->fieldMappings['foo']['name']);
-        $this->assertEquals('string', $class->fieldMappings['foo']['type']);
+        $this->assertEquals('foo', $class->mappings['foo']['name']);
+        $this->assertEquals('string', $class->mappings['foo']['type']);
 
         $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ParentPrivatePropertyMappingObject';
         $class = $this->loadMetadataForClassname($className);
@@ -333,8 +333,8 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
         $cmf = new ClassMetadataFactory($dm);
         $class = $cmf->getMetadataFor($className);
 
-        $this->assertEquals('foo', $class->fieldMappings['foo']['name']);
-        $this->assertEquals('string', $class->fieldMappings['foo']['type']);
+        $this->assertEquals('foo', $class->mappings['foo']['name']);
+        $this->assertEquals('string', $class->mappings['foo']['type']);
     }
 
     public function testLoadChildMapping()
@@ -352,10 +352,10 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue(isset($class->childMappings));
         $this->assertCount(2, $class->childMappings);
-        $this->assertTrue(isset($class->childMappings['child1']));
-        $this->assertEquals('first', $class->childMappings['child1']['name']);
-        $this->assertTrue(isset($class->childMappings['child2']));
-        $this->assertEquals('second', $class->childMappings['child2']['name']);
+        $this->assertTrue(isset($class->mappings['child1']));
+        $this->assertEquals('first', $class->mappings['child1']['name']);
+        $this->assertTrue(isset($class->mappings['child2']));
+        $this->assertEquals('second', $class->mappings['child2']['name']);
     }
 
     public function testLoadChildrenMapping()
@@ -373,12 +373,12 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue(isset($class->childrenMappings));
         $this->assertCount(2, $class->childrenMappings);
-        $this->assertTrue(isset($class->childrenMappings['all']));
-        $this->assertFalse(isset($class->childrenMappings['all']['filter']));
-        $this->assertTrue(isset($class->childrenMappings['some']));
-        $this->assertEquals('*some*', $class->childrenMappings['some']['filter']);
-        $this->assertEquals(2, $class->childrenMappings['some']['fetchDepth']);
-        $this->assertEquals(3, $class->childrenMappings['some']['cascade']);
+        $this->assertTrue(isset($class->mappings['all']));
+        $this->assertFalse(isset($class->mappings['all']['filter']));
+        $this->assertTrue(isset($class->mappings['some']));
+        $this->assertEquals('*some*', $class->mappings['some']['filter']);
+        $this->assertEquals(2, $class->mappings['some']['fetchDepth']);
+        $this->assertEquals(3, $class->mappings['some']['cascade']);
     }
 
     public function testLoadRepositoryMapping()
@@ -493,20 +493,20 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testReferenceOneMapping($class)
     {
-        $this->assertEquals(2, count($class->associationsMappings));
-        $this->assertTrue(isset($class->associationsMappings['referenceOneWeak']));
+        $this->assertEquals(2, count($class->referenceMappings));
+        $this->assertTrue(isset($class->mappings['referenceOneWeak']));
         $this->assertCount(2, $class->getAssociationNames());
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $class->getAssociationTargetClass('referenceOneWeak'));
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $class->getAssociationTargetClass('referenceOneHard'));
 
-        $referenceOneWeak = $class->associationsMappings['referenceOneWeak'];
+        $referenceOneWeak = $class->mappings['referenceOneWeak'];
         $this->assertEquals('referenceOneWeak', $referenceOneWeak['fieldName']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $referenceOneWeak['targetDocument']);
         $this->assertEquals('weak', $referenceOneWeak['strategy']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceOneMappingObject', $referenceOneWeak['sourceDocument']);
         $this->assertEquals(ClassMetadata::MANY_TO_ONE, $referenceOneWeak['type']);
 
-        $referenceOneHard = $class->associationsMappings['referenceOneHard'];
+        $referenceOneHard = $class->mappings['referenceOneHard'];
         $this->assertEquals('referenceOneHard', $referenceOneHard['fieldName']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $referenceOneHard['targetDocument']);
         $this->assertEquals('hard', $referenceOneHard['strategy']);
@@ -527,21 +527,21 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testReferenceManyMapping($class)
     {
-        $this->assertEquals(2, count($class->associationsMappings));
-        $this->assertTrue(isset($class->associationsMappings['referenceManyWeak']));
+        $this->assertEquals(2, count($class->referenceMappings));
+        $this->assertTrue(isset($class->mappings['referenceManyWeak']));
         $this->assertCount(2, $class->getAssociationNames());
 
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $class->getAssociationTargetClass('referenceManyWeak'));
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $class->getAssociationTargetClass('referenceManyHard'));
 
-        $referenceManyWeak = $class->associationsMappings['referenceManyWeak'];
+        $referenceManyWeak = $class->mappings['referenceManyWeak'];
         $this->assertEquals('referenceManyWeak', $referenceManyWeak['fieldName']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $referenceManyWeak['targetDocument']);
         $this->assertEquals('weak', $referenceManyWeak['strategy']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceManyMappingObject', $referenceManyWeak['sourceDocument']);
         $this->assertEquals(ClassMetadata::MANY_TO_MANY, $referenceManyWeak['type']);
 
-        $referenceManyHard = $class->associationsMappings['referenceManyHard'];
+        $referenceManyHard = $class->mappings['referenceManyHard'];
         $this->assertEquals('referenceManyHard', $referenceManyHard['fieldName']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $referenceManyHard['targetDocument']);
         $this->assertEquals('hard', $referenceManyHard['strategy']);
@@ -562,25 +562,25 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testReferrersMapping($class)
     {
-        $all = $class->referrersMappings['allReferrers'];
+        $all = $class->mappings['allReferrers'];
         $this->assertEquals('allReferrers', $all['fieldName']);
         $this->assertEquals('allReferrers', $all['name']);
         $this->assertEmpty($all['filter']);
         $this->assertNull($all['referenceType']);
 
-        $filtered = $class->referrersMappings['filteredReferrers'];
+        $filtered = $class->mappings['filteredReferrers'];
         $this->assertEquals('filteredReferrers', $filtered['fieldName']);
         $this->assertEquals('filteredReferrers', $filtered['name']);
         $this->assertEquals('test_filter', $filtered['filter']);
         $this->assertEmpty($filtered['referenceType']);
 
-        $hard = $class->referrersMappings['hardReferrers'];
+        $hard = $class->mappings['hardReferrers'];
         $this->assertEquals('hardReferrers', $hard['fieldName']);
         $this->assertEquals('hardReferrers', $hard['name']);
         $this->assertEmpty($hard['filter']);
         $this->assertEquals('hard', $hard['referenceType']);
 
-        $weak = $class->referrersMappings['weakReferrers'];
+        $weak = $class->mappings['weakReferrers'];
         $this->assertEquals('weakReferrers', $weak['fieldName']);
         $this->assertEquals('weakReferrers', $weak['name']);
         $this->assertEmpty($weak['filter']);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -70,7 +70,7 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Test cache driver setting and handling.');
     }
 
-    public function testLoadMetadata_referenceableChildOverriddenAsFalse()
+    public function testLoadMetadataReferenceableChildOverriddenAsFalse()
     {
         // if the child class overrides referenceable as false it is not taken into account
         // as we only ever set the referenceable property to TRUE. This prevents us from
@@ -80,7 +80,7 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($meta->referenceable);
     }
 
-    public function testLoadMetadata_defaults()
+    public function testLoadMetadataDefaults()
     {
         $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\DefaultMappingObject');
         $this->assertFalse($meta->referenceable);
@@ -90,7 +90,7 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($meta->customRepositoryClassName);
     }
 
-    public function testLoadMetadata_classInheritanceChild()
+    public function testLoadMetadataClassInheritanceChild()
     {
         $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceChildMappingObject');
         $this->assertTrue($meta->referenceable);
@@ -100,7 +100,7 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Foobar', $meta->customRepositoryClassName);
     }
 
-    public function testLoadMetadata_classInheritanceChildCanOverride()
+    public function testLoadMetadataClassInheritanceChildCanOverride()
     {
         $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceChildOverridesMappingObject');
         $this->assertTrue($meta->referenceable);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
@@ -16,7 +16,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $cmi = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
         $cmi->initializeReflection(new RuntimeReflectionService());
         $this->assertEquals(null, $cmi->getTypeOfField('some_field'));
-        $cmi->fieldMappings['some_field'] = array('type' => 'some_type');
+        $cmi->mappings['some_field'] = array('type' => 'some_type');
         $this->assertEquals('some_type', $cmi->getTypeOfField('some_field'));
     }
 
@@ -38,7 +38,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $cm->mapField(array('fieldName' => 'id', 'id' => true, 'strategy' => 'repository'));
 
-        $this->assertTrue(isset($cm->fieldMappings['id']));
+        $this->assertTrue(isset($cm->mappings['id']));
         $this->assertEquals(
             array(
                 'id' => true,
@@ -48,7 +48,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
                 'multivalue' => false,
                 'strategy' => 'repository',
             )
-            , $cm->fieldMappings['id']
+            , $cm->mappings['id']
         );
 
         $this->assertEquals('id', $cm->identifier);
@@ -65,8 +65,8 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $cm->mapField(array('fieldName' => 'username', 'name' => 'username', 'type' => 'string'));
         $cm->mapField(array('fieldName' => 'created', 'name' => 'created', 'type' => 'datetime'));
 
-        $this->assertTrue(isset($cm->fieldMappings['username']));
-        $this->assertTrue(isset($cm->fieldMappings['created']));
+        $this->assertTrue(isset($cm->mappings['username']));
+        $this->assertTrue(isset($cm->mappings['created']));
 
         $this->assertEquals(
             array(
@@ -75,7 +75,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
                 'fieldName' => 'username',
                 'multivalue' => false
             ),
-            $cm->fieldMappings['username']
+            $cm->mappings['username']
         );
         $this->assertEquals(
             array(
@@ -84,7 +84,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
                 'fieldName' => 'created',
                 'multivalue' => false
             ),
-            $cm->fieldMappings['created']
+            $cm->mappings['created']
         );
 
         return $cm;
@@ -150,7 +150,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
      */
     public function testSerialize($cm)
     {
-        $expected = 'O:40:"Doctrine\ODM\PHPCR\Mapping\ClassMetadata":9:{s:13:"fieldMappings";a:4:{s:2:"id";a:6:{s:9:"fieldName";s:2:"id";s:2:"id";b:1;s:8:"strategy";s:10:"repository";s:4:"type";s:6:"string";s:4:"name";s:2:"id";s:10:"multivalue";b:0;}s:8:"username";a:4:{s:9:"fieldName";s:8:"username";s:4:"name";s:8:"username";s:4:"type";s:6:"string";s:10:"multivalue";b:0;}s:7:"created";a:4:{s:9:"fieldName";s:7:"created";s:4:"name";s:7:"created";s:4:"type";s:8:"datetime";s:10:"multivalue";b:0;}s:15:"translatedField";a:6:{s:9:"fieldName";s:15:"translatedField";s:4:"type";s:6:"string";s:10:"translated";b:1;s:4:"name";s:15:"translatedField";s:10:"multivalue";b:0;s:5:"assoc";N;}}s:10:"identifier";s:2:"id";s:4:"name";s:39:"Doctrine\Tests\ODM\PHPCR\Mapping\Person";s:16:"generatorOptions";a:0:{}s:11:"idGenerator";i:1;s:25:"customRepositoryClassName";s:25:"customRepositoryClassName";s:18:"isMappedSuperclass";b:1;s:11:"versionable";b:1;s:18:"lifecycleCallbacks";a:1:{s:5:"event";a:1:{i:0;s:8:"callback";}}}';
+        $expected = 'O:40:"Doctrine\ODM\PHPCR\Mapping\ClassMetadata":13:{s:10:"identifier";s:2:"id";s:4:"name";s:39:"Doctrine\Tests\ODM\PHPCR\Mapping\Person";s:11:"idGenerator";i:1;s:8:"mappings";a:5:{s:2:"id";a:6:{s:9:"fieldName";s:2:"id";s:2:"id";b:1;s:8:"strategy";s:10:"repository";s:4:"type";s:6:"string";s:10:"multivalue";b:0;s:4:"name";s:2:"id";}s:8:"username";a:4:{s:9:"fieldName";s:8:"username";s:4:"name";s:8:"username";s:4:"type";s:6:"string";s:10:"multivalue";b:0;}s:7:"created";a:4:{s:9:"fieldName";s:7:"created";s:4:"name";s:7:"created";s:4:"type";s:8:"datetime";s:10:"multivalue";b:0;}s:6:"locale";a:3:{s:9:"fieldName";s:6:"locale";s:4:"type";s:6:"locale";s:4:"name";s:6:"locale";}s:15:"translatedField";a:6:{s:9:"fieldName";s:15:"translatedField";s:4:"type";s:6:"string";s:10:"translated";b:1;s:4:"name";s:15:"translatedField";s:10:"multivalue";b:0;s:5:"assoc";N;}}s:13:"fieldMappings";a:4:{i:0;s:2:"id";i:1;s:8:"username";i:2;s:7:"created";i:3;s:15:"translatedField";}s:17:"referenceMappings";a:0:{}s:17:"referrersMappings";a:0:{}s:16:"childrenMappings";a:0:{}s:13:"childMappings";a:0:{}s:25:"customRepositoryClassName";s:25:"customRepositoryClassName";s:18:"isMappedSuperclass";b:1;s:11:"versionable";b:1;s:18:"lifecycleCallbacks";a:1:{s:5:"event";a:1:{i:0;s:8:"callback";}}}';
         $cm->setCustomRepositoryClassName('customRepositoryClassName');
         $cm->setVersioned(true);
         $cm->addLifecycleCallback('callback', 'event');
@@ -161,7 +161,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
     public function testUnserialize()
     {
-        $cm = unserialize('O:40:"Doctrine\ODM\PHPCR\Mapping\ClassMetadata":11:{s:13:"fieldMappings";a:0:{}s:10:"identifier";N;s:4:"name";s:39:"Doctrine\Tests\ODM\PHPCR\Mapping\Person";s:9:"namespace";s:32:"Doctrine\Tests\ODM\PHPCR\Mapping";s:16:"generatorOptions";a:0:{}s:11:"idGenerator";i:2;s:25:"customRepositoryClassName";s:25:"customRepositoryClassName";s:18:"isMappedSuperclass";b:1;s:11:"versionable";b:1;s:12:"versionField";N;s:18:"lifecycleCallbacks";a:1:{s:5:"event";a:1:{i:0;s:8:"callback";}}}');
+        $cm = unserialize('O:40:"Doctrine\ODM\PHPCR\Mapping\ClassMetadata":13:{s:10:"identifier";s:2:"id";s:4:"name";s:39:"Doctrine\Tests\ODM\PHPCR\Mapping\Person";s:11:"idGenerator";i:1;s:8:"mappings";a:5:{s:2:"id";a:6:{s:9:"fieldName";s:2:"id";s:2:"id";b:1;s:8:"strategy";s:10:"repository";s:4:"type";s:6:"string";s:10:"multivalue";b:0;s:4:"name";s:2:"id";}s:8:"username";a:4:{s:9:"fieldName";s:8:"username";s:4:"name";s:8:"username";s:4:"type";s:6:"string";s:10:"multivalue";b:0;}s:7:"created";a:4:{s:9:"fieldName";s:7:"created";s:4:"name";s:7:"created";s:4:"type";s:8:"datetime";s:10:"multivalue";b:0;}s:6:"locale";a:3:{s:9:"fieldName";s:6:"locale";s:4:"type";s:6:"locale";s:4:"name";s:6:"locale";}s:15:"translatedField";a:6:{s:9:"fieldName";s:15:"translatedField";s:4:"type";s:6:"string";s:10:"translated";b:1;s:4:"name";s:15:"translatedField";s:10:"multivalue";b:0;s:5:"assoc";N;}}s:13:"fieldMappings";a:4:{i:0;s:2:"id";i:1;s:8:"username";i:2;s:7:"created";i:3;s:15:"translatedField";}s:17:"referenceMappings";a:0:{}s:17:"referrersMappings";a:0:{}s:16:"childrenMappings";a:0:{}s:13:"childMappings";a:0:{}s:25:"customRepositoryClassName";s:25:"customRepositoryClassName";s:18:"isMappedSuperclass";b:1;s:11:"versionable";b:1;s:18:"lifecycleCallbacks";a:1:{s:5:"event";a:1:{i:0;s:8:"callback";}}}');
 
         $this->assertInstanceOf('Doctrine\ODM\PHPCR\Mapping\ClassMetadata', $cm);
 
@@ -180,7 +180,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $cm->mapManyToOne(array('fieldName' => 'address', 'targetDocument' => 'Doctrine\Tests\ODM\PHPCR\Mapping\Address'));
 
-        $this->assertTrue(isset($cm->associationsMappings['address']), "No 'address' in associations map.");
+        $this->assertTrue(isset($cm->mappings['address']), "No 'address' in associations map.");
         $this->assertEquals(array(
             'fieldName' => 'address',
             'targetDocument' => 'Doctrine\Tests\ODM\PHPCR\Mapping\Address',
@@ -188,7 +188,8 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
             'type' => ClassMetadata::MANY_TO_ONE,
             'strategy' => 'weak',
             'cascade' => null,
-        ), $cm->associationsMappings['address']);
+            'name' => 'address',
+        ), $cm->mappings['address']);
 
         return $cm;
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildMappingObject.php
@@ -12,7 +12,5 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
  */
 class ClassInheritanceChildMappingObject extends ClassInheritanceParentMappingObject
 {
-    /** @PHPCRODM\Id */
-    public $id;
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildOverridesMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildOverridesMappingObject.php
@@ -18,7 +18,5 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
  */
 class ClassInheritanceChildOverridesMappingObject extends ClassInheritanceParentMappingObject
 {
-    /** @PHPCRODM\Id */
-    public $id;
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferenceableChildReferenceableFalseMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferenceableChildReferenceableFalseMappingObject.php
@@ -12,7 +12,5 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
  */
 class ReferenceableChildReferenceableFalseMappingObject extends ReferenceableMappingObject
 {
-    /** @PHPCRODM\Id */
-    public $id;
 }
 


### PR DESCRIPTION
this PR came out of http://doctrine-project.org/jira/browse/PHPCR-79
in order to make the implementation of a type guesser easier (https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/56)

please review all the changes in the tests as they highlight the BC breaks. one BC break where I am not sure is that we apparently used to allow overriding identifier mappings. that being said .. the sandbox tests run through fine with these changes.
