### PR TITLE
fall back to assigned in AutoIdGenerator and improve exception reporting

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Id/AssignedIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/AssignedIdGenerator.php
@@ -37,7 +37,7 @@ class AssignedIdGenerator extends IdGenerator
     {
         $id = $cm->getFieldValue($document, $cm->identifier);
         if (!$id) {
-            throw new IdException('ID could not be determined. Make sure the document has a property with Doctrine\ODM\PHPCR\Mapping\Annotations\Id annotation and that the property is set to the path where the document is to be stored.');
+            throw new IdException('ID could not be read from the document instance using the AssignedIdGenerator.');
         }
 
         return $id;

--- a/lib/Doctrine/ODM/PHPCR/Id/AutoIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/AutoIdGenerator.php
@@ -38,13 +38,12 @@ class AutoIdGenerator extends ParentIdGenerator
         if (null === $parent) {
             $parent = $class->parentMapping ? $class->getFieldValue($document, $class->parentMapping) : null;
         }
-        $id = $class->getFieldValue($document, $class->identifier);
 
-        if (empty($id)) {
-            if (null === $parent) {
-                throw IdException::noIdNoParent($document, $class->parentMapping);
-            }
+        $id = $class->getFieldValue($document, $class->identifier);
+        if (empty($id) && null === $parent) {
+            throw IdException::noIdNoParent($document, $class->parentMapping);
         }
+
         if (empty($parent)) {
             return $id;
         }

--- a/lib/Doctrine/ODM/PHPCR/Id/ParentIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/ParentIdGenerator.php
@@ -38,6 +38,7 @@ class ParentIdGenerator extends IdGenerator
         if (null === $parent) {
             $parent = $class->parentMapping ? $class->getFieldValue($document, $class->parentMapping) : null;
         }
+
         $name = $class->nodename ? $class->getFieldValue($document, $class->nodename) : null;
         $id = $class->getFieldValue($document, $class->identifier);
 


### PR DESCRIPTION
have better exception messages that explain what happened if we have no parent in the AutoIdGenerator.

the ParentIdGenerator prefers the assigned id if there is one. the AutoIdGenerator now follows the same logic
