### PR TITLE
findTranslation should be consistent with find

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -438,7 +438,11 @@ class DocumentManager implements ObjectManager
     {
         try {
             if (UUIDHelper::isUUID($id)) {
-                $id = $this->session->getNodeByIdentifier($id)->getPath();
+                try {
+                    $id = $this->session->getNodeByIdentifier($id)->getPath();
+                } catch (ItemNotFoundException $e) {
+                    return null;
+                }
             } elseif (strpos($id, '/') !== 0) {
                 $id = '/'.$id;
             }


### PR DESCRIPTION
If an identifier does not exist, 'find' method will return null, and 'findTranslation' will throw ItemNotFoundException. Catch the exception in 'findTranslation' method and return null to provide consistency.
