### PR TITLE
Made computeSingleDocumentChangeset public

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -852,7 +852,7 @@ class UnitOfWork
     /**
      * Detects the changes that need to be persisted
      */
-    private function computeChangeSets()
+    public function computeChangeSets()
     {
         foreach ($this->identityMap as $document) {
             $state = $this->getDocumentState($document);
@@ -907,10 +907,12 @@ class UnitOfWork
     }
 
     /**
+     * Computes changeset for a given document.
+     *
      * @param ClassMetadata $class
      * @param object        $document
      */
-    private function computeChangeSet(ClassMetadata $class, $document)
+    public function computeChangeSet(ClassMetadata $class, $document)
     {
         if ($document instanceof Proxy && !$document->__isInitialized()) {
             return;


### PR DESCRIPTION
This is for PR https://github.com/symfony-cmf/RoutingExtraBundle/pull/69 and is to allow document changesets to be recomputed in an `onFlush` event.

I havn't made any of the other methods public, but I guess we probably should if this is all good.
