### PR TITLE
add translated documents lifecycle events, pre-/postBindTranslation and ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Changelog
 
 Third release candidate 1.1
 
-* **2014-04-19**: add bindTranslation event
+* **2014-04-19**: add events for translation lifecycle: pre-/postBindTranslation,
+    pre-/postRemoveTranslation and postLoadTranslation and its callbacks
 
 1.1.0-RC2
 ---------

--- a/lib/Doctrine/ODM/PHPCR/Event.php
+++ b/lib/Doctrine/ODM/PHPCR/Event.php
@@ -36,7 +36,12 @@ final class Event
     const onFlush = 'onFlush';
     const onClear = 'onClear';
     const loadClassMetadata = 'loadClassMetadata';
-    const bindTranslation = 'bindTranslation';
+
+    const postLoadTranslation = 'postLoadTranslation';
+    const preBindTranslation = 'preBindTranslation';
+    const postBindTranslation = 'postBindTranslation';
+    const preRemoveTranslation = 'preRemoveTranslation';
+    const postRemoveTranslation = 'postRemoveTranslation';
 
     public static $lifecycleCallbacks = array(
         self::prePersist => self::prePersist,
@@ -48,6 +53,11 @@ final class Event
         self::postUpdate => self::postUpdate,
         self::postMove => self::postMove,
         self::postLoad => self::postLoad,
+        self::postLoadTranslation => self::postLoadTranslation,
+        self::preBindTranslation => self::preBindTranslation,
+        self::postBindTranslation => self::postBindTranslation,
+        self::preRemoveTranslation => self::preRemoveTranslation,
+        self::postRemoveTranslation => self::postRemoveTranslation,
     );
 
     private function __construct()

--- a/lib/Doctrine/ODM/PHPCR/Event/ListenersInvoker.php
+++ b/lib/Doctrine/ODM/PHPCR/Event/ListenersInvoker.php
@@ -1,0 +1,115 @@
+<?php
+
+
+namespace Doctrine\ODM\PHPCR\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\Common\EventManager;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+
+/**
+ * A method invoker based on document lifecycle.
+ *
+ * @since  1.1
+ * @author Fabio B. Silva      <fabio.bat.silva@gmail.com>
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class ListenersInvoker
+{
+    const INVOKE_NONE       = 0;
+    // Actually not uses in the phpcr-odm
+    const INVOKE_LISTENERS  = 1;
+    const INVOKE_CALLBACKS  = 2;
+    const INVOKE_MANAGER    = 4;
+
+    /**
+     * The EventManager used for dispatching events.
+     *
+     * @var EventManager
+     */
+    private $eventManager;
+
+    /**
+     * @var DocumentManager
+     */
+    private $dm;
+
+    /**
+     * Initializes a new ListenersInvoker instance.
+     *
+     * @param DocumentManager $dm
+     */
+    public function __construct(DocumentManager $dm)
+    {
+        $this->eventManager = $dm->getEventManager();
+        $this->dm = $dm;
+    }
+
+    /**
+     * Get the subscribed event systems
+     *
+     * @param ClassMetadata $metadata
+     * @param string        $eventName The entity lifecycle event.
+     *
+     * @return integer                 Bitmask of subscribed event systems.
+     */
+    public function getSubscribedSystems(ClassMetadata $metadata, $eventName)
+    {
+        $invoke = self::INVOKE_NONE;
+
+        if ($metadata && isset($metadata->lifecycleCallbacks[$eventName])) {
+            $invoke |= self::INVOKE_CALLBACKS;
+        }
+
+        /*
+         * Not implemented for phpcr-odm at the moment.
+         *
+        if (isset($metadata->documentListeners[$eventName])) {
+            $invoke |= self::INVOKE_LISTENERS;
+        }
+        */
+
+        if ($this->eventManager->hasListeners($eventName)) {
+            $invoke |= self::INVOKE_MANAGER;
+        }
+
+        return $invoke;
+    }
+
+    /**
+     * Dispatches the lifecycle event of the given entity.
+     *
+     * @param ClassMetadata $metadata The entity metadata.
+     * @param string $eventName The entity lifecycle event.
+     * @param object $document The Entity on which the event occurred.
+     * @param EventArgs $event The Event args.
+     * @param $invoke
+     */
+    public function invoke(ClassMetadata $metadata, $eventName, $document, EventArgs $event, $invoke)
+    {
+        if ($invoke & self::INVOKE_CALLBACKS) {
+            foreach ($metadata->lifecycleCallbacks[$eventName] as $callback) {
+                $document->$callback($event);
+            }
+        }
+
+        /*
+         * Not implemented for phpcr-odm at the moment.
+         *
+        if ($invoke & self::INVOKE_LISTENERS) {
+            foreach ($metadata->documentListeners[$eventName] as $listener) {
+                $class      = $listener['class'];
+                $method     = $listener['method'];
+                $instance   = $this->resolver->resolve($class);
+
+                $instance->$method($document, $event);
+            }
+        }
+        */
+
+        if ($invoke & self::INVOKE_MANAGER) {
+            $this->eventManager->dispatchEvent($eventName, $event);
+        }
+    }
+}

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -19,10 +19,12 @@
 
 namespace Doctrine\ODM\PHPCR;
 
