### PR TITLE
Fixed command

### DIFF
--- a/bin/phpcrodm.php
+++ b/bin/phpcrodm.php
@@ -39,14 +39,14 @@ $cli = new \Symfony\Component\Console\Application('Doctrine ODM PHPCR Command Li
 $cli->setCatchExceptions(true);
 $cli->setHelperSet($helperSet);
 $cli->addCommands(array(
-    new \PHPCR\Util\Console\Command\CreateWorkspaceCommand(),
-    new \PHPCR\Util\Console\Command\DumpCommand(),
-    new \PHPCR\Util\Console\Command\ExportXmlCommand(),
-    new \PHPCR\Util\Console\Command\ImportXmlCommand(),
-    new \PHPCR\Util\Console\Command\ListWorkspacesCommand(),
-    new \PHPCR\Util\Console\Command\PurgeCommand(),
-    new \PHPCR\Util\Console\Command\QueryCommand(),
-    new \PHPCR\Util\Console\Command\RegisterNodeTypesCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceCreateCommand(),
+    new \PHPCR\Util\Console\Command\NodeDumpCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceExportCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceImportCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceListCommand(),
+    new \PHPCR\Util\Console\Command\WorkspacePurgeCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceQueryCommand(),
+    new \PHPCR\Util\Console\Command\NodeTypeRegisterCommand(),
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\RegisterSystemNodeTypesCommand(),
 ));
 if (isset($extraCommands) && ! empty($extraCommands)) {

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/RegisterSystemNodeTypesCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/RegisterSystemNodeTypesCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use PHPCR\Util\Console\Command\RegisterNodeTypesCommand;
+use PHPCR\Util\Console\Command\NodeTypeRegisterCommand;
 
 use Doctrine\ODM\PHPCR\Translation\Translation;
 
@@ -32,7 +32,7 @@ use Doctrine\ODM\PHPCR\Translation\Translation;
  *
  * This command registers the necessary node types to get phpcr odm working
  */
-class RegisterSystemNodeTypesCommand extends RegisterNodeTypesCommand
+class RegisterSystemNodeTypesCommand extends NodeTypeRegisterCommand
 {
     private $phpcrNamespace = 'phpcr';
     private $phpcrNamespaceUri = 'http://www.doctrine-project.org/projects/phpcr_odm';


### PR DESCRIPTION
Updates RegisterSystemNodeTypes command -- is this command still needed?

Also, the `bin` file probably needs updating with the new commands? I wonder if we can automate this with the SF finder class.
