### PR TITLE
be more helpful when a user is confused and doing weird things

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
@@ -228,6 +228,65 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $savedArticle = $user->articlesReferrers->first();
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsArticle', $savedArticle);
         $this->assertEquals($article->id, $savedArticle->id);
+    }
 
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
+     */
+    public function testCascadeReferenceArray()
+    {
+        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article->text = "foo";
+        $article->topic = "bar";
+        $article->id = '/functional/article';
+        $article->user = array();
+
+        $this->dm->persist($article);
+        $this->dm->flush();
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
+     */
+    public function testCascadeReferenceNoObject()
+    {
+        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article->text = "foo";
+        $article->topic = "bar";
+        $article->id = '/functional/article';
+        $article->user = "This is not an object";
+
+        $this->dm->persist($article);
+        $this->dm->flush();
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
+     */
+    public function testCascadeReferenceManyNoArray()
+    {
+        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user->name = "foo";
+        $user->username = "bar";
+        $user->id = '/functional/user';
+        $user->groups = $this;
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
+     */
+    public function testCascadeReferenceManyNoObject()
+    {
+        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user->name = "foo";
+        $user->username = "bar";
+        $user->id = '/functional/user';
+        $user->groups = array("this is a bad idea");
+
+        $this->dm->persist($user);
+        $this->dm->flush();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChildTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChildTest.php
@@ -69,6 +69,38 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertFalse($this->node->getNode('childtest')->hasNode('test'));
     }
 
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
+     */
+    public function testCreateArray()
+    {
+        $parent = new ChildTestObj();
+        $child = new ChildChildTestObj();
+        $parent->name = 'Parent';
+        $parent->child = array($child);
+        $child->name = 'Child';
+        $parent->id = '/functional/childtest';
+
+        $this->dm->persist($parent);
+        $this->dm->flush();
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
+     */
+    public function testCreateNoObject()
+    {
+        $parent = new ChildTestObj();
+        $child = new ChildChildTestObj();
+        $parent->name = 'Parent';
+        $parent->child = 'This is not an object';
+        $child->name = 'Child';
+        $parent->id = '/functional/childtest';
+
+        $this->dm->persist($parent);
+        $this->dm->flush();
+    }
+
     public function testCreateAddChildLater()
     {
         $parent = new ChildTestObj();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChildrenTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChildrenTest.php
@@ -184,6 +184,36 @@ class ChildrenTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertCount(2, $parent->allChildren);
     }
 
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
+     */
+    public function testCreateChildrenNoArray()
+    {
+        $child = new ChildrenTestObj();
+        $child->id = '/functional/parent/Child A/Child Create-1';
+        $child->name = 'Child A';
+
+        $parent = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\ChildrenTestObj', '/functional/parent/Child A');
+        $this->assertCount(0, $parent->allChildren);
+
+        $parent->allChildren = $child;
+        $this->dm->persist($parent);
+        $this->dm->flush();
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
+     */
+    public function testCreateChildrenNoObject()
+    {
+        $parent = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\ChildrenTestObj', '/functional/parent/Child A');
+        $this->assertCount(0, $parent->allChildren);
+
+        $parent->allChildren = array('This is not an object');
+        $this->dm->persist($parent);
+        $this->dm->flush();
+    }
+
     public function testSliceChildrenCollection()
     {
         $parent = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\ChildrenTestObj', '/functional/parent');


### PR DESCRIPTION
this cost me quite some time to figure out why i got strange errors about `spl_object_hash` expecting an object. these checks improve the error messages. also adding some more sanity checks on child and children that we only had for references until now.
