### PR TITLE
Add Functionnal test to translate array properties

### DIFF
--- a/tests/Doctrine/Tests/Models/Translation/Article.php
+++ b/tests/Doctrine/Tests/Models/Translation/Article.php
@@ -37,6 +37,11 @@ class Article
     /** @PHPCRODM\Children() */
     protected  $children;
 
+    /**
+     * @PHPCRODM\String(assoc="", translated=true)
+     */
+    protected $settings;
+
     public function __construct()
     {
         $this->children = new ArrayCollection();
@@ -67,5 +72,25 @@ class Article
     public function setChildren(ArrayCollection $children)
     {
         $this->children = $children;
+    }
+
+    /**
+     * Set settings
+     *
+     * @param array $settings
+     */
+    public function setSettings(array $settings = array())
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Get settings
+     *
+     * @return array $settings
+     */
+    public function getSettings()
+    {
+        return $this->settings;
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/AttributeTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/AttributeTranslationStrategyTest.php
@@ -156,6 +156,7 @@ class AttributeTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFu
         $data['author'] = 'John Doe';
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
+        $data['settings'] = array('setting-1' => 'one-setting');
 
         $node = $this->getTestNode();
 
@@ -227,4 +228,56 @@ class AttributeTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFu
         return Translation::LOCALE_NAMESPACE . ':' . $locale . '-' . $property;
     }
 
+    /**
+     * Caution : Jackalope\Property guess the property type on the first element
+     * So if it's an boolean, all your array will be set to true
+     * The Array has to be an array of string
+     */
+    public function testTranslationArrayProperties()
+    {
+        // First save some translations
+        $data = array();
+        $data['author'] = 'John Doe';
+        $data['topic'] = 'Some interesting subject';
+        $data['text'] = 'Lorem ipsum...';
+        $data['settings'] = array(
+            'is-active' => 'true',
+            'url'       => 'great-article-in-english.html'
+        );
+
+        $node = $this->getTestNode();
+
+        $strategy = new AttributeTranslationStrategy();
+        $strategy->saveTranslation($data, $node, $this->metadata, 'en');
+
+        // Save translation in another language
+
+        $data['topic'] = 'Un sujet intéressant';
+        $data['settings'] = array(
+            'is-active' => 'true',
+            'url'       => 'super-article-en-francais.html'
+        );
+
+        $strategy->saveTranslation($data, $node, $this->metadata, 'fr');
+        $this->dm->flush();
+
+        $doc = new Article;
+        $doc->author = $data['author'];
+        $doc->topic = $data['topic'];
+        $doc->setText($data['text']);
+        $strategy->loadTranslation($doc, $node, $this->metadata, 'en');
+
+        $this->assertEquals(array('is-active', 'url'), array_keys($doc->getSettings()));
+        $this->assertEquals(array(
+            'is-active' => 'true',
+            'url'       => 'great-article-in-english.html'
+        ), $doc->getSettings());
+
+        $strategy->loadTranslation($doc, $node, $this->metadata, 'fr');
+        $this->assertEquals(array('is-active', 'url'), array_keys($doc->getSettings()));
+        $this->assertEquals(array(
+            'is-active' => 'true',
+            'url'       => 'super-article-en-francais.html'
+        ), $doc->getSettings());
+    }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
@@ -68,6 +68,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $doc->author = 'John Doe';
         $doc->topic = 'Some interesting subject';
         $doc->setText('Lorem ipsum...');
+        $doc->setSettings(array());
         $this->doc = $doc;
     }
 


### PR DESCRIPTION
- also add setting data in the remove translation test

I try to trace the problem but stack in Jackalope\Node in _setProperty

It passes two times in it, one with the good data and the second time the array has lost his keys.

If you fix the problem, I'll be happy if you explain it.

Nico 
