### PR TITLE
Ensure we do not fail on proxy classes

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ODM\PHPCR;
 
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\PHPCR\Exception\ClassMismatchException;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
@@ -30,7 +31,7 @@ use PHPCR\PropertyType;
  */
 class DocumentClassMapper implements DocumentClassMapperInterface
 {
-    private function expandClassName($dm, $className = null)
+    private function expandClassName(DocumentManager $dm, $className = null)
     {
         if (null === $className) {
             return null;
@@ -40,7 +41,7 @@ class DocumentClassMapper implements DocumentClassMapperInterface
             $className = $dm->getClassMetadata($className)->getName();
         }
 
-        return $className;
+        return ClassUtils::getRealClass($className);
     }
 
     /**


### PR DESCRIPTION
Alternative to #436

I am not 100% sure why @AxaliaN got an error, but suppose he did get_class in userland code. the phpcr-odm only does get_class for exceptions and when interacting with getClassMetadata which in turn uses doctrine utils.

but i still think it does no harm and could help avoid unexpected errors with proxies.
