### PR TITLE
prevent empty alias in querybuilder

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/SourceDocument.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/SourceDocument.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Source;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 
 class SourceDocument extends AbstractLeafNode
 {
@@ -11,6 +11,13 @@ class SourceDocument extends AbstractLeafNode
 
     public function __construct(AbstractNode $parent, $documentFqn, $alias)
     {
+        if (!is_string($alias) || empty($alias)) {
+            throw new InvalidArgumentException(sprintf(
+                'The alias for %s must be a non-empty string.',
+                $documentFqn
+            ));
+        }
+
         $this->documentFqn = $documentFqn;
         $this->alias = $alias;
         parent::__construct($parent);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/LeafNodeTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/LeafNodeTestCase.php
@@ -2,11 +2,15 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Builder;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
 
 abstract class LeafNodeTestCase extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var AbstractNode
+     */
+    protected $parent;
+
     public function setUp()
     {
         $this->parent = $this->getMockBuilder(

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceDocumentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceDocumentTest.php
@@ -2,8 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Builder;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
+use Doctrine\ODM\PHPCR\Query\Builder\SourceDocument;
 
 class SourceDocumentTest extends LeafNodeTestCase
 {
@@ -15,5 +14,13 @@ class SourceDocumentTest extends LeafNodeTestCase
                 'getAlias' => 'a',
             )),
         );
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
+     */
+    public function testEmptyAlias()
+    {
+        new SourceDocument($this->parent, 'My\Fqn', '');
     }
 }


### PR DESCRIPTION
fix #336 

this is not a BC break. we just fail earlier than before and with a clear message that might help the user figure out what is wrong.
