### PR TITLE
properly validate className and return null if not possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+* **2014-02-02**: DocumentManager::find()/findMany now actually validate the
+  requested class name. If the class name determined by the DocumentClassMapper
+  is not instance of the requested class name, null is returned. As previously,
+  you can pass `null` as first argument to find content regardless of its
+  class.
+  Previously, you sometimes got the content mapped into the requested class
+  regardless of the content at $id, while in other situations you got a
+  PHPCRException.
+
 1.1.0-beta1
 -----------
 

--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapperInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapperInterface.php
@@ -19,8 +19,7 @@
 
 namespace Doctrine\ODM\PHPCR;
 
-use Doctrine\ODM\PHPCR\DocumentManager;
-
+use Doctrine\ODM\PHPCR\Exception\ClassMismatchException;
 use PHPCR\NodeInterface;
 
 interface DocumentClassMapperInterface
@@ -31,12 +30,15 @@ interface DocumentClassMapperInterface
      * @param DocumentManager $dm
      * @param NodeInterface   $node
      * @param string          $className explicit class to use. If set, this
-     *      class will be used unless the declared document class is a subclass
-     *      of this class. In that case the document class is used
+     *      class or a subclass of it has to be used. If this is not possible,
+     *      an InvalidArgumentException has to be thrown.
      *
      * @return string $className if not null, the class configured for this
      *      node if defined and the Generic document if no better class can be
      *      found
+     *
+     * @throws ClassMismatchException if $node represents a class that is not
+     *      a descendant of $className.
      */
     public function getClassName(DocumentManager $dm, NodeInterface $node, $className = null);
 
@@ -50,14 +52,14 @@ interface DocumentClassMapperInterface
     public function writeMetadata(DocumentManager $dm, NodeInterface $node, $className);
 
     /**
-     * Determine if the document is instance of the specified $className and
+     * Check if the document is instance of the specified $className and
      * throw exception if not.
      *
      * @param DocumentManager $dm
      * @param object          $document
      * @param string          $className
      *
-     * @throws PHPCRException if document is not of type $className
+     * @throws ClassMismatchException if document is not of type $className
      */
     public function validateClassName(DocumentManager $dm, $document, $className);
 }

--- a/lib/Doctrine/ODM/PHPCR/Exception/ClassMismatchException.php
+++ b/lib/Doctrine/ODM/PHPCR/Exception/ClassMismatchException.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\PHPCR\Exception;
+
+use Doctrine\ODM\PHPCR\PHPCRExceptionInterface;
+
+/**
+ * The requested class did not match the data found in the repository.
+ */
+class ClassMismatchException extends RuntimeException implements PHPCRExceptionInterface
+{
+    public static function incompatibleClasses($id, $nodeClassName, $className)
+    {
+        return new self(sprintf(
+            'Document at %s is of class %s incompatible with class %s',
+            $id,
+            $nodeClassName,
+            $className
+        ));
+    }
+}

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -304,7 +304,7 @@ class UnitOfWork
      *
      * @return object
      *
-     * @throws PHPCRException if $className was specified and does not match
+     * @throws PHPCRExceptionInterface if $className was specified and does not match
      *      the class of the document corresponding to $node.
      */
     public function getOrCreateDocument($className, NodeInterface $node, array &$hints = array())
@@ -2752,7 +2752,7 @@ class UnitOfWork
      * @param string $id            The document id to look for.
      * @param string $rootClassName The name of the root class of the mapped document hierarchy.
      *
-     * @return mixed Returns the document with the specified id if it exists in
+     * @return object|false Returns the document with the specified id if it exists in
      *               this UnitOfWork, FALSE otherwise.
      */
     public function getDocumentById($id)

--- a/tests/Doctrine/Tests/Models/CMS/CmsTeamUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsTeamUser.php
@@ -16,6 +16,11 @@ class CmsTeamUser extends CmsUser
 
     /** @PHPCRODM\Nodename */
     public $nodename;
+
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
 }
 
 class CmsTeamUserRepository extends DocumentRepository implements RepositoryIdInterface

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -46,23 +46,6 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->getPhpcrSession()->save();
     }
 
