### PR TITLE
Retrieve locales for non-persisted documents

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2803,8 +2803,12 @@ class UnitOfWork
 
         $oid = spl_object_hash($document);
         if ($this->contains($oid)) {
-            $node = $this->session->getNode($this->getDocumentId($document));
-            $locales = $this->dm->getTranslationStrategy($metadata->translator)->getLocalesFor($document, $node, $metadata);
+            try {
+                $node = $this->session->getNode($this->getDocumentId($document));
+                $locales = $this->dm->getTranslationStrategy($metadata->translator)->getLocalesFor($document, $node, $metadata);
+            } catch (PathNotFoundException $e) {
+                $locales = array();
+            }
         } else {
             $locales = array();
         }


### PR DESCRIPTION
Hacky fix to retrieve locales for not-yet-in-storage documents. Currently if you try `getLocalesFor` on a new and persisted document the UOW will call the session to get the node which will throw a "node not found in workspace" exception.

This PR adds a try catch - but this should not be necessary.

Basically we just need to determine if this document has been loaded by the UOW - but there is no `STATE_*` constant that corresponds to this -- is there a better way to do this today?
