### PR TITLE
getOriginalPaths is only implemented for ReferresCollection

### DIFF
--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -38,7 +38,6 @@ class CmsUser
     public function __construct()
     {
         $this->articlesReferrers = new ArrayCollection();
-        $this->groups = new ArrayCollection();
     }
 
     public function getId()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRemoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRemoveTest.php
@@ -19,6 +19,10 @@ class CascadeRemoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCas
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $class->mappings['groups']['cascade'] = ClassMetadata::CASCADE_REMOVE;
 
+        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $class->mappings['articlesReferrers']['cascade'] = ClassMetadata::CASCADE_REMOVE;
+
+
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
         $class->mappings['users']['cascade'] = ClassMetadata::CASCADE_REMOVE;
 


### PR DESCRIPTION
without the correct check you get errors with new documents that have referrers as an ArrayCollection and a cascade remove.