-    public function testFind()
-    {
-        $user = $this->dm->find($this->type, '/functional/user');
-
-        $this->assertInstanceOf($this->type, $user);
-        $this->assertEquals('/functional/user', $user->id);
-
-        $this->assertEquals('lsmith', $user->username);
-        $this->assertEquals(array(3, 1, 2), $user->numbers);
-
-        $user = $this->dm->find($this->type, 'functional/user');
-        $this->assertInstanceOf($this->type, $user);
-
-        $user = $this->dm->find($this->type, 'functional/user');
-        $this->assertInstanceOf($this->type, $user);
-    }
-
     public function testInsert()
     {
         $user = new User();
@@ -261,7 +244,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $userNew = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\User2', '/functional/user');
+        $userNew = $this->dm->find($this->type, '/functional/user');
 
         $this->assertNotNull($userNew, "Have to hydrate user object!");
         $this->assertEquals($user->username, $userNew->username);
@@ -371,22 +354,6 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals('test3', $pUser3->username);
     }
 
-    public function testFindTypeValidation()
-    {
-        // hackish: forcing the class metadata to be loaded for those two classes so that the alias mapper finds them
-        $this->dm->getRepository($this->type);
-        $this->dm->getRepository($this->type.'2');
-        // --
-
-        $this->dm->getConfiguration()->setValidateDoctrineMetadata(false);
-        $user = $this->dm->find($this->type.'2', '/functional/user');
-        $this->assertNotInstanceOf($this->type, $user);
-
-        $this->dm->getConfiguration()->setValidateDoctrineMetadata(true);
-        $this->setExpectedException('\Doctrine\ODM\PHPCR\PHPCRException');
-        $this->dm->find($this->type, '/functional/user');
-    }
-
     public function testNullRemovesTheProperty()
     {
         $user1 = $this->dm->find($this->type, '/functional/user');
@@ -399,25 +366,6 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertNull($user2->note);
     }
 
-    public function testInheritance()
-    {
-        $user = new User4();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
-        $user->id = '/functional/test';
-        $user->name = 'inheritance';
-
-        $this->dm->persist($user);
-        $this->dm->flush();
-        $this->dm->clear();
-
-        $userNew = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\User4', '/functional/test');
-
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
-        $this->assertEquals($user->username, $userNew->username);
-        $this->assertEquals($user->numbers, $userNew->numbers);
-        $this->assertEquals($user->name, $userNew->name);
-    }
 
     public function testNoIdProperty()
     {
@@ -535,8 +483,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $userNew = $this->dm->find($this->type, '/functional/test');
-
+        $userNew = $this->dm->find(null, '/functional/test');
         $this->assertNotNull($userNew, "Have to hydrate user object!");
         $this->assertEquals($user->username, $userNew->username);
         $this->assertEquals($user->numbers, $userNew->numbers);
@@ -584,15 +531,6 @@ class User3
     public $id;
     /** @PHPCRODM\String */
     public $username;
-}
-
-/**
- * @PHPCRODM\Document()
- */
-class User4 extends User
-{
-    /** @PHPCRODM\String */
-    public $name;
 }
 
 /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Doctrine\Tests\ODM\PHPCR\Functional;
