### PR TITLE
Allow the namespace alias to be used in query builder

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
@@ -30,11 +30,26 @@ use PHPCR\PropertyType;
  */
 class DocumentClassMapper implements DocumentClassMapperInterface
 {
+    private function expandClassName($dm, $className = null)
+    {
+        if (null === $className) {
+            return null;
+        }
+
+        if (false !== strstr($className, ':')) {
+            $className = $dm->getClassMetadata($className)->getName();
+        }
+
+        return $className;
+    }
+
     /**
      * {@inheritDoc}
      */
     public function getClassName(DocumentManager $dm, NodeInterface $node, $className = null)
     {
+        $className = $this->expandClassName($dm, $className);
+
         if ($node->hasProperty('phpcr:class')) {
             $nodeClassName = $node->getProperty('phpcr:class')->getString();
 
@@ -46,7 +61,8 @@ class DocumentClassMapper implements DocumentClassMapperInterface
             }
             $className = $nodeClassName;
         }
-            // default to the built in generic document class
+
+        // default to the built in generic document class
         if (empty($className)) {
             $className = 'Doctrine\\ODM\\PHPCR\\Document\\Generic';
         }
@@ -59,6 +75,8 @@ class DocumentClassMapper implements DocumentClassMapperInterface
      */
     public function writeMetadata(DocumentManager $dm, NodeInterface $node, $className)
     {
+        $className = $this->expandClassName($dm, $className);
+
         if ('Doctrine\\ODM\\PHPCR\\Document\\Generic' !== $className) {
             $node->setProperty('phpcr:class', $className, PropertyType::STRING);
 
@@ -75,6 +93,8 @@ class DocumentClassMapper implements DocumentClassMapperInterface
      */
     public function validateClassName(DocumentManager $dm, $document, $className)
     {
+        $className = $this->expandClassName($dm, $className);
+
         if (!$document instanceof $className) {
             throw ClassMismatchException::incompatibleClasses(
                 $dm->getUnitOfWork()->determineDocumentId($document),

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentClassMapperTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentClassMapperTest.php
@@ -211,6 +211,37 @@ class DocumentClassMapperTest extends \PHPUnit_Framework_Testcase
         ;
         $this->mapper->validateClassName($this->dm, $generic, 'Other\Class');
     }
+
+    public function provideExpandClassName()
+    {
+        return array(
+            array('Foobar/BarFoo/Document/Foobar', 'Foobar/BarFoo/Document/Foobar', false),
+            array('Foobar:Barfoo', 'Foobar\Barfoo', true),
+        );
+    }
+
+    /**
+     * @dataProvider provideExpandClassName
+     */
+    public function testExpandClassName($className, $fqClassName, $isAlias)
+    {
+        if ($isAlias) {
+            $this->dm->expects($this->once())
+                ->method('getClassMetadata')
+                ->with($className)
+                ->will($this->returnValue($this->metadata));
+            $this->metadata->expects($this->once())
+                ->method('getName')
+                ->will($this->returnValue($fqClassName));
+        }
+
+        $refl = new \ReflectionClass($this->mapper);
+        $method = $refl->getMethod('expandClassName');
+        $method->setAccessible(true);
+        $res = $method->invoke($this->mapper, $this->dm, $className);
+
+        $this->assertEquals($fqClassName, $res);
+    }
 }
 
 class BaseClass {}

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
@@ -69,6 +69,15 @@ class FindTypeValidationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTe
         $this->assertSame($user, $userAgain);
     }
 
+    public function testFindWithNamespace()
+    {
+        $config = $this->dm->getConfiguration();
+        $config->addDocumentNamespace('Foobar', 'Doctrine\Tests\ODM\PHPCR\Functional');
+
+        $user = $this->dm->find('Foobar:TypeUser', 'functional/user');
+        $this->assertNotNull($user);
+    }
+
     public function testFindAutoclass()
     {
         $user = $this->dm->find(null, '/functional/user');

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
@@ -119,6 +119,19 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
         $this->assertCount(2, $res);
     }
 
+    public function testFromWithAlias()
+    {
+        $config = $this->dm->getConfiguration();
+        $config->addDocumentNamespace('Foobar', 'Doctrine\Tests\Models\Blog');
+
+        $qb = $this->createQb();
+        $qb->from()->document('Foobar:User', 'a');
+        // add where to stop rouge documents that havn't been stored in /functional/ from appearing.
+        $qb->where()->eq()->field('a.status')->literal('query_builder')->end();
+        $res = $qb->getQuery()->execute();
+        $this->assertCount(2, $res);
+    }
+
     /**
      * @depends testFrom
      */


### PR DESCRIPTION
Allow namespace aliases (e.g. FoobarBundle:Bar) to be used
in the query builder.

Fixes #407

This fixes the issue, although I notice we have the same issue with `->find($className, $path)` and maybe other places.
