### PR TITLE
Child version test

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/VersioningTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/VersioningTest.php
@@ -75,7 +75,7 @@ END_CND;
         $versionNodeWithChild = $this->node->addNode('versionTestObjWithChild');
         $versionNodeWithChild->setProperty('username', 'lsmith');
         $versionNodeWithChild->setProperty('numbers', array(3, 1, 2));
-        $versionNodeWithChild->setProperty('phpcr:class', $this->typeVersion);
+        $versionNodeWithChild->setProperty('phpcr:class', $this->typeVersionCopy);
         $versionNodeWithChild->addMixin("mix:versionable");
 
         $childNode = $versionNodeWithChild->addNode('versionTestChild');
@@ -353,7 +353,7 @@ END_CND;
     }
 
     /**
-     * Check that when restoring a document, changes are reverted in both the document and the child
+     * Check when restoring a document, changes are reverted in both the document and the child
      * (using a node type where version is set to "copy")
      */
     public function testRestoreVersionCopyWithChild()
@@ -411,8 +411,15 @@ class VersionTestObj
 /**
  * @PHPCRODM\Document(versionable="full", nodeType="phpcr:versionCascade")
  */
-class VersionCopyTestObj extends VersionTestObj
+class VersionCopyTestObj
 {
+    /** @PHPCRODM\Id */
+    public $id;
+    /** @PHPCRODM\Node */
+    public $node;
+
+    /** @PHPCRODM\String(name="username") */
+    public $username;
 }
 
 /**


### PR DESCRIPTION
As discussed here:
https://groups.google.com/forum/?fromgroups=#!topic/symfony-cmf-devs/--3J2hbMsa8

I've created **failing** test cases to show how I expect versioning to work with a node type child definition "on version copy".

In effect I'm expecting versions to be 'in sync' with this method, so that when creating a version of the parent, a new version of the child is also created; When reverting the parent, any changes to the child are also reverted.

I could be wrong of course, and I'm not 100% sure my node type is correct...

Also, there's probably a better place to load the node type definition, but I don't think it's ready to go in the standard fixtures.
