### PR TITLE
improve exception message when no translator is defined for a translateable document

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -411,7 +411,11 @@ class UnitOfWork
 
         if (! isset($hints['prefetch']) || $hints['prefetch']) {
             if ($class->translator) {
-                $prefetchLocale = $locale ?: $this->dm->getLocaleChooserStrategy()->getLocale();
+                try {
+                    $prefetchLocale = $locale ?: $this->dm->getLocaleChooserStrategy()->getLocale();
+                } catch (InvalidArgumentException $e) {
+                    throw new InvalidArgumentException($e->getMessage() . ' but document ' . $class->name . ' is mapped with translations.');
+                }
             } else {
                 $prefetchLocale = null;
             }


### PR DESCRIPTION
however there is a bigger issue. i think we fixed some issues in inheritance of mapping information. i just updated a client to PHPCR ODM 1.1 and got this error triggered because they extend from the ContentBundle StaticContent document. now the question is .. does it make sense to make it possible to disable `translator` mappings via inheritance? or do we need to provide non translatable mappings too? or does the client simply need to create their own base class?
