### PR TITLE
Support for date time objects

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Query/PhpcrExpressionVisitor.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/PhpcrExpressionVisitor.php
@@ -135,7 +135,13 @@ class PhpcrExpressionVisitor extends ExpressionVisitor
      */
     public function walkValue(Value $value)
     {
-        return $this->qomf->literal($value->getValue());
+        $value = $value->getValue();
+
+        if ($value instanceof \DateTime) {
+            $value = $value->format('c');
+        }
+
+        return $this->qomf->literal($value);
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/PhpcrExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/PhpcrExpressionVisitorTest.php
@@ -101,6 +101,16 @@ class PhpcrExpressionVisitorTest extends PHPCRFunctionalTestCase
         $this->assertEquals('test', $res->getLiteralValue());
     }
 
+    public function testWalkValueWithDateTime()
+    {
+        $val = new \Doctrine\Common\Collections\Expr\Value(new \DateTime('2013-05-10'));
+        $res = $this->visitor->walkValue($val);
+        $this->assertInstanceOf('PHPCR\Query\QOM\LiteralInterface', $res);
+
+        // actual result includes tz: 2013-05-10T00:00:00+01:00
+        $this->assertEquals('2013-05-10T00:00:00', substr($res->getLiteralValue(), 0 ,19));
+    }
+
     public function getDispatchExpressions()
     {
         $eb = new ExpressionBuilder;


### PR DESCRIPTION
Not sure about this PR -- but hopefully this at least raises the issue.

The following doesn't work at the moment.

```
$qb->where($qb->expr()->lt('date', $post->getDate()));
```

This PR converts the date time object into a string, formatted like `2013-05-10T00:00:00+01:00` as I don't think there is a native way to do this with PHPCR? I seem to recall a discussion on the cmf mailing list about date times.

As I say, not 100% on this, so comments welcome :)
