### PR TITLE
avoid php warning in File::setFileContentFromFilesystem

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Document/File.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/File.php
@@ -44,10 +44,16 @@ class File extends AbstractFile
      */
     public function setFileContentFromFilesystem($filename)
     {
+        if (!$filename) {
+            throw new RuntimeException('The filename may not be empty');
+        }
+        if (!is_readable($filename)) {
+            throw new RuntimeException(sprintf('File "%s" not found or not readable', $filename));
+        }
         $this->getContent();
         $stream = fopen($filename, 'rb');
         if (! $stream) {
-            throw new RuntimeException("File '$filename' not found");
+            throw new RuntimeException(sprintf('Failed to open file "%s"', $filename));
         }
 
         $this->content->setData($stream);


### PR DESCRIPTION
rather throw an exception explaining what went wrong than triggering a p...hp warning on empty filename. should we even do file_exists() to avoid all kinds of warnings?

there is no BC break involved as the code previously threw a runtime exception a bit later, after triggering the warning.
