### PR TITLE
Normalized execute results to ArrayCollection

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Query/Query.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Query.php
@@ -4,6 +4,7 @@ namespace Doctrine\ODM\PHPCR\Query;
 
 use PHPCR\Query\QueryInterface;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Query
@@ -172,6 +173,10 @@ class Query
                 throw QueryException::hydrationModeNotKnown($this->hydrationMode);
         }
 
+        if (is_array($data)) {
+            $data = new ArrayCollection($data);
+        }
+
         return $data;
     }
 
@@ -210,15 +215,13 @@ class Query
     {
         $result = $this->execute(null, $hydrationMode);
 
-        if (!is_array($result)) {
-            return $result;
-        }
-
         if (count($result) > 1) {
             throw QueryException::nonUniqueResult();
+        } elseif (count($result) <= 0) {
+            return null;
         }
 
-        return array_shift($result);
+        return $result->first();
     }
 
     /**
@@ -236,17 +239,13 @@ class Query
      */
     public function getSingleResult($hydrationMode = null)
     {
-        $result = $this->execute(null, $hydrationMode);
+        $result = $this->getOneOrNullResult($hydrationMode);
 
-        if (!$result) {
+        if (null === $result) {
             throw QueryException::noResult();
         }
 
-        if (count($result) > 1) {
-            throw QueryException::nonUniqueResult();
-        }
-
-        return array_shift($result);
+        return $result;
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
@@ -15,6 +15,7 @@ class QueryTest extends \PHPUnit_Framework_Testcase
         $this->dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $this->arrayCollection = $this->getMock('Doctrine\Common\Collections\ArrayCollection');
         $this->query = new Query($this->phpcrQuery, $this->dm);
     }
 
@@ -50,9 +51,10 @@ class QueryTest extends \PHPUnit_Framework_Testcase
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue('ok'));
+            ->will($this->returnValue(array('ok')));
         $res = $this->query->execute(null, Query::HYDRATE_PHPCR);
-        $this->assertEquals('ok', $res);
+        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $res);
+        $this->assertEquals('ok', $res->first());
     }
 
     public function testExecute_hydrateDocument()
@@ -60,13 +62,13 @@ class QueryTest extends \PHPUnit_Framework_Testcase
         $this->dm->expects($this->exactly(2))
             ->method('getDocumentsByPhpcrQuery')
             ->with($this->phpcrQuery)
-            ->will($this->returnValue('ok'));
+            ->will($this->returnValue(array('ok')));
 
         $res = $this->query->execute();
-        $this->assertEquals('ok', $res);
+        $this->assertEquals('ok', $res->first());
 
         $res = $this->query->execute(null, Query::HYDRATE_DOCUMENT);
-        $this->assertEquals('ok', $res);
+        $this->assertEquals('ok', $res->first());
     }
 
     /**


### PR DESCRIPTION
- Original logic used array operations that didn't work
  on ArrayCollections, so refactored to use ArrayCollections all the
  time, although I am unsure as to why Doctrine ORM does not do this.
- Also getSingleResult reuses getOneOrNull logic