+use Doctrine\Common\EventArgs;
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
 
+use Doctrine\ODM\PHPCR\Event\ListenersInvoker;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\ODM\PHPCR\Exception\RuntimeException;
 use Doctrine\ODM\PHPCR\Id\AssignedIdGenerator;
@@ -63,6 +65,7 @@ use Jackalope\Session as JackalopeSession;
  * @author      Brian King <brian@liip.ch>
  * @author      David Buchmann <david@liip.ch>
  * @author      Daniel Barsotti <daniel.barsotti@liip.ch>
+ * @author      Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
  */
 class UnitOfWork
 {
@@ -209,9 +212,14 @@ class UnitOfWork
     private $session;
 
     /**
+     * @var Event\ListenersInvoker
+     */
+    private $eventListenersInvoker;
+
+    /**
      * @var \Doctrine\Common\EventManager
      */
-    private $evm;
+    private $eventManager;
 
     /**
      * @var DocumentClassMapperInterface
@@ -242,7 +250,8 @@ class UnitOfWork
     {
         $this->dm = $dm;
         $this->session = $dm->getPhpcrSession();
-        $this->evm = $dm->getEventManager();
+        $this->eventListenersInvoker = new ListenersInvoker($dm);
+        $this->eventManager = $dm->getEventManager();
 
         $config = $dm->getConfiguration();
         $this->documentClassMapper = $config->getDocumentClassMapper();
@@ -480,12 +489,14 @@ class UnitOfWork
         // Load translations
         $this->doLoadTranslation($document, $class, $locale, $fallback);
 
-        // Invoke the postLoad lifecycle callbacks and listeners
-        if (isset($class->lifecycleCallbacks[Event::postLoad])) {
-            $class->invokeLifecycleCallbacks(Event::postLoad, $document);
-        }
-        if ($this->evm->hasListeners(Event::postLoad)) {
-            $this->evm->dispatchEvent(Event::postLoad, new LifecycleEventArgs($document, $this->dm));
+        if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postLoad)) {
+            $this->eventListenersInvoker->invoke(
+                $class,
+                Event::postLoad,
+                $document,
+                new LifecycleEventArgs($document, $this->dm),
+                $invoke
+            );
         }
 
         return $document;
@@ -596,6 +607,16 @@ class UnitOfWork
             ));
         }
 
+        if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::preBindTranslation)) {
+            $this->eventListenersInvoker->invoke(
+                $class,
+                Event::preBindTranslation,
+                $document,
+                new LifecycleEventArgs($document, $this->dm),
+                $invoke
+            );
+        }
+
         $this->setLocale($document, $class, $locale);
 
         $oid = spl_object_hash($document);
@@ -608,8 +629,14 @@ class UnitOfWork
             $this->documentTranslations[$oid][$locale][$field] = $class->reflFields[$field]->getValue($document);
         }
 
-        if ($this->evm->hasListeners(Event::bindTranslation)) {
-            $this->evm->dispatchEvent(Event::bindTranslation, new LifecycleEventArgs($document, $this->dm));
+        if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postBindTranslation)) {
+            $this->eventListenersInvoker->invoke(
+                $class,
+                Event::postBindTranslation,
+                $document,
+                new LifecycleEventArgs($document, $this->dm),
+                $invoke
+            );
         }
     }
 
@@ -830,11 +857,14 @@ class UnitOfWork
         $this->setDocumentState($oid, self::STATE_REMOVED);
 
         $class = $this->dm->getClassMetadata(get_class($document));
-        if (isset($class->lifecycleCallbacks[Event::preRemove])) {
-            $class->invokeLifecycleCallbacks(Event::preRemove, $document);
-        }
-        if ($this->evm->hasListeners(Event::preRemove)) {
-            $this->evm->dispatchEvent(Event::preRemove, new LifecycleEventArgs($document, $this->dm));
+        if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::preRemove)) {
+            $this->eventListenersInvoker->invoke(
+                $class,
+                Event::preRemove,
+                $document,
+                new LifecycleEventArgs($document, $this->dm),
+                $invoke
+            );
         }
 
         $this->cascadeRemove($class, $document, $visited);
@@ -1488,11 +1518,14 @@ class UnitOfWork
      */
     public function persistNew(ClassMetadata $class, $document, $overrideIdGenerator = null, $parent = null)
     {
-        if (isset($class->lifecycleCallbacks[Event::prePersist])) {
-            $class->invokeLifecycleCallbacks(Event::prePersist, $document);
-        }
-        if ($this->evm->hasListeners(Event::prePersist)) {
-            $this->evm->dispatchEvent(Event::prePersist, new LifecycleEventArgs($document, $this->dm));
+        if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::prePersist)) {
+            $this->eventListenersInvoker->invoke(
+                $class,
+                Event::prePersist,
+                $document,
+                new LifecycleEventArgs($document, $this->dm),
+                $invoke
+            );
         }
 
         $generator = $this->getIdGenerator($overrideIdGenerator ? $overrideIdGenerator : $class->idGenerator);
@@ -1896,10 +1929,7 @@ class UnitOfWork
      */
     public function commit($document = null)
     {
-        // Raise preFlush
-        if ($this->evm->hasListeners(Event::preFlush)) {
-            $this->evm->dispatchEvent(Event::preFlush, new ManagerEventArgs($this->dm));
-        }
+        $this->invokeGlobalEvent(Event::preFlush, new ManagerEventArgs($this->dm));
 
         if ($document === null) {
             $this->computeChangeSets();
@@ -1911,9 +1941,7 @@ class UnitOfWork
             }
         }
 
-        if ($this->evm->hasListeners(Event::onFlush)) {
-            $this->evm->dispatchEvent(Event::onFlush, new ManagerEventArgs($this->dm));
-        }
+        $this->invokeGlobalEvent(Event::onFlush, new ManagerEventArgs($this->dm));
 
         try {
             $utx = $this->session->getWorkspace()->getTransactionManager();
@@ -1959,10 +1987,7 @@ class UnitOfWork
             $col->takeSnapshot();
         }
 
-        // Raise postFlush
-        if ($this->evm->hasListeners(Event::postFlush)) {
-            $this->evm->dispatchEvent(Event::postFlush, new ManagerEventArgs($this->dm));
-        }
+        $this->invokeGlobalEvent(Event::postFlush, new ManagerEventArgs($this->dm));
 
         if (null === $document) {
             $this->documentTranslations = array();
@@ -2117,11 +2142,14 @@ class UnitOfWork
 
             $this->doSaveTranslation($document, $node, $class);
 
-            if (isset($class->lifecycleCallbacks[Event::postPersist])) {
-                $class->invokeLifecycleCallbacks(Event::postPersist, $document);
-            }
-            if ($this->evm->hasListeners(Event::postPersist)) {
-                $this->evm->dispatchEvent(Event::postPersist, new LifecycleEventArgs($document, $this->dm));
+            if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postPersist)) {
+                $this->eventListenersInvoker->invoke(
+                    $class,
+                    Event::postPersist,
+                    $document,
+                    new LifecycleEventArgs($document, $this->dm),
+                    $invoke
+                );
             }
         }
 
