### PR TITLE
cleanup document class migration command, add missing generate proxies command

### DIFF
--- a/bin/phpcrodm.php
+++ b/bin/phpcrodm.php
@@ -1,13 +1,27 @@
 <?php
 
-($autoload = @include_once __DIR__ . '/../vendor/autoload.php') || $autoload = @include_once __DIR__ . '/../../../autoload.php';
+$up = DIRECTORY_SEPARATOR . '..';
+$file = DIRECTORY_SEPARATOR . 'autoload.php';
+$candiates = array(
+    __DIR__ . $up . $file,
+    __DIR__ . $up . DIRECTORY_SEPARATOR . 'vendor' . $file,
+    __DIR__ . $up . $up . $up . $file,
+);
+
+foreach ($candiates as $path) {
+    echo $path;
+    $autoload = @include_once $path;
+    if ($autoload) {
+        break;
+    }
+}
+
 if (!$autoload) {
-    throw new RuntimeException('Install dependencies to run phpcr.');
+    throw new RuntimeException('Install dependencies to run the console.');
 }
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 AnnotationRegistry::registerLoader(array($autoload, 'loadClass'));
-AnnotationRegistry::registerFile(__DIR__.'/../lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php');
 
 $configFile = getcwd() . DIRECTORY_SEPARATOR . 'cli-config.php';
 
@@ -53,6 +67,8 @@ $cli->addCommands(array(
     new \PHPCR\Util\Console\Command\WorkspaceListCommand(),
     new \PHPCR\Util\Console\Command\WorkspacePurgeCommand(),
     new \PHPCR\Util\Console\Command\WorkspaceQueryCommand(),
+    new \Doctrine\ODM\PHPCR\Tools\Console\Command\DocumentMigrateClassCommand(),
+    new \Doctrine\ODM\PHPCR\Tools\Console\Command\GenerateProxiesCommand(),
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\DumpQueryBuilderReferenceCommand(),
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\InfoDoctrineCommand(),
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\RegisterSystemNodeTypesCommand(),

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/GenerateProxiesCommand.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\PHPCR\Tools\Console\Command;
+
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Doctrine\ODM\PHPCR\Tools\Console\MetadataFilter;
+
+/**
+ * Command to (re)generate the proxy classes used by doctrine.
+ *
+ * Adapted from the Doctrine ORM command.
+ *
+ * @link    www.doctrine-project.org
+ * @since   PHPCR-ODM 1.1
+ * @author  Benjamin Eberlei <kontakt@beberlei.de>
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Roman Borschel <roman@code-factory.org>
+ */
+class GenerateProxiesCommand extends Command
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+        ->setName('doctrine:phpcr:generate-proxies')
+        ->setDescription('Generates proxy classes for document classes.')
+        ->setDefinition(array(
+            new InputOption(
+                'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'A string pattern used to match entities that should be processed.'
+            ),
+            new InputArgument(
+                'dest-path', InputArgument::OPTIONAL,
+                'The path to generate your proxy classes. If none is provided, the path from the configuration will be used.'
+            ),
+        ))
+        ->setHelp(<<<EOT
+Generates proxy classes for entity classes.
+EOT
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var $documentManager DocumentManager */
+        $documentManager = $this->getHelper('phpcr')->getDocumentManager();
+
+        $metadatas = $documentManager->getMetadataFactory()->getAllMetadata();
+        $metadatas = MetadataFilter::filter($metadatas, $input->getOption('filter'));
+
+        // Process destination directory
+        if (($destPath = $input->getArgument('dest-path')) === null) {
+            $destPath = $documentManager->getConfiguration()->getProxyDir();
+        }
+
+        if ( ! is_dir($destPath)) {
+            mkdir($destPath, 0777, true);
+        }
+
+        $destPath = realpath($destPath);
+
+        if ( ! file_exists($destPath)) {
+            throw new \InvalidArgumentException(
+                sprintf("Proxies destination directory '<info>%s</info>' does not exist.", $documentManager->getConfiguration()->getProxyDir())
+            );
+        } else if ( ! is_writable($destPath)) {
+            throw new \InvalidArgumentException(
+                sprintf("Proxies destination directory '<info>%s</info>' does not have write permissions.", $destPath)
+            );
+        }
+
+        if ( count($metadatas)) {
+            foreach ($metadatas as $metadata) {
+                $output->write(
+                    sprintf('Processing entity "<info>%s</info>"', $metadata->name) . PHP_EOL
+                );
+            }
+
+            // Generating Proxies
+            $documentManager->getProxyFactory()->generateProxyClasses($metadatas, $destPath);
+
+            // Outputting information message
+            $output->write(PHP_EOL . sprintf('Proxy classes generated to "<info>%s</INFO>"', $destPath) . PHP_EOL);
+        } else {
+            $output->write('No Metadata Classes to process.' . PHP_EOL);
+        }
+
+    }
+}

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/MetadataFilter.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\PHPCR\Tools\Console;
+
+/**
+ * Used by CLI Tools to restrict entity-based commands to given patterns.
+ *
+ * Copied from Doctrine\ODM\PHPCR\Tools\Console\MetadataFilter
+ *
+ * @license     http://www.opensource.org/licenses/mit-license.php MIT
+ * @link        www.doctrine-project.com
+ * @since       1.0
+ * @author      Benjamin Eberlei <kontakt@beberlei.de>
+ * @author      Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author      Jonathan Wage <jonwage@gmail.com>
+ * @author      Roman Borschel <roman@code-factory.org>
+ */
+class MetadataFilter extends \FilterIterator implements \Countable
+{
+    /**
+     * @var array
+     */
+    private $filter = array();
+
+    /**
+     * Filter Metadatas by one or more filter options.
+     *
+     * @param array        $metadatas
+     * @param array|string $filter
+     *
+     * @return array
+     */
+    static public function filter(array $metadatas, $filter)
+    {
+        $metadatas = new MetadataFilter(new \ArrayIterator($metadatas), $filter);
+
+        return iterator_to_array($metadatas);
+    }
+
+    /**
+     * @param \ArrayIterator $metadata
+     * @param array|string   $filter
+     */
+    public function __construct(\ArrayIterator $metadata, $filter)
+    {
+        $this->filter = (array) $filter;
+
+        parent::__construct($metadata);
+    }
+
+    /**
+     * @return bool
+     */
+    public function accept()
+    {
+        if (count($this->filter) == 0) {
+            return true;
+        }
+
+        $it = $this->getInnerIterator();
+        $metadata = $it->current();
+
+        foreach ($this->filter as $filter) {
+            $pregResult = preg_match("/$filter/", $metadata->name);
+
+            if ($pregResult === false) {
+                throw new \RuntimeException(
+                    sprintf("Error while evaluating regex '/%s/'.", $filter)
+                );
+            }
+
+            if ($pregResult === 0) {
+                return false;
+            }
+
+            if ($pregResult) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->getInnerIterator());
+    }
+}


### PR DESCRIPTION
DocumentMigrateClassCommand was not using the DocumentClassMapper but mimicking the default DocumentClassMapper behaviour (with an inconsistency: storing all parent classes instead of all _mapped_ parent classes).

I also copied the generate proxies command from doctrine orm. This command is not needed in the symfony bundle as its done in a cache warming listener - the orm is doing the same, not exposing the proxy command to the symfony console. This command is essential to use doctrine phpcr-odm standalone.

Documentation is updated in https://github.com/doctrine/phpcr-odm-documentation/pull/46
