### PR TITLE
Wronger order of variables

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
@@ -40,6 +40,8 @@ class DocumentClassMapper implements DocumentClassMapperInterface
             $className = $dm->getClassMetadata($className)->getName();
         }
 
+        $className = \Doctrine\Common\Util\ClassUtils::getRealClass($className);
+
         return $className;
     }
 


### PR DESCRIPTION
When checking if the given classname is a subclass of a different classname (in my case, a Proxy), a wrong order of variables was checked. The code checked if the actual classname is a subclass of the Proxy, which in fact, is the other way around.
