### PR TITLE
fix associative arrays if the type is not string

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1894,7 +1894,7 @@ class UnitOfWork
                     if ($mapping['multivalue'] && $fieldValue) {
                         $fieldValue = (array) $fieldValue;
                         if (isset($mapping['assoc'])) {
-                            $node->setProperty($mapping['assoc'], array_keys($fieldValue), $type);
+                            $node->setProperty($mapping['assoc'], array_keys($fieldValue), PropertyType::STRING);
                             $fieldValue = array_values($fieldValue);
                         }
                     }
@@ -1971,7 +1971,7 @@ class UnitOfWork
                     if ($mapping['multivalue']) {
                         $value = empty($fieldValue) ? null : ($fieldValue instanceof Collection ? $fieldValue->toArray() : $fieldValue);
                         if ($value && isset($mapping['assoc'])) {
-                            $node->setProperty($mapping['assoc'], array_keys($value), $type);
+                            $node->setProperty($mapping['assoc'], array_keys($value), PropertyType::STRING);
                             $value = array_values($value);
                         }
                         $node->setProperty($mapping['name'], $value, $type);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -486,6 +486,24 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals($user->parameters, $assocArray);
     }
 
+    public function testAssocNumberProperty()
+    {
+        $user = new User();
+        $user->username = "test";
+        $assocArray = array('foo' => 1, 'ding' => 2);
+        $user->assocNumbers = $assocArray;
+        $user->id = '/functional/test';
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $user = $this->dm->find(null, '/functional/test');
+
+        $this->assertNotNull($user);
+        $this->assertEquals($user->assocNumbers, $assocArray);
+    }
+
     public function testVersionedDocument()
     {
         $user = new VersionTestObj();
@@ -520,6 +538,8 @@ class User
     public $numbers;
     /** @PHPCRODM\String(name="parameters", assoc="") */
     public $parameters;
+    /** @PHPCRODM\Long(name="assocNumbers", assoc="") */
+    public $assocNumbers;
 }
 
 /**


### PR DESCRIPTION
Bugfix ... see added test
