### PR TITLE
inherit document level options and allow mapped-superclass to have all options

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php
@@ -25,33 +25,27 @@ use Doctrine\Common\Annotations\Annotation;
  * @Annotation
  * @Target("CLASS")
  */
-final class Document
+class Document
 {
     /** @var string */
     public $nodeType;
-    /** @var array */
-    public $mixins;
     /** @var string */
     public $repositoryClass;
     /** @var string */
+    public $translator;
+    /** @var array */
+    public $mixins;
+    /** @var string */
     public $versionable;
     /** @var boolean */
-    public $referenceable = false;
-    /** @var string */
-    public $translator;
+    public $referenceable;
 }
 /**
  * @Annotation
  * @Target("CLASS")
  */
-final class MappedSuperclass
+final class MappedSuperclass extends Document
 {
-    /** @var string */
-    public $nodeType = 'nt:unstructured';
-    /** @var string */
-    public $repositoryClass;
-    /** @var string */
-    public $translator;
 }
 /**
  * @Annotation

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -132,7 +132,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var string
      */
-    public $nodeType;
+    public $nodeType = 'nt:unstructured';
 
     /**
      * READ-ONLY: The JCR Mixins to be used for this node
@@ -498,11 +498,11 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * @param string $versionable A valid versionable annotation.
+     * @param string|boolean $versionable A valid versionable annotation or false to disable versioning.
      */
     public function setVersioned($versionable)
     {
-        if (!in_array($versionable, self::$validVersionableAnnotations)) {
+        if ($versionable && !in_array($versionable, self::$validVersionableAnnotations)) {
             throw new \InvalidArgumentException("Invalid value in '{$this->name}' for the versionable annotation: '{$versionable}'");
         }
         $this->versionable = $versionable;
@@ -513,6 +513,9 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function setReferenceable($referenceable)
     {
+        if ($this->referenceable && ! $referenceable) {
+            throw new MappingException('Can not overwrite referenceable attribute to false in child class');
+        }
         $this->referenceable = $referenceable;
     }
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -126,6 +126,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
     {
         if ($parent) {
+            $this->addInheritedDocumentOptions($class, $parent);
             $this->addInheritedFields($class, $parent);
         }
 
@@ -140,6 +141,22 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
         $this->validateRuntimeMetadata($class, $parent);
         $class->setParentClasses($this->getParentClasses($class->name));
+    }
+
+    /**
+     * Set the document level options of the parent class to the subclass.
+     *
+     * @param ClassMetadata $subClass
+     * @param ClassMetadata $parentClass
+     */
+    private function addInheritedDocumentOptions(ClassMetadata $subClass, ClassMetadata $parentClass)
+    {
+        $subClass->setCustomRepositoryClassName($parentClass->customRepositoryClassName);
+        $subClass->setTranslator($parentClass->translator);
+        $subClass->setVersioned($parentClass->versionable);
+        $subClass->setReferenceable($parentClass->referenceable);
+        $subClass->setNodeType($parentClass->getNodeType());
+        $subClass->setMixins($parentClass->getMixins());
     }
 
     /**

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
@@ -79,34 +79,27 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
         if ($documentAnnot instanceof ODM\MappedSuperclass) {
             $metadata->isMappedSuperclass = true;
         }
-
-        if ($documentAnnot instanceof ODM\Document) {
-            if ($documentAnnot->referenceable) {
-                $metadata->setReferenceable(true);
-            }
-
-            if ($documentAnnot->versionable) {
-                $metadata->setVersioned($documentAnnot->versionable);
-            }
-
-            if ($documentAnnot->mixins) {
-                $metadata->setMixins($documentAnnot->mixins);
-            }
+        if (null !== $documentAnnot->referenceable) {
+            $metadata->setReferenceable($documentAnnot->referenceable);
         }
 
-        if ($documentAnnot->nodeType) {
+        if (null !== $documentAnnot->versionable) {
+            $metadata->setVersioned($documentAnnot->versionable);
+        }
+
+        if (null !== $documentAnnot->mixins) {
+            $metadata->setMixins($documentAnnot->mixins);
+        }
+
+        if (null !== $documentAnnot->nodeType) {
             $metadata->setNodeType($documentAnnot->nodeType);
         }
 
-        if (!$metadata->nodeType) {
-            $metadata->setNodeType('nt:unstructured');
-        }
-
-        if ($documentAnnot->repositoryClass) {
+        if (null !== $documentAnnot->repositoryClass) {
             $metadata->setCustomRepositoryClassName($documentAnnot->repositoryClass);
         }
 
-        if ($documentAnnot->translator) {
+        if (null !== $documentAnnot->translator) {
             $metadata->setTranslator($documentAnnot->translator);
         }
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
@@ -64,37 +64,37 @@ class XmlDriver extends FileDriver
             return;
         }
 
-        if ($xmlRoot->getName() == 'document') {
-            if (isset($xmlRoot['repository-class'])) {
-                $class->setCustomRepositoryClassName((string) $xmlRoot['repository-class']);
-            }
+        if (isset($xmlRoot['repository-class'])) {
+            $class->setCustomRepositoryClassName((string) $xmlRoot['repository-class']);
+        }
 
-            if (isset($xmlRoot['translator'])) {
-                $class->setTranslator((string) $xmlRoot['translator']);
-            }
+        if (isset($xmlRoot['translator'])) {
+            $class->setTranslator((string) $xmlRoot['translator']);
+        }
 
-            if (isset($xmlRoot['versionable']) && $xmlRoot['versionable'] !== 'false') {
-                $class->setVersioned(strtolower($xmlRoot['versionable']));
-            }
+        if (isset($xmlRoot['versionable']) && $xmlRoot['versionable'] !== 'false') {
+            $class->setVersioned(strtolower($xmlRoot['versionable']));
+        }
 
-            if (isset($xmlRoot['referenceable']) && $xmlRoot['referenceable'] !== 'false') {
-                $class->setReferenceable((bool) $xmlRoot['referenceable']);
-            }
+        if (isset($xmlRoot['referenceable']) && $xmlRoot['referenceable'] !== 'false') {
+            $class->setReferenceable((bool) $xmlRoot['referenceable']);
+        }
 
-            if (isset($xmlRoot->mixins)) {
-                $mixins = array();
-                foreach ($xmlRoot->mixins->mixin as $mixin) {
-                    $attributes = $mixin->attributes();
-                    if (! isset($attributes['type'])) {
-                        throw new MappingException('<mixin> missing mandatory type attribute');
-                    }
-                    $mixins[] = (string) $attributes['type'];
+        if (isset($xmlRoot->mixins)) {
+            $mixins = array();
+            foreach ($xmlRoot->mixins->mixin as $mixin) {
+                $attributes = $mixin->attributes();
+                if (! isset($attributes['type'])) {
+                    throw new MappingException('<mixin> missing mandatory type attribute');
                 }
-                $class->setMixins($mixins);
+                $mixins[] = (string) $attributes['type'];
             }
+            $class->setMixins($mixins);
+        }
 
-            $class->setNodeType(isset($xmlRoot['node-type']) ? (string) $xmlRoot['node-type'] : 'nt:unstructured');
-        } elseif ($xmlRoot->getName() === 'mapped-superclass') {
+        $class->setNodeType(isset($xmlRoot['node-type']) ? (string) $xmlRoot['node-type'] : 'nt:unstructured');
+
+        if ($xmlRoot->getName() === 'mapped-superclass') {
             $class->isMappedSuperclass = true;
         }
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
@@ -64,33 +64,33 @@ class YamlDriver extends FileDriver
         }
         $element['type'] = isset($element['type']) ? $element['type'] : 'document';
 
-        if ($element['type'] == 'document') {
-            if (isset($element['repositoryClass'])) {
-                $class->setCustomRepositoryClassName($element['repositoryClass']);
-            }
+        if (isset($element['repositoryClass'])) {
+            $class->setCustomRepositoryClassName($element['repositoryClass']);
+        }
 
-            if (isset($element['translator'])) {
-                $class->setTranslator($element['translator']);
-            }
+        if (isset($element['translator'])) {
+            $class->setTranslator($element['translator']);
+        }
 
-            if (isset($element['versionable']) && $element['versionable']) {
-                $class->setVersioned($element['versionable']);
-            }
+        if (isset($element['versionable']) && $element['versionable']) {
+            $class->setVersioned($element['versionable']);
+        }
 
-            if (isset($element['referenceable']) && $element['referenceable']) {
-                $class->setReferenceable($element['referenceable']);
-            }
+        if (isset($element['referenceable']) && $element['referenceable']) {
+            $class->setReferenceable($element['referenceable']);
+        }
 
-            if (isset($element['mixins'])) {
-                $mixins = array();
-                foreach ($element['mixins'] as $mixin) {
-                    $mixins[] = $mixin;
-                }
-                $class->setMixins($mixins);
+        if (isset($element['mixins'])) {
+            $mixins = array();
+            foreach ($element['mixins'] as $mixin) {
+                $mixins[] = $mixin;
             }
+            $class->setMixins($mixins);
+        }
 
-            $class->setNodeType(isset($element['nodeType']) ? $element['nodeType'] : 'nt:unstructured');
-        } elseif ($element['type'] === 'mappedSuperclass') {
+        $class->setNodeType(isset($element['nodeType']) ? $element['nodeType'] : 'nt:unstructured');
+
+        if ($element['type'] === 'mappedSuperclass') {
             $class->isMappedSuperclass = true;
         }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -467,6 +467,12 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
     public function testMappedSuperclassTypeMapping($class)
     {
         $this->assertTrue($class->isMappedSuperclass);
+        $this->assertEquals("phpcr:test", $class->nodeType);
+        $this->assertEquals("Fqn\Class", $class->customRepositoryClassName);
+        $this->assertEquals("children", $class->translator);
+        $this->assertEquals(array('mix:one', 'mix:two'), $class->mixins);
+        $this->assertEquals("simple", $class->versionable);
+        $this->assertTrue($class->referenceable);
     }
 
     public function testLoadNodeMapping()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -78,14 +78,12 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Test cache driver setting and handling.');
     }
 
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
+     */
     public function testLoadMetadataReferenceableChildOverriddenAsFalse()
     {
-        // if the child class overrides referenceable as false it is not taken into account
-        // as we only ever set the referenceable property to TRUE. This prevents us from
-        // knowing if the user has explicitly set referenceable to FALSE on a child entity.
         $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceableChildReferenceableFalseMappingObject');
-
-        $this->assertTrue($meta->referenceable);
     }
 
     public function testLoadMetadataDefaults()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildOverridesMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildOverridesMappingObject.php
@@ -7,10 +7,9 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 /**
  * A class that represents a parent class for the purposes
  * of testing class property inheritance
- * 
+ *
  * @PHPCRODM\Document(
- *   referenceable=false, 
- *   nodeType="nt:test-override", 
+ *   nodeType="nt:test-override",
  *   translator="bar",
  *   repositoryClass="Barfoo",
  *   versionable="full"

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/MappedSuperclassMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/MappedSuperclassMappingObject.php
@@ -6,8 +6,8 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * A class that uses the repository strategy to generate IDs
- * 
- * @PHPCRODM\MappedSuperclass
+ *
+ * @PHPCRODM\MappedSuperclass(nodeType="phpcr:test", repositoryClass="Fqn\Class", translator="children", mixins={"mix:one", "mix:two"}, versionable="simple", referenceable=true)
  */
 class MappedSuperclassMappingObject
 {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.MappedSuperclassMappingObject.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.MappedSuperclassMappingObject.dcm.xml
@@ -3,7 +3,18 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
                   https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
-    <mapped-superclass name="Doctrine\Tests\ODM\PHPCR\Mapping\Model\MappedSuperclassMappingObject">
+    <mapped-superclass
+        name="Doctrine\Tests\ODM\PHPCR\Mapping\Model\MappedSuperclassMappingObject"
+        translator="children"
+        versionable="SIMPLE"
+        node-type="phpcr:test"
+        repository-class="Fqn\Class"
+        referenceable="true"
+    >
+        <mixins>
+            <mixin type="mix:one" />
+            <mixin type="mix:two" />
+        </mixins>
         <id name="id" />
     </mapped-superclass>
 </doctrine-mapping>

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.MappedSuperclassMappingObject.dcm.yml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.MappedSuperclassMappingObject.dcm.yml
@@ -1,3 +1,9 @@
 Doctrine\Tests\ODM\PHPCR\Mapping\Model\MappedSuperclassMappingObject:
   type: mappedSuperclass
+  nodeType: phpcr:test
+  repositoryClass: Fqn\Class
+  translator: children
+  mixins: [mix:one, mix:two]
+  versionable: simple
+  referenceable: true
   id: id


### PR DESCRIPTION
fix http://www.doctrine-project.org/jira/browse/PHPCR-77

there is two kind-of BC breaks:
- we now throw exception when explicitly setting referenceable to false after it was true in parent class
- we inherit document level options, which we did not before, so if people where relying on this wrong behaviour they can't anymore

i chose to allow all options on mapped-superclass as well, makes no sense to not allow some.
