### PR TITLE
use the referring property name and not the class field name

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -427,7 +427,7 @@ class UnitOfWork
                 $this->dm,
                 $document,
                 $referringField['strategy'],
-                $mapping['referencedBy'],
+                $referringField['property'],
                 $locale,
                 $mapping['referringDocument']
             );
@@ -1520,12 +1520,11 @@ class UnitOfWork
                     if (!$managedCol) {
                         $referringMeta = $this->dm->getClassMetadata($mapping['referringDocument']);
                         $referringField = $referringMeta->mappings[$mapping['referencedBy']];
-
                         $managedCol = new ReferrersCollection(
                             $this->dm,
                             $managedCopy,
                             $referringField['strategy'],
-                            $mapping['referencedBy'],
+                            $referringField['property'],
                             $locale
                         );
                         $prop->setValue($managedCopy, $managedCol);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
@@ -587,7 +587,7 @@ class ReferrerTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertCount(1, $referenced->referrers);
         $this->assertEquals("referrerNamedPropTestObj", $referenced->referrers[0]->name);
 
-        $allReferrers = $this->dm->getReferrers($referenced, null, 'namedReference');
+        $allReferrers = $this->dm->getReferrers($referenced, null, 'named-reference');
         $this->assertCount(2, $allReferrers);
     }
 
@@ -739,7 +739,7 @@ class OtherReferrerTestObj
     public $id;
     /** @PHPCRODM\String */
     public $name;
-    /** @PHPCRODM\ReferenceOne(targetDocument="ReferrerRefTestObj", cascade="persist") */
+    /** @PHPCRODM\ReferenceOne(targetDocument="ReferrerRefTestObj", property="named-reference", cascade="persist") */
     public $namedReference;
 }
 
@@ -768,7 +768,7 @@ class ReferrerNamedPropTestObj
     public $id;
     /** @PHPCRODM\String */
     public $name;
-    /** @PHPCRODM\ReferenceOne(targetDocument="ReferrerRefTestObj", cascade="persist") */
+    /** @PHPCRODM\ReferenceOne(targetDocument="ReferrerRefTestObj", property="named-reference", cascade="persist") */
     public $namedReference;
 }
 


### PR DESCRIPTION
#299 fixed reference mappings. this PR fixes referrer mappings.
