### PR TITLE
use ClassUtils::getClass when refreshing a document to not fail on proxies

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
@@ -30,7 +30,7 @@ use PHPCR\PropertyType;
  */
 class DocumentClassMapper implements DocumentClassMapperInterface
 {
-    private function expandClassName($dm, $className = null)
+    private function expandClassName(DocumentManager $dm, $className = null)
     {
         if (null === $className) {
             return null;

--- a/lib/Doctrine/ODM/PHPCR/Id/IdException.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/IdException.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\ODM\PHPCR\Id;
 
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\PHPCR\PHPCRException;
 
 class IdException extends PHPCRException
@@ -13,7 +14,7 @@ class IdException extends PHPCRException
                 'may not be empty in document of class "%s"',
             $parent,
             $nodename,
-            get_class($document)
+            ClassUtils::getClass($document)
         );
 
         return new self($message);
@@ -24,7 +25,7 @@ class IdException extends PHPCRException
         $message = sprintf(
             'Property "%s" mapped as ParentDocument may not be empty in document of class "%s"',
             $parent,
-            get_class($document)
+            ClassUtils::getClass($document)
         );
 
         return new self($message);
@@ -35,7 +36,7 @@ class IdException extends PHPCRException
         $message = sprintf(
             'NodeName property "%s" may not be empty in document of class "%s"',
             $fieldName,
-            get_class($document)
+            ClassUtils::getClass($document)
         );
 
         return new self($message);
@@ -43,12 +44,12 @@ class IdException extends PHPCRException
 
     public static function parentIdCouldNotBeDetermined($document, $parent, $parentObject)
     {
-        $parentType = is_object($parentObject) ? get_class($parentObject) : $parentObject;
+        $parentType = is_object($parentObject) ? ClassUtils::getClass($parentObject) : $parentObject;
         $message = sprintf(
             'ParentDocument property "%s" of document of class "%s" contains an ' .
             'object for which no ID could be found',
             $parent,
-            get_class($document),
+            ClassUtils::getClass($document),
             $parentType
         );
 
@@ -60,7 +61,7 @@ class IdException extends PHPCRException
         $message = sprintf(
             'NodeName property "%s" of document "%s" contains the illegal PHPCR value "%s".',
             $fieldName,
-            get_class($document),
+            ClassUtils::getClass($document),
             $nodeName
         );
 
@@ -77,7 +78,7 @@ class IdException extends PHPCRException
         $message = sprintf(
             '%s discovered as new child of %s in field "%s" has a node name ' .
             'mismatch. The mapping says "%s" but the child was assigned "%s".',
-            get_class($childDocument),
+            ClassUtils::getClass($childDocument),
             $parentId,
             $parentFieldName,
             $fieldNodeName,

--- a/lib/Doctrine/ODM/PHPCR/Id/RepositoryIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/RepositoryIdGenerator.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ODM\PHPCR\Id;
 
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 
@@ -36,7 +37,7 @@ class RepositoryIdGenerator extends IdGenerator
         }
         $repository = $dm->getRepository($class->name);
         if (!($repository instanceof RepositoryIdInterface)) {
-            throw new IdException("ID could not be determined. Make sure the that the Repository '".get_class($repository)."' implements RepositoryIdInterface");
+            throw new IdException("ID could not be determined. Make sure the that the Repository '".ClassUtils::getClass($repository)."' implements RepositoryIdInterface");
         }
 
         $id = $repository->generateId($document, $parent);

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1524,7 +1524,7 @@ class UnitOfWork
         $this->cascadeRefresh($class, $document, $visited);
 
         $hints = array('refresh' => true);
-        $this->getOrCreateDocument(get_class($document), $node, $hints);
+        $this->getOrCreateDocument(ClassUtils::getClass($document), $node, $hints);
     }
 
     public function merge($document)
@@ -2260,7 +2260,7 @@ class UnitOfWork
                                     $refClass = $this->dm->getClassMetadata(get_class($fv));
                                     $this->setMixins($refClass, $associatedNode);
                                     if (!$associatedNode->isNodeType('mix:referenceable')) {
-                                        throw new PHPCRException(sprintf('Referenced document %s is not referenceable. Use referenceable=true in Document annotation: '.self::objToStr($document, $this->dm), get_class($fv)));
+                                        throw new PHPCRException(sprintf('Referenced document %s is not referenceable. Use referenceable=true in Document annotation: '.self::objToStr($document, $this->dm), ClassUtils::getClass($fv)));
                                     }
                                     $refNodesIds[] = $associatedNode->getIdentifier();
                                 }
@@ -2279,7 +2279,7 @@ class UnitOfWork
                                 $refClass = $this->dm->getClassMetadata(get_class($fieldValue));
                                 $this->setMixins($refClass, $associatedNode);
                                 if (!$associatedNode->isNodeType('mix:referenceable')) {
-                                    throw new PHPCRException(sprintf('Referenced document %s is not referenceable. Use referenceable=true in Document annotation: '.self::objToStr($document, $this->dm), get_class($fieldValue)));
+                                    throw new PHPCRException(sprintf('Referenced document %s is not referenceable. Use referenceable=true in Document annotation: '.self::objToStr($document, $this->dm), ClassUtils::getClass($fieldValue)));
                                 }
                                 $node->setProperty($mapping['property'], $associatedNode->getIdentifier(), $strategy);
                             }
@@ -2355,7 +2355,7 @@ class UnitOfWork
                                     break;
                                 default:
                                     // in class metadata we only did a santiy check but not look at the actual mapping
-                                    throw new MappingException(sprintf('Field "%s" of document "%s" is not a reference field. Error in referrer annotation: '.self::objToStr($document, $this->dm), $mapping['referencedBy'], get_class($fv)));
+                                    throw new MappingException(sprintf('Field "%s" of document "%s" is not a reference field. Error in referrer annotation: '.self::objToStr($document, $this->dm), $mapping['referencedBy'], ClassUtils::getClass($fv)));
                             }
                         }
                     }
@@ -3266,7 +3266,7 @@ class UnitOfWork
     {
         $string = method_exists($obj, '__toString')
             ? (string) $obj
-            : get_class($obj).'@'.spl_object_hash($obj);
+            : ClassUtils::getClass($obj).'@'.spl_object_hash($obj);
 
         if ($dm) {
             try {


### PR DESCRIPTION
we have one place in the UoW where we should not have used a get_class but ClassUtils::getClass to not stumble over proxies.

i also updated the get_class calls in exceptions to ClassUtils::getClass to not confuse users with proxy class names.