@@ -2186,13 +2214,14 @@ class UnitOfWork
             }
 
             if ($dispatchEvents) {
-                if (isset($class->lifecycleCallbacks[Event::preUpdate])) {
-                    $class->invokeLifecycleCallbacks(Event::preUpdate, $document);
-                    $this->changesetComputed = array_diff($this->changesetComputed, array($oid));
-                    $this->computeChangeSet($class, $document);
-                }
-                if ($this->evm->hasListeners(Event::preUpdate)) {
-                    $this->evm->dispatchEvent(Event::preUpdate, new LifecycleEventArgs($document, $this->dm));
+                if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::preUpdate)) {
+                    $this->eventListenersInvoker->invoke(
+                        $class,
+                        Event::preUpdate,
+                        $document,
+                        new LifecycleEventArgs($document, $this->dm),
+                        $invoke
+                    );
                     $this->changesetComputed = array_diff($this->changesetComputed, array($oid));
                     $this->computeChangeSet($class, $document);
                 }
@@ -2386,11 +2415,14 @@ class UnitOfWork
             $this->doSaveTranslation($document, $node, $class);
 
             if ($dispatchEvents) {
-                if (isset($class->lifecycleCallbacks[Event::postUpdate])) {
-                    $class->invokeLifecycleCallbacks(Event::postUpdate, $document);
-                }
-                if ($this->evm->hasListeners(Event::postUpdate)) {
-                    $this->evm->dispatchEvent(Event::postUpdate, new LifecycleEventArgs($document, $this->dm));
+                if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postUpdate)) {
+                    $this->eventListenersInvoker->invoke(
+                        $class,
+                        Event::postUpdate,
+                        $document,
+                        new LifecycleEventArgs($document, $this->dm),
+                        $invoke
+                    );
                 }
             }
         }
