### PR TITLE
when replacing children having children of their own, things fail

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -588,6 +588,10 @@ class DocumentManager implements ObjectManager
             throw new \InvalidArgumentException('Parameter $document needs to be an object, '.gettype($document).' given');
         }
 
+        if (UnitOfWork::STATE_MANAGED === $this->unitOfWork->getDocumentState($document)) {
+            return;
+        }
+
         $this->errorIfClosed();
         $this->unitOfWork->scheduleInsert($document);
     }

--- a/lib/Doctrine/ODM/PHPCR/Id/AssignedIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/AssignedIdGenerator.php
@@ -36,7 +36,7 @@ class AssignedIdGenerator extends IdGenerator
     {
         $id = $cm->getFieldValue($document, $cm->identifier);
         if (!$id) {
-            throw new \RuntimeException('ID could not be determined. Make sure the document has a property with Doctrine\ODM\PHPCR\Mapping\Annotations\Id annotation and that the property is set to the path where the document is to be stored.');
+            throw new \RuntimeException('ID could not be determined. Make sure the document has a property mapped as id and that the property is set to the path where the document is to be stored.');
         }
 
         return $id;

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1340,6 +1340,12 @@ class UnitOfWork
         return $this->doMerge($document, $visited);
     }
 
+    /**
+     * @param object              $managedCopy The document containing this property
+     * @param object              $document    The new child document that is found in this property
+     * @param \ReflectionProperty $prop        The property
+     * @param array               $mapping     Mapping options for the property
+     */
     private function doMergeSingleDocumentProperty($managedCopy, $document, \ReflectionProperty $prop, array $mapping)
     {
         if (null === $document) {
@@ -1349,7 +1355,7 @@ class UnitOfWork
                 $prop->setValue($managedCopy, $document);
             } else {
                 $targetClass = $this->dm->getClassMetadata(get_class($document));
-                $id = $targetClass->getIdentifierValues($document);
+                $id = $targetClass->getIdentifierValue($document);
                 $proxy = $this->getOrCreateProxy($id, $targetClass->name);
                 $prop->setValue($managedCopy, $proxy);
                 $this->registerDocument($proxy, $id);
@@ -1459,7 +1465,16 @@ class UnitOfWork
                     }
                     $this->cascadeMergeCollection($managedCol, $mapping);
                 } elseif ('child' === $mapping['type']) {
+                    $parentId = $class->getIdentifierValue($document);
+                    $nodename = $mapping['fieldName'];
+                    // TODO from looking in other places, i got the impression we should to this
+                    // but this gives an exception as it tries to read the nodename property on the $other document
+                    // $nodename = $this->getChildNodename($parentId, $mapping['fieldName'], $other, $document);
+                    $childId = $parentId . '/' . $nodename;
+
                     if (null !== $other) {
+                        $childMeta = $this->dm->getClassMetadata(get_class($other));
+                        $childMeta->setIdentifierValue($other, $childId);
                         $this->doMergeSingleDocumentProperty($managedCopy, $other, $prop, $mapping);
                     }
                 } elseif ('children' === $mapping['type']) {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChildTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChildTest.php
@@ -280,6 +280,98 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals('new name', $parent->child->name);
     }
 
+    public function testChildReplaceRemoveChild()
+    {
+        $parent = new ChildTestObj();
+        $child = new ChildTestObj();
+        $grandchild = new ChildChildTestObj();
+        $parent->name = 'Parent';
+        $parent->id = '/functional/childtest';
+        $parent->child = $child;
+        $child->name = 'Child';
+        $child->child = $grandchild;
+        $grandchild->name = 'Grandchild';
+        $this->dm->persist($parent);
+        $this->dm->flush();
+        $this->dm->clear();
+        $parent = $this->dm->find($this->type, '/functional/childtest');
+        $newChild = new ChildTestObj();
+        $newChild->name = 'new name';
+        $parent->child = $newChild;
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $parent = $this->dm->find($this->type, '/functional/childtest');
+        $this->assertEquals('new name', $parent->child->name);
+        // should be assertNull but then tries to dump the object which goes into endless loop
+        $this->assertTrue(null == $parent->child->child, 'the child was not deleted');
+    }
+
+    public function testChildReplaceDeep()
+    {
+        $parent = new ChildTestObj();
+        $child = new ChildTestObj();
+        $grandchild = new ChildChildTestObj();
+        $parent->name = 'Parent';
+        $parent->id = '/functional/childtest';
+        $parent->child = $child;
+        $child->name = 'Child';
+        $child->child = $grandchild;
+        $grandchild->name = 'Grandchild';
+        $this->dm->persist($parent);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $parent = $this->dm->find($this->type, '/functional/childtest');
+        $newChild = new ChildTestObj();
+        $newChild->name = 'new name';
+        $parent->child = $newChild;
+        $newGrandChild = new ChildChildTestObj();
+        $newChild->child = $newGrandChild;
+        $newGrandChild->name = 'new grandchild';
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $parent = $this->dm->find($this->type, '/functional/childtest');
+        $this->assertEquals('new name', $parent->child->name);
+        $this->assertEquals('new grandchild', $parent->child->child->name);
+    }
+
+
+    public function testChildReplaceDeepUnneededPersist()
+    {
+        $parent = new ChildTestObj();
+        $child = new ChildTestObj();
+        $grandchild = new ChildChildTestObj();
+        $parent->name = 'Parent';
+        $parent->id = '/functional/childtest';
+        $parent->child = $child;
+        $child->name = 'Child';
+        $child->child = $grandchild;
+        $grandchild->name = 'Grandchild';
+        $this->dm->persist($parent);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $parent = $this->dm->find($this->type, '/functional/childtest');
+        $newChild = new ChildTestObj();
+        $newChild->name = 'new name';
+        $parent->child = $newChild;
+        $newGrandChild = new ChildChildTestObj();
+        $newChild->child = $newGrandChild;
+        $newGrandChild->name = 'new grandchild';
+        $this->dm->persist($parent);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $parent = $this->dm->find($this->type, '/functional/childtest');
+        $this->assertEquals('new name', $parent->child->name);
+        $this->assertEquals('new grandchild', $parent->child->child->name);
+    }
+
     public function testModificationAfterPersist()
     {
         $parent = new ChildTestObj();


### PR DESCRIPTION
this is a WIP with failing tests and some tentative fixes that seem to be wrong.

see https://github.com/symfony-cmf/symfony-cmf/wiki/PHPCR-ODM-replace-document for a proposal how to actually solve the problems.

This needs hacks for example in the BlockBundle\Document\ImagineBlock::setImage
