### PR TITLE
Supported for using referrer fields in queries

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/BuilderConverterPhpcr.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/BuilderConverterPhpcr.php
@@ -122,7 +122,19 @@ class BuilderConverterPhpcr
      */
     protected function getPhpcrProperty($originalAlias, $odmField)
     {
-        $fieldMeta = $this->getMetadata($originalAlias)->getField($odmField);
+        $meta = $this->getMetadata($originalAlias);
+
+        if ($meta->hasField($odmField)) {
+            $fieldMeta = $meta->getField($odmField);
+        } elseif ($meta->hasAssociation($odmField)) {
+            $fieldMeta = $meta->getAssociation($odmField);
+        } else {
+            throw new \Exception(sprintf(
+                'Could not find a mapped field or association named "%s" for alias "%s"',
+                $odmField, $originalAlias
+            ));
+        }
+
         $propertyName = $fieldMeta['property'];
 
         if (empty($fieldMeta['translated'])

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -28,6 +28,11 @@ class CmsAddress
     /** @PHPCRODM\ReferenceOne(targetDocument="CmsUser") */
     public $user;
 
+    /**
+     * @PHPCRODM\Uuid
+     */
+    public $uuid;
+
     public function getId()
     {
         return $this->id;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/BuilderConverterPhpcrTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/BuilderConverterPhpcrTest.php
@@ -39,6 +39,9 @@ class BuilderConverterPhpcrTest extends \PHPUnit_Framework_TestCase
                     return $meta;
                 }
 
+                $meta->expects($me->any())
+                    ->method('hasField')
+                    ->will($me->returnValue(true));
 
                 $meta->expects($me->any())
                     ->method('getField')


### PR DESCRIPTION
It turns out that it was not possible to use referrer fields in the query builder, this PR fixes that, and makes joining on referrers possible.

Closes: https://github.com/doctrine/phpcr-odm/issues/467

``` php
        $qb = $this->dm->createQueryBuilder();
        $qb->fromDocument('Doctrine\Tests\Models\CMS\CmsUser', 'u');
        $qb->addJoinInner()
            ->right()->document('Doctrine\Tests\Models\CMS\CmsAddress', 'a')->end()
            ->condition()->equi('u.address', 'a.uuid');
        $qb->where()->eq()->field('a.city')->literal('Lyon');
        $q = $qb->getQuery();
        $res = $q->execute();
```