@@ -2416,12 +2448,14 @@ class UnitOfWork
             }
 
             $class = $this->dm->getClassMetadata(get_class($document));
-            if (isset($class->lifecycleCallbacks[Event::preMove])) {
-                $class->invokeLifecycleCallbacks(Event::preMove, $document);
-            }
-
-            if ($this->evm->hasListeners(Event::preMove)) {
-                $this->evm->dispatchEvent(Event::preMove, new MoveEventArgs($document, $this->dm, $sourcePath, $targetPath));
+            if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::preMove)) {
+                $this->eventListenersInvoker->invoke(
+                    $class,
+                    Event::preMove,
+                    $document,
+                    new MoveEventArgs($document, $this->dm, $sourcePath, $targetPath),
+                    $invoke
+                );
             }
 
             $this->session->move($sourcePath, $targetPath);
@@ -2462,12 +2496,14 @@ class UnitOfWork
                 }
             }
 
-            if (isset($class->lifecycleCallbacks[Event::postMove])) {
-                $class->invokeLifecycleCallbacks(Event::postMove, $document);
-            }
-
-            if ($this->evm->hasListeners(Event::postMove)) {
-                $this->evm->dispatchEvent(Event::postMove, new MoveEventArgs($document, $this->dm, $sourcePath, $targetPath));
+            if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postMove)) {
+                $this->eventListenersInvoker->invoke(
+                    $class,
+                    Event::postMove,
+                    $document,
+                    new MoveEventArgs($document, $this->dm, $sourcePath, $targetPath),
+                    $invoke
+                );
             }
         }
     }
@@ -2543,11 +2579,14 @@ class UnitOfWork
             $this->unregisterDocument($document);
             $this->purgeChildren($document);
 
