### PR TITLE
Fix bug preventing PHPCR property names being used from mapping

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -337,14 +337,14 @@ class UnitOfWork
         $refNodeUUIDs = array();
         foreach ($class->referenceMappings as $fieldName) {
             $mapping = $class->mappings[$fieldName];
-            if (!$node->hasProperty($fieldName)) {
+            if (!$node->hasProperty($mapping['property'])) {
                 continue;
             }
 
             if ($mapping['type'] & ClassMetadata::MANY_TO_ONE
                 && $mapping['strategy'] !== 'path'
             ) {
-                $refNodeUUIDs[] = $node->getProperty($fieldName)->getString();
+                $refNodeUUIDs[] = $node->getProperty($mapping['property'])->getString();
             }
         }
 
@@ -356,7 +356,7 @@ class UnitOfWork
         foreach ($class->referenceMappings as $fieldName) {
             $mapping = $class->mappings[$fieldName];
             if ($mapping['type'] === ClassMetadata::MANY_TO_ONE) {
-                if (!$node->hasProperty($fieldName)) {
+                if (!$node->hasProperty($mapping['property'])) {
                     continue;
                 }
 
@@ -365,15 +365,15 @@ class UnitOfWork
                         $referencedClass = $this->dm->getMetadataFactory()->getMetadataFor(ltrim($mapping['targetDocument'], '\\'))->name;
 
                         if ($mapping['strategy'] === 'path') {
-                            $path = $node->getProperty($fieldName)->getString();
+                            $path = $node->getProperty($mapping['property'])->getString();
                         } else {
-                            $referencedNode = $node->getProperty($fieldName)->getNode();
+                            $referencedNode = $node->getProperty($mapping['property'])->getNode();
                             $path = $referencedNode->getPath();
                         }
 
                         $proxy = $this->getOrCreateProxy($path, $referencedClass, $locale);
                     } else {
-                        $referencedNode = $node->getProperty($fieldName)->getNode();
+                        $referencedNode = $node->getProperty($mapping['property'])->getNode();
                         $proxy = $this->getOrCreateProxyFromNode($referencedNode, $locale);
                     }
                 } catch (RepositoryException $e) {
@@ -388,8 +388,8 @@ class UnitOfWork
                 $documentState[$fieldName] = $proxy;
             } elseif ($mapping['type'] === ClassMetadata::MANY_TO_MANY) {
                 $referencedNodes = array();
-                if ($node->hasProperty($fieldName)) {
-                    foreach ($node->getProperty($fieldName)->getString() as $reference) {
+                if ($node->hasProperty($mapping['property'])) {
+                    foreach ($node->getProperty($mapping['property'])->getString() as $reference) {
                         $referencedNodes[] = $reference;
                     }
                 }
@@ -2000,8 +2000,8 @@ class UnitOfWork
                     if (!$this->writeMetadata) {
                         continue;
                     }
-                    if ($node->hasProperty($fieldName) && is_null($fieldValue)) {
-                        $node->getProperty($fieldName)->remove();
+                    if ($node->hasProperty($mapping['property']) && is_null($fieldValue)) {
+                        $node->getProperty($mapping['property'])->remove();
                         continue;
                     }
 
@@ -2039,7 +2039,7 @@ class UnitOfWork
                             }
 
                             $refNodesIds = empty($refNodesIds) ? null : $refNodesIds;
-                            $node->setProperty($fieldName, $refNodesIds, $strategy);
+                            $node->setProperty($mapping['property'], $refNodesIds, $strategy);
                         }
                     } elseif ($mapping['type'] === $class::MANY_TO_ONE) {
                         if (isset($fieldValue)) {
@@ -2053,7 +2053,7 @@ class UnitOfWork
                                 if (!$associatedNode->isNodeType('mix:referenceable')) {
                                     throw new PHPCRException(sprintf('Referenced document %s is not referenceable. Use referenceable=true in Document annotation: '.self::objToStr($document, $this->dm), get_class($fieldValue)));
                                 }
-                                $node->setProperty($fieldName, $associatedNode->getIdentifier(), $strategy);
+                                $node->setProperty($mapping['property'], $associatedNode->getIdentifier(), $strategy);
                             }
                         }
                     }

--- a/tests/Doctrine/Tests/Models/References/RefManyTestObj.php
+++ b/tests/Doctrine/Tests/Models/References/RefManyTestObj.php
@@ -11,7 +11,7 @@ class RefManyTestObj
 {
     /** @PHPCRODM\Id */
     public $id;
-    /** @PHPCRODM\ReferenceMany(targetDocument="RefRefTestObj", cascade="persist") */
+    /** @PHPCRODM\ReferenceMany(targetDocument="RefRefTestObj", cascade="persist", property="myReferences") */
     public $references;
     /** @PHPCRODM\String */
     public $name;

--- a/tests/Doctrine/Tests/Models/References/RefTestObj.php
+++ b/tests/Doctrine/Tests/Models/References/RefTestObj.php
@@ -11,7 +11,7 @@ class RefTestObj
 {
     /** @PHPCRODM\Id */
     public $id;
-    /** @PHPCRODM\ReferenceOne(targetDocument="RefRefTestObj", cascade="persist") */
+    /** @PHPCRODM\ReferenceOne(targetDocument="RefRefTestObj", cascade="persist", property="myReference") */
     public $reference;
     /** @PHPCRODM\String */
     public $name;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -82,10 +82,10 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals('referenced', $refRefTestNode->getProperty('name')->getString());
 
         $refTestNode = $this->session->getNode('/functional/refTestObj');
-        $this->assertTrue($refTestNode->hasProperty('reference'));
+        $this->assertTrue($refTestNode->hasProperty('myReference'));
 
-        $this->assertEquals($refRefTestNode->getIdentifier(), $refTestNode->getProperty('reference')->getString());
-        $this->assertTrue(UUIDHelper::isUUID($refTestNode->getProperty('reference')->getString()));
+        $this->assertEquals($refRefTestNode->getIdentifier(), $refTestNode->getProperty('myReference')->getString());
+        $this->assertTrue(UUIDHelper::isUUID($refTestNode->getProperty('myReference')->getString()));
     }
 
     public function testFindByUUID()
@@ -255,7 +255,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertFalse($this->session->getNode('/functional')->getNode('refManyTestObj')->hasProperty('references'));
+        $this->assertFalse($this->session->getNode('/functional')->getNode('refManyTestObj')->hasProperty('myReferences'));
     }
 
     public function testCreateAddRefLater()
@@ -268,7 +268,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertFalse($this->session->getNode('/functional')->getNode('refTestObj')->hasProperty('reference'));
+        $this->assertFalse($this->session->getNode('/functional')->getNode('refTestObj')->hasProperty('myReference'));
 
         $referrer = $this->dm->find($this->referrerType, '/functional/refTestObj');
         $referrer->reference = new RefRefTestObj();
@@ -281,8 +281,8 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         $refTestNode = $this->session->getNode('/functional/refTestObj');
         $refRefTestNode = $this->session->getNode('/functional')->getNode('refRefTestObj');
-        $this->assertTrue($refTestNode->hasProperty('reference'));
-        $this->assertEquals($refTestNode->getProperty('reference')->getString(), $refRefTestNode->getIdentifier());
+        $this->assertTrue($refTestNode->hasProperty('myReference'));
+        $this->assertEquals($refTestNode->getProperty('myReference')->getString(), $refRefTestNode->getIdentifier());
     }
 
     public function testCreateAddManyRefLater()
@@ -312,11 +312,11 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $refManyNode = $this->session->getNode('/functional/refManyTestObj');
-        $this->assertTrue($refManyNode->hasProperty('references'));
+        $this->assertTrue($refManyNode->hasProperty('myReferences'));
 
-        $this->assertCount($max, $refManyNode->getProperty('references')->getString());
+        $this->assertCount($max, $refManyNode->getProperty('myReferences')->getString());
 
-        foreach ($refManyNode->getProperty('references')->getNode() as $referenced) {
+        foreach ($refManyNode->getProperty('myReferences')->getNode() as $referenced) {
             $this->assertTrue($referenced->hasProperty('name'));
         }
     }
@@ -343,7 +343,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $node = $this->session->getNode('/functional/refTestObj')->getPropertyValue('reference');
+        $node = $this->session->getNode('/functional/refTestObj')->getPropertyValue('myReference');
         $this->assertInstanceOf('PHPCR\\NodeInterface', $node);
         $this->assertEquals('referenced changed', $node->getPropertyValue('name'));
     }
