### PR TITLE
Set fallback if locale is set explicitly

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2306,6 +2306,7 @@ class UnitOfWork
         $childrenHints = array();
         if (!is_null($locale)) {
             $childrenHints['locale'] = $locale;
+            $childrenHints['fallback'] = true; // if we set locale explicitly this is no longer automatically done
         }
 
         $childNodes = $node->getNodes($filter);


### PR DESCRIPTION
This completes the closed PR https://github.com/doctrine/phpcr-odm/pull/226.

Otherwise, if a collection has an attribute in language X, it only looks for children with locale X and if it is not available, the fallback languages are not taken into account. This caused a problem in https://github.com/symfony-cmf/cmf-sandbox/pull/143 
