### PR TITLE
fix console to support creating the currently configured workspace

### DIFF
--- a/cli-config.doctrine_dbal.php.dist
+++ b/cli-config.doctrine_dbal.php.dist
@@ -24,6 +24,18 @@ $workspace = 'default';
 $user = 'admin';
 $pass = 'admin';
 
+/// --- end configuration options --- ///
+
+/* when creating a new workspace, be sure to use default workspace in
+ * connection in case the workspace to create is the one configured
+ * here.
+ */
+if (! isset($argv[1])
+    || 'phpcr:workspace:create' == $argv[1]
+) {
+    $workspace = 'default';
+}
+
 /* only create a session if this is not about the server control command */
 if (isset($argv[1])
     && $argv[1] != 'jackalope:init:dbal'

--- a/cli-config.jackrabbit.php.dist
+++ b/cli-config.jackrabbit.php.dist
@@ -22,10 +22,19 @@ if (! isset($argv[1])
 $params = array(
     'jackalope.jackrabbit_uri'  => 'http://localhost:8080/server/',
 );
-
 $workspace = 'default';
 $user = 'admin';
 $pass = 'admin';
+
+/// --- end configuration options --- ///
+
+/* when creating a new workspace, be sure to use default workspace in
+ * connection in case the workspace to create is the one configured
+ * here.
+ */
+if ('phpcr:workspace:create' == $argv[1]) {
+    $workspace = 'default';
+}
 
 /* bootstrapping the repository implementation. for jackalope, do this: */
 $factory = new \Jackalope\RepositoryFactoryJackrabbit();


### PR DESCRIPTION
a bugfix to not choke when running `phpcr:workspace:create` and the cli-config.php is configured to use the new workspace already.
