### PR TITLE
Add HierarchyInterface for nt:hierarchyNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2013-09-26**: [Model] add HierarchyInterface for objects that resolve to
+  nt:HierarchyNode, the method AbstractFile::addChild is
+  changed to use the interface instead of AbstractFile as parameter.
 * **2013-09-13**: [QueryBuilder] Replaced query builder with new
   implementation. See documentation:
   http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/query-builder.html 

--- a/lib/Doctrine/ODM/PHPCR/Document/AbstractFile.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/AbstractFile.php
@@ -19,12 +19,13 @@
 
 namespace Doctrine\ODM\PHPCR\Document;
 
+use Doctrine\ODM\PHPCR\HierarchyInterface;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * This class represents an abstract "file"
  */
-abstract class AbstractFile
+abstract class AbstractFile implements HierarchyInterface
 {
     /** @PHPCRODM\Id(strategy="parent") */
     protected $id;

--- a/lib/Doctrine/ODM/PHPCR/Document/Folder.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/Folder.php
@@ -19,8 +19,9 @@
 
 namespace Doctrine\ODM\PHPCR\Document;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\HierarchyInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * This class represents a Folder in the repository, aka nt:folder
@@ -66,11 +67,12 @@ class Folder extends AbstractFile
     }
 
     /**
-     * Add a child File to this Folder document
+     * Add a child document that resolves to nt:hierarchyNode (like the File)
+     * to this document that resolves to nt:folder (like the Folder)
      *
-     * @param $child AbstractFile
+     * @param $child HierarchyInterface
      */
-    public function addChild(AbstractFile $child)
+    public function addChild(HierarchyInterface $child)
     {
         if (null === $this->children) {
             $this->children = new ArrayCollection();

--- a/lib/Doctrine/ODM/PHPCR/HierarchyInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/HierarchyInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Doctrine\ODM\PHPCR;
+
+/**
+ * Interface for objects that resolve to the node type nt:hierarchyNode, like
+ * the File and Folder documents.
+ *
+ * @see http://wiki.apache.org/jackrabbit/nt:hierarchyNode
+ */
+interface HierarchyInterface
+{
+    /**
+     * Get the parent node.
+     *
+     * @return Object|null
+     */
+    public function getParent();
+
+    /**
+     * Set the parent node.
+     *
+     * @param Object $parent
+     *
+     * @return boolean
+     */
+    public function setParent($parent);
+}


### PR DESCRIPTION
This PR adds an `HierarchyInterface` that can be implemented by documents that resolve to an nt:hierarchyNode. The `Folder::addChild` method required an `AbstractFile` as parameter and is changed to have the `HierarchyInterface` as parameter. This allows nt:hierarchyNodes that are no `File` or `Folder` to be added as child of a `Folder`. The `Symfony\Cmf\Bundle\MediaBundle\Doctrine\Phpcr\Media` is an example of this. 
