### PR TITLE
Updated CHANGLOG to match new CMF project format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,5 +50,5 @@ Changelog
    ->execute(Query::HYDRATE_PHPCR);
  * CreateQuery($statement, $language) has NOT been implemented in the new query builder.
    It is, however, still available in the DocumentManager.
- * DocumetManager->getDocumentsByQuery renamed to getDocumentsByPhpcrQuery()
+ * DocumentManager->getDocumentsByQuery renamed to getDocumentsByPhpcrQuery()
 


### PR DESCRIPTION
See https://github.com/symfony-cmf/symfony-cmf/wiki/Change-log-format

You can view the Github-formatted version on my fork:
https://github.com/fazy/phpcr-odm/blob/changelog-update/CHANGELOG.md
