### PR TITLE
properly do language fallback again

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2727,8 +2727,7 @@ class UnitOfWork
             $localesToTry = $this->dm->getLocaleChooserStrategy()->getPreferredLocalesOrder($document, $metadata, $locale);
 
             foreach ($localesToTry as $desiredLocale) {
-                if ($strategy->loadTranslation($document, $node, $metadata, $desiredLocale)
-                ) {
+                if ($strategy->loadTranslation($document, $node, $metadata, $desiredLocale)) {
                     $localeUsed = $desiredLocale;
                     break;
                 }


### PR DESCRIPTION
i think at some point in the refactorings, this broke. without this i get no language fallback but empty documents in the request language if the request language does not exist.

btw, why does the !$fallback case just before this case still try to fallback to the default locale? does that make sense? i think it should only do that if $locale was empty but not if the locale was not empty and translation loading failed.
