### PR TITLE
Add composer self-update to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 #  - TRANSPORT=midgard_mysql
 
 before_script:
+  - composer self-update
   - ./tests/travis_${TRANSPORT}.sh
   - composer update --prefer-source
 


### PR DESCRIPTION
Just trying to find an error with dependencies.

If someone is more interested: https://github.com/composer/composer/compare/7755564962718189d5d7d9fdee595283c8f032b7...master
There seems to be a BC in composer between that commit (7755564962718189d5d7d9fdee595283c8f032b7) and now.
