### PR TITLE
allow autoname without a nodename nor id mapping

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -104,7 +104,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * READ-ONLY: The ID generator used for generating IDs for this class.
      *
-     * @var \Doctrine\ODM\PHPCR\Id\IdGenerator
+     * @var int constant for the id generator to use for this class
      */
     public $idGenerator = self::GENERATOR_TYPE_NONE;
 
@@ -362,7 +362,8 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Validate Identifier
+     * Validate Identifier mapping, determine the strategy if none is
+     * explicitly set.
      *
      * @throws MappingException if no identifiers are mapped
      */
@@ -372,6 +373,7 @@ class ClassMetadata implements ClassMetadataInterface
         if (! $this->isMappedSuperclass) {
             if (! $this->identifier
                 && !($this->parentMapping && $this->nodename)
+                && !(self::GENERATOR_TYPE_AUTO === $this->idGenerator && $this->parentMapping)
             ) {
                 throw MappingException::identifierRequired($this->name);
             }


### PR DESCRIPTION
this is a quickfix for #368 so that the feature basically works in 1.0 without any of the BC breaks introduced by the other PR.
