### PR TITLE
DO NOT MERGE: show issue with ArrayCollection

### DIFF
--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -38,6 +38,7 @@ class CmsUser
     public function __construct()
     {
         $this->articlesReferrers = new ArrayCollection();
+        $this->groups = new ArrayCollection();
     }
 
     public function getId()


### PR DESCRIPTION
This simple change makes the tests fail. The reason is that we keep the ArrayCollection of the newly created user after flush and cannot detect that new elements are added to the collection when we flush again. This detection of change is only possible with a PersistentCollection.

I had a quick check of the ORM code. The UnitOfWork there replaces anything not a PersistentCollection with one in computeChangeSet. That way the ORM can detect a change like this.

I guess doing that similar should fix this error and reduce some code complexity in the ODM's UnitOfWork as we no longer need checks and extra code for non PersistentCollections. But I guess it will be still a bit complicated since we have at least three different types of PersistentCollection (maybe that could be simplified as well).

Changing this is probably some kind of BC break and this may be only exposed in edge cases (when you modify a newly created instance after flush and modify it again) but you easily get it when you load fixtures with Alice (because there is a flush after each yml file) and you may run into this as well, when you need to create dependent instances and don't want or can't use cascading (such as creating a route for a content automatically when creating the content).
