### PR TITLE
allow to configure the fallback locales for one language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2014-03-01**: The LocaleChooserInterface got a new method setFallbackLocales
+  which allows to update the fallback for a specific locale.
+
 * **2014-02-02**: DocumentManager::find()/findMany now actually validate the
   requested class name. If the class name determined by the DocumentClassMapper
   is not instance of the requested class name, null is returned. As previously,

--- a/lib/Doctrine/ODM/PHPCR/Translation/LocaleChooser/LocaleChooser.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/LocaleChooser/LocaleChooser.php
@@ -83,6 +83,22 @@ class LocaleChooser implements LocaleChooserInterface
     /**
      * {@inheritDoc}
      */
+    public function setFallbackLocales($locale, array $order, $replace = false)
+    {
+        if (!$replace && isset($this->localePreference[$locale])) {
+            foreach ($this->localePreference[$locale] as $oldLocale) {
+                if (!in_array($oldLocale, $order)) {
+                    $order[] = $oldLocale;
+                }
+            }
+        }
+
+        $this->localePreference[$locale] = $order;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getFallbackLocales($document, ClassMetadata $metadata, $forLocale = null)
     {
         if (is_null($forLocale)) {

--- a/lib/Doctrine/ODM/PHPCR/Translation/LocaleChooser/LocaleChooserInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/LocaleChooser/LocaleChooserInterface.php
@@ -33,7 +33,7 @@ use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
  * for getDefaultLocalesOrder. In some situations, you want a fixed order of
  * available languages, regardless of the current users preferences.
  *
- * @author brian () liip.ch
+ * @author Brian King <brian@liip.ch>
  */
 interface LocaleChooserInterface
 {
@@ -55,6 +55,16 @@ interface LocaleChooserInterface
      *      is found in $localePreference
      */
     public function setLocalePreference($localePreference);
+
+    /**
+     * Set or update the order of fallback locales for the selected locale.
+     *
+     * @param string $locale  The locale to update the fallback order for.
+     * @param array  $order   An order of locales to try as fallback.
+     * @param bool   $replace Whether to append existing locales to the end or
+     *                        replace the whole fallback order.
+     */
+    public function setFallbackLocales($locale, array $order, $replace = false);
 
     /**
      * Gets an ordered list of locales to try as fallback for a locale.

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/LocaleChooserTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/LocaleChooserTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ODM\PHPCR\Translation;
 
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 
 use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 
@@ -15,6 +16,9 @@ class LocaleChooserTest extends PHPCRTestCase
     protected $localeChooser;
     protected $orderEn = array('de');
     protected $orderDe = array('en');
+    /**
+     * @var ClassMetadata|\PHPUnit_Framework_MockObject_MockObject
+     */
     protected $mockMetadata;
 
     public function setUp()
@@ -22,7 +26,6 @@ class LocaleChooserTest extends PHPCRTestCase
         $this->mockMetadata = $this->getMockBuilder('\Doctrine\ODM\PHPCR\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
         $this->localeChooser = new LocaleChooser(array('en' => $this->orderEn, 'de' => $this->orderDe), 'en');
     }
-
 
     public function testGetFallbackLocales()
     {
@@ -33,6 +36,18 @@ class LocaleChooserTest extends PHPCRTestCase
         $this->localeChooser->setLocale('de');
         $orderDe = $this->localeChooser->getFallbackLocales(null, $this->mockMetadata);
         $this->assertEquals($this->orderDe, $orderDe);
+    }
+
+    public function testSetFallbackLocalesMerge()
+    {
+        $this->localeChooser->setFallbackLocales('de', array('fr'), false);
+        $this->assertEquals(array('fr', 'en'), $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'de'));
+    }
+
+    public function testSetFallbackLocalesReplace()
+    {
+        $this->localeChooser->setFallbackLocales('de', array('fr'), true);
+        $this->assertEquals(array('fr'), $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'de'));
     }
 
     /**


### PR DESCRIPTION
this is useful to update the fallback based on a request or information loaded from the currently logged in user.
