### PR TITLE
implement remove cascade support for Referrers/ReferenceMany

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/ChildrenCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ChildrenCollection.php
@@ -199,4 +199,20 @@ class ChildrenCollection extends PersistentCollection
 
         return $this->originalNodeNames;
     }
+
+    /**
+     * Reset originalNodeNames and mark the collection as non dirty
+     */
+    public function takeSnapshot()
+    {
+        if (is_array($this->originalNodeNames)) {
+            if ($this->initialized) {
+                $this->originalNodeNames[] = $this->collection->getKeys();
+            } else {
+                $this->originalNodeNames = null;
+            }
+        }
+
+        parent::takeSnapshot();
+    }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
@@ -18,7 +18,7 @@ class CmsGroup
     /** @PHPCRODM\String() */
     public $name;
 
-    /** @PHPCRODM\ReferenceMany(targetDocument="CmsUser") */
+    /** @PHPCRODM\ReferenceMany(targetDocument="CmsUser", cascade="persist") */
     public $users;
 
     public function setName($name)

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
@@ -625,6 +625,37 @@ class ReferrerTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertSame($referrer, $referenced->referrers->first());
         $this->assertEquals('changed', $referrer->name);
     }
+
+    public function testCascadeRemoveByCollection()
+    {
+        $referrerRefManyTestObj = new ReferrerRefTestObj2();
+        $referrerRefManyTestObj->id = "/functional/referrerRefManyTestObj";
+
+        $max = 5;
+        for ($i = 0; $i < $max; $i++) {
+            $newReferrerTestObj = new ReferrerTestObj2();
+            $newReferrerTestObj->id = "/functional/referrerTestObj$i";
+            $newReferrerTestObj->name = "referrerTestObj$i";
+            $newReferrerTestObj->reference = $referrerRefManyTestObj;
+            $this->dm->persist($newReferrerTestObj);
+        }
+
+        $this->dm->persist($referrerRefManyTestObj);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $referenced = $this->dm->find(null, "/functional/referrerRefManyTestObj");
+        $this->assertCount($max, $referenced->referrers);
+        $referenced->referrers->remove(0);
+        $referenced->referrers->remove(3);
+        $this->assertCount($max - 2, $referenced->referrers);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $referenced = $this->dm->find(null, "/functional/referrerRefManyTestObj");
+        $this->assertCount($max - 2, $referenced->referrers);
+    }
 }
 
 /**
@@ -729,7 +760,6 @@ class ReferrerTestObj
     public $reference;
 }
 
-
 /**
  * @PHPCRODM\Document()
  */
@@ -783,4 +813,30 @@ class ReferrerRefTestObj
     public $name;
     /** @PHPCRODM\MixedReferrers() */
     public $referrers;
+}
+
+/**
+ * @PHPCRODM\Document(referenceable=true)
+ */
+class ReferrerRefTestObj2
+{
+    /** @PHPCRODM\Id */
+    public $id;
+    /** @PHPCRODM\String */
+    public $name;
+    /** @PHPCRODM\Referrers(referringDocument="ReferrerTestObj2", referencedBy="reference", cascade={"persist", "remove"}) */
+    public $referrers;
+}
+
+/**
+ * @PHPCRODM\Document()
+ */
+class ReferrerTestObj2
+{
+    /** @PHPCRODM\Id */
+    public $id;
+    /** @PHPCRODM\String */
+    public $name;
+    /** @PHPCRODM\ReferenceOne(targetDocument="ReferrerRefTestObj2", cascade="persist") */
+    public $reference;
 }


### PR DESCRIPTION
supersedes #302, fixes #310 and fixes https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/142
- [x] add test for `Referrer` remove cascade
- [x] fix remove cascade for `ReferenceMany`
- [x] add test for `ReferenceMany` remove cascade
- [x] fox remove cascade `ReferenceMany`
- [x] add tests for multiple `flush()` calls without a `clear()`
