### PR TITLE
cleanup id strategy logic and validation step

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
@@ -93,12 +93,12 @@ class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_PARENT, $metadata->idGenerator, 'parentId');
         $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\ParentIdStrategyDifferentOrder');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_PARENT, $metadata->idGenerator, 'parentId2');
+        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AutoNameIdStrategy');
+        $this->assertEquals(ClassMetadata::GENERATOR_TYPE_AUTO, $metadata->idGenerator, 'autoname as only has parent but not nodename');
         $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AssignedIdStrategy');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_ASSIGNED, $metadata->idGenerator, 'assigned');
         $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\RepositoryIdStrategy');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_REPOSITORY, $metadata->idGenerator, 'repository');
-        $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AutoAssignedIdStrategy');
-        $this->assertEquals(ClassMetadata::GENERATOR_TYPE_ASSIGNED, $metadata->idGenerator, 'autoassigned');
         $metadata = $this->dm->getClassMetadata('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\StandardCase');
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_ASSIGNED, $metadata->idGenerator, 'standardcase');
     }
@@ -210,6 +210,18 @@ class ParentIdStrategyDifferentOrder
 /**
  * @PHPCRODM\Document
  */
+class AutoNameIdStrategy
+{
+    /** @PHPCRODM\ParentDocument */
+    public $parent;
+
+    /** @PHPCRODM\Id() */
+    public $id;
+}
+
+/**
+ * @PHPCRODM\Document
+ */
 class AssignedIdStrategy
 {
     /** @PHPCRODM\Id(strategy="assigned") */
@@ -234,18 +246,6 @@ class RepositoryIdStrategy
     public $parent;
 
     /** @PHPCRODM\Id(strategy="repository") */
-    public $id;
-}
-
-/**
-* @PHPCRODM\Document
-*/
-class AutoAssignedIdStrategy
-{
-    /** @PHPCRODM\ParentDocument */
-    public $parent;
-
-    /** @PHPCRODM\Id() */
     public $id;
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
@@ -21,7 +21,6 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
     public function testClassName()
     {
-
         $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
         $cm->initializeReflection(new RuntimeReflectionService());
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Person', $cm->name);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.TranslatorMappingObject.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.TranslatorMappingObject.dcm.xml
@@ -4,6 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
                   https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
     <document name="Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObject" translator="attribute">
+        <id name="id" />
         <locale name="doclocale" />
         <field name="publishDate" type="date" />
         <field name="topic" type="string" translated="true" />

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ReferrersMappingObject.dcm.yml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ReferrersMappingObject.dcm.yml
@@ -1,6 +1,7 @@
 Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferrersMappingObject:
   type: document
   referenceable: true
+  id: id
   referrers:
     filteredReferrers:
       referencedBy: referenceManyWeak

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.TranslatorMappingObject.dcm.yml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.TranslatorMappingObject.dcm.yml
@@ -1,5 +1,6 @@
 Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObject:
   translator: attribute
+  id: id
   locale: doclocale
   fields:
     publishDate:

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -47,6 +47,7 @@ class UnitOfWorkTest extends PHPCRTestCase
         $metadata = new ClassMetadata($this->type);
         $metadata->initializeReflection($cmf->getReflectionService());
         $metadata->mapId(array('fieldName' => 'id', 'id' => true));
+        $metadata->idGenerator = ClassMetadata::GENERATOR_TYPE_ASSIGNED;
         $metadata->mapField(array('fieldName' => 'username', 'type' => 'string'));
         $cmf->setMetadataFor($this->type, $metadata);
     }


### PR DESCRIPTION
this involves a small BC break because if the parent is mapped but no nodename, we now prefer the (recently added) autoname strategy over the assigned id. the id priority is now:
- explicit strategy defined on the id mapping
- parent strategy if parent and nodename are both mapped
- autoname strategy if the parent is mapped
- assigned id strategy if the id is mapped
- in any other situations, things can not work and an exception is thrown

we might want to update the documentation with this as well. if it al makes sense, i can do that.

fix [PHPCR-60](http://www.doctrine-project.org/jira/browse/PHPCR-60)
