### PR TITLE
[WIP] fix referrers cascade persist

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -621,6 +621,10 @@ class ClassMetadata implements ClassMetadataInterface
         if (empty($mapping['cascade'])) {
             $mapping['cascade'] = null;
         }
+        if ($mapping['cascade'] && empty($mapping['filter'])) {
+            throw MappingException::referrerWithoutMappedBy($this->name, $mapping['fieldName']);
+        }
+
         $mapping['type'] = 'referrers';
         $mapping = $this->validateAndCompleteFieldMapping($mapping, $inherited, false);
         $this->referrersMappings[] = $mapping['fieldName'];
@@ -928,7 +932,9 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @return array the association mapping with the field of this name
+     *
+     * @throws MappingException if the class has no mapping field with this name
      */
     public function getAssociation($fieldName)
     {

--- a/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
@@ -103,6 +103,11 @@ class MappingException extends \Exception
         return new self("The 'assoc' attributes may not overlap with assoc property '$overlappingAssoc' for property '$fieldName' in '$document'.");
     }
 
+    public static function referrerWithoutMappedBy($document, $fieldName)
+    {
+        return new self("The referrer field '$fieldName'. in .'$document'. is declared to cascade but no filter for the remote property is specified");
+    }
+
     public static function mappingNotFound($className, $fieldName)
     {
         return new self("No mapping found for field '$fieldName' in class '$className'.");

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1747,7 +1747,7 @@ class UnitOfWork
                     }
 
                     $node->setProperty($mapping['name'], $fieldValue, $type);
-                } elseif (in_array($fieldName, $class->referenceMappings)) {
+                } elseif (in_array($fieldName, $class->referenceMappings) || in_array($fieldName, $class->referrersMappings)) {
                     $this->scheduledAssociationUpdates[$oid] = $document;
 
                     //populate $associationChangesets to force executeUpdates($this->scheduledAssociationUpdates)
@@ -1883,6 +1883,49 @@ class UnitOfWork
                                     throw new PHPCRException(sprintf('Referenced document %s is not referenceable. Use referenceable=true in Document annotation: '.self::objToStr($document, $this->dm), get_class($fieldValue)));
                                 }
                                 $node->setProperty($fieldName, $associatedNode->getIdentifier(), $strategy);
+                            }
+                        }
+                    }
+                } elseif ('referrers' === $mapping['type']) {
+                    if (isset($fieldValue)) {
+                        // TODO: should we look for all phpcr referrers with that property and also remove references to us?
+
+                        /*
+                         * each document in referrers field is supposed to
+                         * reference this document, so we have to update its
+                         * referencing property to contain the uuid of this
+                         * document
+                         */
+                        foreach ($fieldValue as $fv) {
+                            if ($fv === null) {
+                                continue;
+                            }
+
+                            if (! $node->isNodeType('mix:referenceable')) {
+                                throw new PHPCRException(sprintf('Document to be referenced through referrer annotation %s is not referenceable. Use referenceable=true in Document annotation: '.self::objToStr($document, $this->dm), $mapping['fieldName']));
+                            }
+
+                            $referencingNode = $this->session->getNode($this->getDocumentId($fv));
+                            $referencingMeta = $this->dm->getClassMetadata(get_class($fv));
+                            if (! $referencingMeta->hasAssociation($mapping['filter'])) {
+                                throw new PHPCRException(sprintf('Field "%s" of document "%s" is not defined. Error in referrer annotation: '.self::objToStr($document, $this->dm), $mapping['filter'], get_class($fv)));
+                            }
+                            $referencingField = $referencingMeta->getAssociation($mapping['filter']);
+                            $uuid = $node->getIdentifier();
+
+                            $type = $referencingField['strategy'] == 'weak' ? PropertyType::WEAKREFERENCE : PropertyType::REFERENCE;
+                            if ($referencingField['type'] === ClassMetadata::MANY_TO_ONE) {
+                                $referencingNode->setProperty($referencingField['name'], $uuid, $type);
+                            } elseif ($referencingField['type'] === ClassMetadata::MANY_TO_MANY) {
+                                if ($referencingNode->hasProperty($referencingField['name'])) {
+                                    if (! in_array($uuid, $referencingNode->getPropertyValue($referencingField['name']), PropertyType::STRING)) {
+                                        $referencingNode->getProperty($referencingField['name'])->addValue($uuid); // property should be correct type already
+                                    }
+                                } else {
+                                    $referencingNode->setProperty($referencingField['name'], array($uuid), $type);
+                                }
+                            } else {
+                                throw new PHPCRException(sprintf('Field "%s" of document "%s" is not a reference field. Error in referrer annotation: '.self::objToStr($document, $this->dm), $mapping['filter'], get_class($fv)));
                             }
                         }
                     }

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -32,6 +32,13 @@ class CmsUser
     public $children;
     /** @PHPCRODM\Child(name="assistant", cascade="persist") */
     public $child;
+    /** @PHPCRODM\Referrers(filter="user", cascade="persist") */
+    public $articlesReferrers;
+
+    public function __construct()
+    {
+        $this->articlesReferrers = new ArrayCollection();
+    }
 
     public function getId()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
@@ -160,4 +160,31 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $article = $this->dm->find('Doctrine\Tests\Models\CMS\CmsArticle', $article->id);
         $this->assertEquals($user->id, $article->user->getId());
     }
+
+     public function testCascadeManagedDocumentReferrerDuringFlush()
+    {
+
+        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user->username = "dbu";
+        $user->name = "David";
+        $this->dm->persist($user);
+
+        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article->text = "foo";
+        $article->topic = "bar";
+        $article->id = '/functional/article_referrer';
+        $user->articlesReferrers->add($article);
+
+        $this->assertFalse($this->dm->contains($article));
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $user = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', '/functional/dbu');
+        $this->assertNotNull($user);
+        $this->assertTrue(1 <= count ($user->articlesReferrers));
+        $article = $user->articlesReferrers->first();
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsArticle', $article);
+        $this->assertEquals($article->id, $article->id);
+    }
 }


### PR DESCRIPTION
this now almost works, except that we seem to hit some jackalope bug which i seem to confused to understand.

note that atm this breaks two other tests:
- Doctrine\Tests\ODM\PHPCR\Functional\EventManagerTest::testTriggerEvents => wft is https://github.com/doctrine/phpcr-odm/blob/master/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php#L129 trying to achieve? is this leftover code from when referrers where not cascading yet? if we really want to test something about referrers there, we now need to define the filter option to the mapping as cascading persist only works if we know the name of the referring property.
- Doctrine\Tests\ODM\PHPCR\Functional\MergeTest::testMergeNewDocument => here i am not sure why this fails and did work before
