### PR TITLE
Allow retrieval of non-flushed document translations.

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -427,6 +427,7 @@ class DocumentManager implements ObjectManager
             }
 
             $document = $this->unitOfWork->getDocumentById($id);
+
             if ($document) {
                 $this->unitOfWork->validateClassName($document, $className);
                 $class = $this->getClassMetadata(get_class($document));

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationHierarchyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationHierarchyTest.php
@@ -61,7 +61,7 @@ class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
         return $doc;
     }
 
-    public function testInsertChild()
+    public function testBindTranslation()
     {
         $parent = $this->dm->find($this->type, '/functional/thename');
 
@@ -87,7 +87,7 @@ class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
         $this->assertEquals('fr', $child->locale);
     }
 
-    function testFindPropagateLocale()
+    function testFindTranslationPropagateLocale()
     {
         $child = new Article();
         $child->id = '/functional/thename/child';
@@ -168,9 +168,8 @@ class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
 
         $doc = $this->dm->findTranslation($this->type, '/functional/thename', 'fr');
 
-        $this->dm->bindTranslation($doc, 'en');
         $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $doc->child);
-        $this->assertEquals('en', $doc->locale);
+        $this->assertEquals('fr', $doc->locale);
         $this->assertEquals('fr', $doc->child->locale);
         $this->assertEquals('Sujet interessant', $doc->child->topic);
     }


### PR DESCRIPTION
- getLocalesFor now takes into account pending translations
- findTranslations also

Any translated fields in the UOW `documentTranslations` will be used before asking PHPCR for the document. This does mean however that any fields that _are_ translated in the database but _are not_ translated in memory will not be translated. I guess that should probably be fixed.
