### PR TITLE
uuid fields for xml/yml driver

### DIFF
--- a/doctrine-phpcr-odm-mapping.xsd
+++ b/doctrine-phpcr-odm-mapping.xsd
@@ -137,6 +137,7 @@
             <xs:element name="document-listeners" type="phpcr:document-listeners" minOccurs="0" maxOccurs="1" />
             -->
             <xs:element name="id" type="phpcr:id" minOccurs="0" maxOccurs="1" />
+            <xs:element name="uuid" type="phpcr:uuid" minOccurs="0" maxOccurs="1" />
             <xs:element name="locale" type="phpcr:locale" minOccurs="0" maxOccurs="1" />
             <xs:element name="field" type="phpcr:field" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="node" type="phpcr:node" minOccurs="0" maxOccurs="1"/>
@@ -201,6 +202,10 @@
              -->
             <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
         </xs:choice>
+        <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
+        <xs:anyAttribute namespace="##other"/>
+    </xs:complexType>
+    <xs:complexType name="uuid">
         <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
         <xs:anyAttribute namespace="##other"/>
     </xs:complexType>

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
@@ -232,6 +232,23 @@ class XmlDriver extends FileDriver
             }
         }
 
+        if (isset($xmlRoot->uuid)) {
+            $mapping = array();
+            $attributes = $xmlRoot->uuid->attributes();
+
+            foreach ($attributes as $key => $value) {
+                $mapping[$key] = (string) $value;
+            }
+
+            if (!array_key_exists('name', $mapping)) {
+                throw new MappingException(sprintf('Missing name attribute for field of %s', $className));
+            }
+
+            $mapping['uuid'] = true;
+            $mapping['fieldName'] = $mapping['name'];
+            $class->mapField($mapping);
+        }
+
         $class->validateClassMapping();
     }
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
@@ -109,6 +109,14 @@ class YamlDriver extends FileDriver
                 $class->mapField($mapping);
             }
         }
+
+        if (isset($element['uuid'])) {
+            $mapping = array(
+                'fieldName' => $element['uuid'],
+                'uuid'      => true,
+            );
+            $class->mapField($mapping);
+        }
         if (isset($element['id'])) {
             if (is_array($element['id'])) {
                 if (!isset($element['id']['fieldName'])) {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -679,4 +679,23 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($class->mappings['stringAssoc']['multivalue']);
         $this->assertEquals('stringAssocKeys', $class->mappings['stringAssoc']['assoc']);
     }
+
+    /**
+     * @depends testLoadUuidMapping
+     * @param   $class
+     */
+    public function testUuidMapping($class)
+    {
+        $this->assertTrue(isset($class->uuidFieldName));
+        $this->assertEquals('uuid', $class->uuidFieldName);
+        $this->assertEquals('string', $class->mappings['uuid']['type']);
+        $this->assertEquals('jcr:uuid', $class->mappings['uuid']['property']);
+    }
+
+    public function testLoadUuidMapping()
+    {
+        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\UuidMappingObject';
+
+        return $this->loadMetadataForClassname($className);
+    }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/UuidMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/UuidMappingObject.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * @PHPCRODM\Document(referenceable=true)
+ */
+class UuidMappingObject
+{
+    /** @PHPCRODM\Id */
+    public $id;
+
+    /**@PHPCRODM\Uuid()*/
+    public $uuid;
+}

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.UuidMappingObject.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.UuidMappingObject.dcm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
+                  https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
+    <document name="Doctrine\Tests\ODM\PHPCR\Mapping\Model\UuidMappingObject" referenceable="true">
+        <id name="id" />
+        <uuid name="uuid" />
+    </document>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.UuidMappingObject.dcm.yml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.UuidMappingObject.dcm.yml
@@ -1,0 +1,4 @@
+Doctrine\Tests\ODM\PHPCR\Mapping\Model\UuidMappingObject:
+  referenceable: true
+  uuid: uuid
+  id: id


### PR DESCRIPTION
again without that typo and with one commit only.
(See https://github.com/doctrine/phpcr-odm/pull/437) for all commits.

What did i changed?
For xml/yml driver didn't exist a mapping for the uuid. Just for the annotation driver. So i created both. I added the condition for both drivers with creating the mapping the `ClassMetadata` needs. 
Created a new test with a fixtures too.