-            if (isset($class->lifecycleCallbacks[Event::postRemove])) {
-                $class->invokeLifecycleCallbacks(Event::postRemove, $document);
-            }
-            if ($this->evm->hasListeners(Event::postRemove)) {
-                $this->evm->dispatchEvent(Event::postRemove, new LifecycleEventArgs($document, $this->dm));
+            if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postRemove)) {
+                $this->eventListenersInvoker->invoke(
+                    $class,
+                    Event::postRemove,
+                    $document,
+                    new LifecycleEventArgs($document, $this->dm),
+                    $invoke
+                );
             }
         }
     }
@@ -2873,9 +2912,7 @@ class UnitOfWork
         $this->documentHistory =
         $this->documentVersion = array();
 
-        if ($this->evm->hasListeners(Event::onClear)) {
-            $this->evm->dispatchEvent(Event::onClear, new ManagerEventArgs($this->dm));
-        }
+        $this->invokeGlobalEvent(Event::onClear, new ManagerEventArgs($this->dm));
 
         $this->session->refresh(false);
     }
@@ -2952,6 +2989,17 @@ class UnitOfWork
                     $strategy->saveTranslation($data, $node, $metadata, $locale);
                 } else {
                     $strategy->removeTranslation($document, $node, $metadata, $locale);
+
+                    $class = $this->dm->getClassMetadata(get_class($document));
+                    if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postRemoveTranslation)) {
+                        $this->eventListenersInvoker->invoke(
+                            $class,
+                            Event::postRemoveTranslation,
+                            $document,
+                            new LifecycleEventArgs($document, $this->dm),
+                            $invoke
+                        );
+                    }
                 }
             }
         }
@@ -3140,6 +3188,17 @@ class UnitOfWork
                 }
             }
         }
+
+        $class = $this->dm->getClassMetadata(get_class($document));
+        if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postLoadTranslation)) {
+            $this->eventListenersInvoker->invoke(
+                $class,
+                Event::postLoadTranslation,
+                $document,
+                new LifecycleEventArgs($document, $this->dm),
+                $invoke
+            );
+        }
     }
 
     private function cascadeDoLoadTranslation($document, $mapping, $locale)
@@ -3163,6 +3222,17 @@ class UnitOfWork
 
     public function removeTranslation($document, $locale)
     {
+        $class = $this->dm->getClassMetadata(get_class($document));
+        if ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::preRemoveTranslation)) {
+            $this->eventListenersInvoker->invoke(
+                $class,
+                Event::preRemoveTranslation,
+                $document,
+                new LifecycleEventArgs($document, $this->dm),
+                $invoke
+            );
+        }
+
         $metadata = $this->dm->getClassMetadata(get_class($document));
         if (!$this->isDocumentTranslatable($metadata)) {
             return;
@@ -3498,4 +3568,16 @@ class UnitOfWork
         return $result;
     }
 