@@ -380,7 +380,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->find($this->referrerManyType, '/functional/refManyTestObj');
 
         $i = 0;
-        foreach ($this->session->getNode('/functional/refManyTestObj')->getProperty('references')->getNode() as  $node) {
+        foreach ($this->session->getNode('/functional/refManyTestObj')->getProperty('myReferences')->getNode() as  $node) {
             $this->assertEquals($node->getProperty('name')->getValue(), "new name ".$i);
             $i++;
         }
@@ -417,7 +417,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $referrer = $this->dm->find($this->referrerManyType, '/functional/refManyTestObj');
 
         $i = 0;
-        foreach ($this->session->getNode('/functional/refManyTestObj')->getProperty('references')->getNode() as  $node) {
+        foreach ($this->session->getNode('/functional/refManyTestObj')->getProperty('myReferences')->getNode() as  $node) {
             if ($i != $pos) {
                 $this->assertEquals("refRefTestObj$i", $node->getProperty('name')->getValue());
             } else {
@@ -839,7 +839,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertCount($max, $referrer->references);
 
         $refnode = $this->session->getNode('/functional')->getNode('refManyTestObj');
-        foreach ($refnode->getProperty('references')->getNode() as $referenced) {
+        foreach ($refnode->getProperty('myReferences')->getNode() as $referenced) {
             $this->assertTrue($referenced->hasProperty('name'));
         }
     }
@@ -907,7 +907,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertCount($max - 1, $names);
 
         $i = 0;
-        foreach ($this->session->getNode('/functional')->getNode('refManyTestObj')->getProperty('references')->getNode() as  $node) {
+        foreach ($this->session->getNode('/functional')->getNode('refManyTestObj')->getProperty('myReferences')->getNode() as  $node) {
             if ($i != $pos) {
                 $this->assertTrue(in_array($node->getProperty('name')->getValue(), $names));
             }
@@ -1007,12 +1007,12 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertTrue($this->session->getNode("/functional")->hasNode("refCascadeTestObj"));
         $this->assertTrue($this->session->getNode("/functional")->hasNode("refRefTestObj"));
 
-        $this->assertTrue($this->session->getNode("/functional/refTestObj")->hasProperty("reference"));
+        $this->assertTrue($this->session->getNode("/functional/refTestObj")->hasProperty("myReference"));
         $this->assertTrue($this->session->getNode("/functional/refCascadeTestObj")->hasProperty("reference"));
 
         $this->assertEquals(
             $this->session->getNode("/functional/refCascadeTestObj")->getIdentifier(),
-            $this->session->getNode("/functional/refTestObj")->getProperty("reference")->getString()
+            $this->session->getNode("/functional/refTestObj")->getProperty("myReference")->getString()
         );
         $this->assertEquals(
             $this->session->getNode("/functional/refRefTestObj")->getIdentifier(),


### PR DESCRIPTION
- PHPCR property names mapped by "property" were not being used by many
  of the reference logics in the UOW
- Fixed now to use the "property" mapping instead of the name of the
  mapped classes property.