+
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
+use PHPCR\PropertyType;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * Test the DocumentManager::find method.
+ *
+ * @group functional
+ */
+class FindTypeValidationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+{
+    /**
+     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     */
+    private $dm;
+
+    /**
+     * Class name of the document class
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var \PHPCR\NodeInterface
+     */
+    private $node;
+
+    public function setUp()
+    {
+        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\TypeUser';
+        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->node = $this->resetFunctionalNode($this->dm);
+
+        $user = $this->node->addNode('user');
+        $user->setProperty('username', 'lsmith');
+        $user->setProperty('note', 'test');
+        $user->setProperty('numbers', array(3, 1, 2));
+        $user->setProperty('parameters', array('bar', 'dong'));
+        $user->setProperty('parameterKey', array('foo', 'ding'));
+        $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
+        $this->dm->getPhpcrSession()->save();
+    }
+
+    public function testFind()
+    {
+        $user = $this->dm->find($this->type, '/functional/user');
+
+        $this->assertInstanceOf($this->type, $user);
+        $this->assertEquals('/functional/user', $user->id);
+
+        $this->assertEquals('lsmith', $user->username);
+        $this->assertEquals(array(3, 1, 2), $user->numbers);
+
+        // subsequent find must find the same object again
+
+        $userAgain = $this->dm->find($this->type, 'functional/user');
+        $this->assertInstanceOf($this->type, $user);
+        $this->assertSame($user, $userAgain);
+
+        $userAgain = $this->dm->find($this->type, 'functional/user');
+        $this->assertInstanceOf($this->type, $user);
+        $this->assertSame($user, $userAgain);
+    }
+
+    public function testFindAutoclass()
+    {
+        $user = $this->dm->find(null, '/functional/user');
+
+        $this->assertInstanceOf($this->type, $user);
+    }
+
+    /**
+     * TypeUser is a superclass of TypeTeamUser
+     */
+    public function testInheritance()
+    {
+        $user = new TypeTeamUser();
+        $user->username = "test";
+        $user->numbers = array(1, 2, 3);
+        $user->id = '/functional/test';
+        $user->name = 'inheritance';
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $userNew = $this->dm->find($this->type, '/functional/test');
+
+        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertEquals($user->username, $userNew->username);
+        $this->assertEquals($user->numbers, $userNew->numbers);
+        $this->assertEquals($user->name, $userNew->name);
+    }
+
+    /**
+     * TypeTeamUser is not a superclass of User
+     */
+    public function testNotInstanceOf()
+    {
+        $user = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\TypeTeamUser', '/functional/user');
+
+        $this->assertTrue(null === $user, get_class($user));
+    }
+
+    /**
+     * TypeTeamUser is not a superclass of User. Still works when loading from cache.
+     */
+    public function testCacheNotInstanceOf()
+    {
+        $user = $this->dm->find($this->type, '/functional/user');
+        $this->assertInstanceOf($this->type, $user);
+
+        $user = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\TypeTeamUser', '/functional/user');
+        $this->assertTrue(null === $user, get_class($user));
+    }
+
+    /**
+     * TypeTeamUser is not a superclass of User
+     */
+    public function testManyNotInstanceOf()
+    {
+        $users = $this->dm->findMany('Doctrine\Tests\ODM\PHPCR\Functional\TypeTeamUser', array('/functional/user'));
+
+        $this->assertCount(0, $users);
+    }
+}
+
+/**
+ * @PHPCRODM\Document()
+ */
+class TypeUser
+{
+    /** @PHPCRODM\Id */
+    public $id;
+    /** @PHPCRODM\Node */
+    public $node;
+    /** @PHPCRODM\String */
+    public $username;
+    /** @PHPCRODM\String(nullable=true) */
+    public $note;
+    /** @PHPCRODM\Int(multivalue=true,nullable=true) */
+    public $numbers;
+    /** @PHPCRODM\String(assoc="",nullable=true) */
+    public $parameters;
+    /** @PHPCRODM\Long(assoc="",nullable=true) */
+    public $assocNumbers;
+}
+
+/**
+ * @PHPCRODM\Document()
+ */
+class TypeTeamUser extends TypeUser
+{
+    /** @PHPCRODM\String */
+    public $name;
+}

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
@@ -6,7 +6,6 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 use PHPCR\PropertyType;
 
-use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
 
 /**
@@ -38,8 +37,8 @@ class MoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         // remove node for root tests
         $session = $this->dm->getPhpcrSession();
         $root = $session->getNode('/');
-        if ($root->hasNode('lsmith')) {
-            $root->getNode('lsmith')->remove();
+        if ($root->hasNode('dbu')) {
+            $root->getNode('dbu')->remove();
             $session->save();
         }
     }
@@ -225,12 +224,22 @@ class MoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     public function testMoveToRootByParent()
     {
+        $user2 = new CmsTeamUser();
+        $user2->username = 'dbu';
+        $user2->parent = $this->dm->find(null, '/functional/lsmith');
+        $this->dm->persist($user2);
+        $this->dm->flush();
         $this->dm->clear();
-        $user = $this->dm->find('Doctrine\ODM\PHPCR\Document\Generic', '/functional/lsmith');
-        $this->assertNotNull($user, 'User must exist');
+
+        $user = $this->dm->find(null, '/functional/lsmith/dbu');
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsTeamUser', $user);
         $root = $this->dm->find(null, '/');
         $user->setParent($root);
         $this->dm->persist($user);
         $this->dm->flush();
+        $this->dm->clear();
+
+        $user = $this->dm->find(null, '/dbu');
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsTeamUser', $user);
     }
 }


### PR DESCRIPTION
fix #386 

as you can see from the adjusted tests, there is indeed potential for BC breaks in this. mainly if people relied on this to load a content into an arbitrary class. but imho that has no real value.

also, we had a mess with throwing an exception when trying to get an already cached document in a different class but the same thing working if there was no cached version yet.
