### PR TITLE
fix issue when reordering children of uninitialized parent proxy

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2505,7 +2505,9 @@ class UnitOfWork
                     $class = $this->dm->getClassMetadata(get_class($parent));
                     foreach ($class->childrenMappings as $fieldName) {
                         $children = $class->reflFields[$fieldName]->getValue($parent);
-                        $children->setInitialized(false);
+                        if ($children instanceof PersistentCollection) {
+                            $children->setInitialized(false);
+                        }
                     }
                 }
             }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
@@ -189,6 +189,15 @@ class ReorderTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->reorder($parent, 'first', 'second', false);
     }
 
+    public function testReorderParentProxy()
+    {
+        $first = $this->dm->find(null, '/functional/source/first');
+        $parent = $first->getParent();
+        $this->dm->reorder($parent, 'first', 'second', false);
+        $this->dm->flush();
+        $this->assertSame(array('second', 'first', 'third', 'fourth'), $this->getChildrenNames($parent->getChildren()));
+    }
+
     private function getChildrenNames($children)
     {
         $result = array();


### PR DESCRIPTION
see discussion at https://github.com/symfony-cmf/MenuBundle/issues/181
