### PR TITLE
make AbstractFile mapped and add the mixin

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Document/AbstractFile.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/AbstractFile.php
@@ -23,6 +23,8 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * This class represents an abstract "file"
+ *
+ * @PHPCRODM\MappedSuperclass(mixins="mix:created")
  */
 abstract class AbstractFile
 {


### PR DESCRIPTION
I don't know why this class even worked without the MappedSuperclass, guess only because annotations are seen on the extending class.

adding the mixin to avoid issues like #337
