### PR TITLE
expose doctrine:phpcr:mapping:info command in console and fix configuration templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+* **2013-11-01**: Enabled the doctrine:phpcr:mapping:info command. To actually
+  use it, you need to update your cli-config.php file and add:
+
+    $driver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver(
+        new \Doctrine\Common\Annotations\AnnotationReader(),
+         __DIR__ . '/lib/Doctrine/ODM/PHPCR/Document'
+    );
+    $config->setMetadataDriverImpl($driver);
+
 1.0.0
 -----
 

--- a/bin/phpcrodm.php
+++ b/bin/phpcrodm.php
@@ -48,10 +48,10 @@ $cli->addCommands(array(
     new \PHPCR\Util\Console\Command\WorkspaceQueryCommand(),
     new \PHPCR\Util\Console\Command\NodeTypeRegisterCommand(),
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\RegisterSystemNodeTypesCommand(),
+    new \Doctrine\ODM\PHPCR\Tools\Console\Command\InfoDoctrineCommand(),
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\DumpQueryBuilderReferenceCommand(),
 ));
 if (isset($extraCommands) && ! empty($extraCommands)) {
     $cli->addCommands($extraCommands);
 }
 $cli->run();
-

--- a/cli-config.doctrine_dbal.php.dist
+++ b/cli-config.doctrine_dbal.php.dist
@@ -37,6 +37,11 @@ if (isset($argv[1])
 
     /* prepare the doctrine configuration */
     $config = new \Doctrine\ODM\PHPCR\Configuration();
+    $driver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver(
+        new \Doctrine\Common\Annotations\AnnotationReader(),
+        __DIR__ . '/lib/Doctrine/ODM/PHPCR/Document'
+    );
+    $config->setMetadataDriverImpl($driver);
 
     $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session, $config);
 

--- a/cli-config.jackrabbit.php.dist
+++ b/cli-config.jackrabbit.php.dist
@@ -35,6 +35,11 @@ $session = $repository->login($credentials, $workspace);
 
 /* prepare the doctrine configuration */
 $config = new \Doctrine\ODM\PHPCR\Configuration();
+$driver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver(
+    new \Doctrine\Common\Annotations\AnnotationReader(),
+    __DIR__ . '/lib/Doctrine/ODM/PHPCR/Document'
+);
+$config->setMetadataDriverImpl($driver);
 
 $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session, $config);
 

--- a/cli-config.midgard_mysql.php.dist
+++ b/cli-config.midgard_mysql.php.dist
@@ -31,6 +31,11 @@ $session =  $repository->login($credentials, $workspace);
 
 /* prepare the doctrine configuration */
 $config = new \Doctrine\ODM\PHPCR\Configuration();
+$driver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver(
+    new \Doctrine\Common\Annotations\AnnotationReader(),
+    __DIR__ . '/lib/Doctrine/ODM/PHPCR/Document'
+);
+$config->setMetadataDriverImpl($driver);
 
 $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session, $config);
 

--- a/cli-config.midgard_sqlite.php.dist
+++ b/cli-config.midgard_sqlite.php.dist
@@ -28,6 +28,11 @@ $session =  $repository->login($credentials, $workspace);
 
 /* prepare the doctrine configuration */
 $config = new \Doctrine\ODM\PHPCR\Configuration();
+$driver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver(
+    new \Doctrine\Common\Annotations\AnnotationReader(),
+    __DIR__ . '/lib/Doctrine/ODM/PHPCR/Document'
+);
+$config->setMetadataDriverImpl($driver);
 
 $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session, $config);
 


### PR DESCRIPTION
we seem to have missed adding this command to the console.

unsure if we need to call this a BC break. if you do not use this newly exposed command, there is no issue, but if you start using it, you must update the cli-config.php file to have the driver loaded, or you get a very uninformative fatal exception PHP Fatal error:  Call to a member function isTransient() on a non-object in /home/david/liip/symfony-cmf/doctrine/phpcr-odm/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php on line 268