+    /**
+     * To invoke a global invent without using the ListenersInvoker.
+     *
+     * @param $eventName
+     * @param EventArgs $event
+     */
+    public function invokeGlobalEvent($eventName, EventArgs $event)
+    {
+        if ($this->eventManager->hasListeners($eventName)) {
+            $this->eventManager->dispatchEvent($eventName, $event);
+        }
+    }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsPageTranslatable.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsPageTranslatable.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Doctrine\Tests\Models\CMS;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+
+/**
+ * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsPageTranslatableRepository", referenceable=true, translator="attribute")
+ */
+class CmsPageTranslatable
+{
+    /**
+     * @PHPCRODM\Id(strategy="repository")
+     */
+    public $id;
+
+    /**
+     * @PHPCRODM\Node
+     */
+    public $node;
+
+    /**
+     * @PHPCRODM\Locale
+     */
+    public $locale;
+
+    /**
+     * @PHPCRODM\String
+     */
+    public $content;
+
+    /**
+     * @PHPCRODM\String(translated=true)
+     */
+    public $title;
+
+    /**
+     * @PHPCRODM\MixedReferrers(referenceType="hard")
+     */
+    public $items = array();
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setContent($content)
+    {
+        $this->content = $content;
+        return $this;
+    }
+
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setItems($items)
+    {
+        $this->items = $items;
+        return $this;
+    }
+
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    public function addItem($item)
+    {
+        $this->items[] = $item;
+    }
+
+    public function removeItem($item)
+    {
+        foreach ($this->items as $key => $value) {
+            if ($value === $item) {
+                unset($this->items[$key]);
+            }
+        }
+    }
+
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+}
+
+class CmsPageTranslatableRepository extends DocumentRepository implements RepositoryIdInterface
+{
+    /**
+     * Generate a document id
+     *
+     * @param object $document
+     * @param null $parent
+     * @return string
+     */
+    public function generateId($document, $parent = null)
+    {
+        return '/functional/'.$document->title;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Translation/Article.php
+++ b/tests/Doctrine/Tests/Models/Translation/Article.php
@@ -54,6 +54,9 @@ class Article
     /** @PHPCRODM\String(translated=true, nullable=true) */
     public $nullable;
 
+    /** @PHPCRODM\String(translated=true, assoc="", nullable=true)*/
+    public $assoc;
+
     /**
      * @PHPCRODM\String(assoc="", translated=true, nullable=true)
      */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
@@ -74,6 +74,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->doc->topic = 'Some interesting subject';
         $this->doc->setText('Lorem ipsum...');
         $this->doc->setSettings(array());
+        $this->doc->assoc = array('key' => 'value');
     }
 
     protected function getTestNode()
@@ -676,17 +677,18 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->persist($a);
 
         $translations = array(
-            'en' => 'Welcome',
-            'fr' => 'Bienvenue',
-            'de' => 'Wilkommen',
+            'en' => array('topic' => 'Welcome', 'assoc_value' => 'in en'),
+            'fr' => array('topic' => 'Bienvenue', 'assoc_value' => 'in fr'),
+            'de' => array('topic' => 'Wilkommen',  'assoc_value' => 'in de'),
         );
 
-        foreach ($translations as $locale => $topic) {
-            $a->topic = $topic;
+        foreach ($translations as $locale => $values) {
+            $a->topic = $values['topic'];
+            $a->assoc = array('key' => $values['assoc_value']);
             $this->dm->bindTranslation($a, $locale);
         }
 
-        foreach ($translations as $locale => $topic) {
+        foreach ($translations as $locale => $values) {
             $trans = $this->dm->findTranslation(
                 'Doctrine\Tests\Models\Translation\Article',
                 '/functional/' . $this->testNodeName,
@@ -695,7 +697,8 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
             $this->assertNotNull($trans, 'Finding translation with locale "'.$locale.'"');
             $this->assertInstanceOf('Doctrine\Tests\Models\Translation\Article', $trans);
-            $this->assertEquals($topic, $trans->topic);
+            $this->assertEquals($values['topic'], $trans->topic);
+            $this->assertEquals($values['assoc_value'], $trans->assoc['key']);
             $this->assertEquals($locale, $trans->locale);
         }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
@@ -45,6 +45,7 @@ class TranslationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertFieldMetadataEquals(false, $metadata, 'publishDate', 'translated');
         $this->assertFieldMetadataEquals(true, $metadata, 'topic', 'translated');
         $this->assertFieldMetadataEquals(true, $metadata, 'text', 'translated');
+        $this->assertFieldMetadataEquals(true, $metadata, 'assoc', 'translated');
 
         $this->assertTrue(isset($metadata->translator));
         $this->assertEquals('attribute', $metadata->translator);


### PR DESCRIPTION
This PR will hopefully cleanup #474.

I created a the following events:
- `preBindTranslation`
- `postBindTranslation`
- `loadTranslation`

and separated the test for the translation stuff. pre- and postBindTranslation surround the process when binding the translation and setting the document's translatable properties to that hash map in the UnitOfWork. loadTranslation is fired when all translation loading is done, means all cascading stuff.

@dbu is it the way you thought about it? Just did not understand your question about implicit/explicit. Can you explain what you mean, please?
