### PR TITLE
yml and xml driver should not prevent inheriting nodetype setting from parent document

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
@@ -92,7 +92,9 @@ class XmlDriver extends FileDriver
             $class->setMixins($mixins);
         }
 
-        $class->setNodeType(isset($xmlRoot['node-type']) ? (string) $xmlRoot['node-type'] : 'nt:unstructured');
+        if (isset($xmlRoot['node-type'])) {
+            $class->setNodeType((string) $xmlRoot['node-type']);
+        }
 
         if ($xmlRoot->getName() === 'mapped-superclass') {
             $class->isMappedSuperclass = true;

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
@@ -88,7 +88,9 @@ class YamlDriver extends FileDriver
             $class->setMixins($mixins);
         }
 
-        $class->setNodeType(isset($element['nodeType']) ? $element['nodeType'] : 'nt:unstructured');
+        if (isset($element['nodeType'])) {
+            $class->setNodeType($element['nodeType']);
+        }
 
         if ($element['type'] === 'mappedSuperclass') {
             $class->isMappedSuperclass = true;


### PR DESCRIPTION
hopefully fixing a bug @rmsint found
