### PR TITLE
Fix ChildrenCollection takeSnapshot bug

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/ChildrenCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ChildrenCollection.php
@@ -207,7 +207,7 @@ class ChildrenCollection extends PersistentCollection
     {
         if (is_array($this->originalNodeNames)) {
             if ($this->initialized) {
-                $this->originalNodeNames[] = $this->collection->getKeys();
+                $this->originalNodeNames = $this->collection->getKeys();
             } else {
                 $this->originalNodeNames = null;
             }


### PR DESCRIPTION
The `takeSnapshot` method of the `ChildrenCollection` appends the keys of the collection creating a nested array. If you flush twice this will result in an `Array to string conversion` error in  [UnitOfWork.php#L1180](https://github.com/doctrine/phpcr-odm/blob/f21d35eb7f4a169f80e12b76c708d644a93158d5/lib/Doctrine/ODM/PHPCR/UnitOfWork.php#L1180).
