### PR TITLE
use getParentDocument/setParentDocument instead of getParent/setParent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Changelog
 
 Third release candidate 1.1
 
+* **2014-04-29**: The provided documents now use getParentDocument and
+  setParentDocument to avoid clashes with domain parent logic and to be
+  consistent with the @ParentDocument annotation. Deprecated the getParent and
+  setParent.
+
 * **2014-04-19**: add events for translation lifecycle: pre-/postBindTranslation,
     pre-/postRemoveTranslation and postLoadTranslation and its callbacks
 

--- a/lib/Doctrine/ODM/PHPCR/Document/AbstractFile.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/AbstractFile.php
@@ -48,19 +48,23 @@ abstract class AbstractFile implements HierarchyInterface
     protected $createdBy;
 
     /**
-     * setter for id
+     * Set the id (the PHPCR path).
      *
      * @param string $id of the node
+     *
+     * @return $this
      */
     public function setId($id)
     {
         $this->id = $id;
+
+        return $this;
     }
 
     /**
-     * getter for id
+     * Get for id (the PHPCR path).
      *
-     * @return string id of the node
+     * @return string id of the document.
      */
     public function getId()
     {
@@ -81,32 +85,59 @@ abstract class AbstractFile implements HierarchyInterface
      * Set the node name of the file. (only mutable on new document before the persist)
      *
      * @param string $name the name of the file
+     *
+     * @return $this
      */
     public function setNodename($name)
     {
         $this->nodename = $name;
+
+        return $this;
     }
 
     /**
-     * The parent Folder document of this document.
+     * The parent document of this document. Could be a Folder.
      *
-     * @return object Folder document that is the parent of this node.
+     * @return object Document that is the parent of this node.
      */
-    public function getParent()
+    public function getParentDocument()
     {
         return $this->parent;
     }
 
     /**
-     * Set the parent document of this document. Only mutable on new document
-     * before the persist.
+     * Kept for BC
      *
-     * @param object $parent Document that is the parent of this node. Must be
-     *      a Folder or otherwise resolve to nt:folder
+     * @deprecated use getParentDocument instead.
+     */
+    public function getParent()
+    {
+        return $this->getParentDocument();
+    }
+
+    /**
+     * Set the parent document of this document.
+     *
+     * @param object $parent Document that is the parent of this node. Could be
+     *                       a Folder or otherwise resolve to nt:folder
+     *
+     * @return $this
+     */
+    public function setParentDocument($parent)
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    /**
+     * Kept for BC
+     *
+     * @deprecated use setParentDocument instead.
      */
     public function setParent($parent)
     {
-        $this->parent = $parent;
+        return $this->setParentDocument($parent);
     }
 
     /**

--- a/lib/Doctrine/ODM/PHPCR/Document/File.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/File.php
@@ -24,7 +24,7 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * This class represents a JCR file, aka nt:file.
- * @ see http://wiki.apache.org/jackrabbit/nt:file
+ * @see http://wiki.apache.org/jackrabbit/nt:file
  *
  * @PHPCRODM\Document(nodeType="nt:file", mixins={}, referenceable=true)
  */
@@ -41,6 +41,10 @@ class File extends AbstractFile
      * Calls file_get_contents with the given filename
      *
      * @param string $filename name of the file which contents should be used
+     *
+     * @return $this
+     *
+     * @throws RuntimeException If the filename does not point to a file that can be read.
      */
     public function setFileContentFromFilesystem($filename)
     {
@@ -62,16 +66,22 @@ class File extends AbstractFile
         $finfo = new \finfo();
         $this->content->setMimeType($finfo->file($filename,FILEINFO_MIME_TYPE));
         $this->content->setEncoding($finfo->file($filename,FILEINFO_MIME_ENCODING));
+
+        return $this;
     }
 
     /**
      * Set the content for this file from the given Resource.
      *
      * @param Resource $content
+     *
+     * @return $this
      */
     public function setContent(Resource $content)
     {
         $this->content = $content;
+
+        return $this;
     }
 
     /*
@@ -95,6 +105,8 @@ class File extends AbstractFile
      * Set the content for this file from the given resource or string.
      *
      * @param resource|string $content the content for the file
+     *
+     * @return $this
      */
     public function setFileContent($content)
     {
@@ -109,6 +121,8 @@ class File extends AbstractFile
         }
 
         $this->content->setData($stream);
+
+        return $this;
     }
 
     /**

--- a/lib/Doctrine/ODM/PHPCR/Document/Folder.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/Folder.php
@@ -20,6 +20,7 @@
 namespace Doctrine\ODM\PHPCR\Document;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\PHPCR\HierarchyInterface;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
@@ -49,7 +50,7 @@ class Folder extends AbstractFile
     /**
      * The children File documents of this Folder document
      *
-     * @return \Doctrine\Common\Collections\Collection list of File documents
+     * @return Collection list of File documents
      */
     public function getChildren()
     {
@@ -60,10 +61,14 @@ class Folder extends AbstractFile
      * Sets the children of this Folder document
      *
      * @param $children ArrayCollection
+     *
+     * @return $this
      */
     public function setChildren(ArrayCollection $children)
     {
         $this->children = $children;
+
+        return $this;
     }
 
     /**
@@ -71,6 +76,8 @@ class Folder extends AbstractFile
      * to this document that resolves to nt:folder (like the Folder)
      *
      * @param $child HierarchyInterface
+     *
+     * @return $this
      */
     public function addChild(HierarchyInterface $child)
     {
@@ -79,5 +86,7 @@ class Folder extends AbstractFile
         }
 
         $this->children->add($child);
+
+        return $this;
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Document/Generic.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/Generic.php
@@ -91,32 +91,58 @@ class Generic
      * Set the node name of the document. (only mutable on new document before the persist)
      *
      * @param string $name the name of the document
+     *
+     * @return $this
      */
     public function setNodename($name)
     {
         $this->nodename = $name;
+
+        return $this;
     }
 
     /**
-     * The parent Folder document of this document.
+     * The parent document of this document.
      *
      * @return object Folder document that is the parent of this node.
      */
-    public function getParent()
+    public function getParentDocument()
     {
         return $this->parent;
     }
 
     /**
-     * Set the parent document of this document. Only mutable on new document
-     * before the persist.
+     * Kept for BC
      *
-     * @param object $parent Document that is the parent of this node. Must be
-     *      a Folder or otherwise resolve to nt:folder
+     * @deprecated use getParentDocument instead.
+     */
+    public function getParent()
+    {
+        return $this->getParentDocument();
+    }
+
+    /**
+     * Set the parent document of this document.
+     *
+     * @param object $parent Document that is the parent of this node..
+     *
+     * @return $this
+     */
+    public function setParentDocument($parent)
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    /**
+     * Kept for BC
+     *
+     * @deprecated use setParentDocument instead.
      */
     public function setParent($parent)
     {
-        $this->parent = $parent;
+        return $this->setParentDocument($parent);
     }
 
     /**
@@ -136,16 +162,22 @@ class Generic
      * Sets the children
      *
      * @param $children ArrayCollection
+     *
+     * return $this
      */
     public function setChildren(ArrayCollection $children)
     {
         $this->children = $children;
+
+        return $this;
     }
 
     /**
      * Add a child to this document
      *
      * @param $child
+     *
+     * @return $this
      */
     public function addChild($child)
     {
@@ -154,6 +186,8 @@ class Generic
         }
 
         $this->children->add($child);
+
+        return $this;
     }
 
     /**
@@ -173,16 +207,22 @@ class Generic
      * Sets the referrers
      *
      * @param $referrers ArrayCollection
+     *
+     * @return $this;
      */
     public function setReferrers(ArrayCollection $referrers)
     {
         $this->referrers = $referrers;
+
+        return $this;
     }
 
     /**
      * Add a referrer to this document
      *
      * @param $referrer
+     *
+     * @return $this;
      */
     public function addReferrer($referrer)
     {
@@ -191,8 +231,15 @@ class Generic
         }
 
         $this->referrers->add($referrer);
+
+        return $this;
     }
 
+    /**
+     * String representation
+     *
+     * @return string
+     */
     public function __toString()
     {
         return (string) $this->nodename;

--- a/lib/Doctrine/ODM/PHPCR/Document/Resource.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/Resource.php
@@ -97,10 +97,14 @@ class Resource
      * child, this must be "jcr:content".
      *
      * @param string $name the name of the resource
+     *
+     * @return $this
      */
     public function setNodename($name)
     {
         $this->nodename = $name;
+
+        return $this;
     }
 
     /**
@@ -108,29 +112,58 @@ class Resource
      *
      * @return object File document that is the parent of this node.
      */
-    public function getParent()
+    public function getParentDocument()
     {
         return $this->parent;
+    }
+
+    /**
+     * Kept for BC
+     *
+     * @deprecated use getParentDocument instead.
+     */
+    public function getParent()
+    {
+        return $this->getParentDocument();
     }
 
     /**
      * Set the parent document of this resource.
      *
      * @param object $parent Document that is the parent of this node.
+     *
+     * @return $this
+     */
+    public function setParentDocument($parent)
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+
+    /**
+     * Kept for BC
+     *
+     * @deprecated use setParentDocument instead.
      */
     public function setParent($parent)
     {
-        $this->parent = $parent;
+        return $this->setParentDocument($parent);
     }
 
     /**
      * Set the data from a binary stream.
      *
      * @param stream $data the contents of this resource
+     *
+     * @return $this
      */
     public function setData($data)
     {
         $this->data = $data;
+
+        return $this;
     }
 
     /**
@@ -169,10 +202,14 @@ class Resource
      * Set the mime type information for this resource.
      *
      * @param string $mimeType
+     *
+     * @return $this
      */
     public function setMimeType($mimeType)
     {
         $this->mimeType = $mimeType;
+
+        return $this;
     }
 
     /**
@@ -189,10 +226,14 @@ class Resource
      * Set the encoding information for the data stream.
      *
      * @param string $encoding
+     *
+     * @return $this
      */
     public function setEncoding($encoding)
     {
         $this->encoding = $encoding;
+
+        return $this;
     }
 
     /**
@@ -212,10 +253,14 @@ class Resource
      * it is not required by the specification.
      *
      * @param \DateTime $lastModified
+     *
+     * @return $this
      */
     public function setLastModified($lastModified)
     {
         $this->lastModified = $lastModified;
+
+        return $this;
     }
 
     /**
@@ -235,10 +280,14 @@ class Resource
      * it is not required by the specification.
      *
      * @param string $lastModifiedBy
+     *
+     * @return $this
      */
     public function setLastModifiedBy($lastModifiedBy)
     {
         $this->lastModifiedBy = $lastModifiedBy;
+
+        return $this;
     }
 
     /**

--- a/lib/Doctrine/ODM/PHPCR/HierarchyInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/HierarchyInterface.php
@@ -11,18 +11,38 @@ namespace Doctrine\ODM\PHPCR;
 interface HierarchyInterface
 {
     /**
-     * Get the parent node.
+     * Get the parent document of this document.
      *
-     * @return Object|null
+     * @return object|null
+     */
+    public function getParentDocument();
+
+    /**
+     * Get the parent document.
+     *
+     * @deprecated in favor of getParentDocument to avoid clashes with domain model parents.
+     *
+     * @return object|null
      */
     public function getParent();
 
     /**
-     * Set the parent node.
+     * Set the parent document for this document.
      *
-     * @param Object $parent
+     * @param object $parent
      *
-     * @return boolean
+     * @return $this
+     */
+    public function setParentDocument($parent);
+
+    /**
+     * Set the parent document.
+     *
+     * @deprecated in favor of getParentDocument to avoid clashes with domain model parents.
+     *
+     * @param object $parent
+     *
+     * @return $this
      */
     public function setParent($parent);
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsTeamUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsTeamUser.php
@@ -11,13 +11,17 @@ use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
  */
 class CmsTeamUser extends CmsUser
 {
-    /** @PHPCRODM\ParentDocument */
+    /**
+     * @PHPCRODM\ParentDocument
+     */
     public $parent;
 
-    /** @PHPCRODM\Nodename */
+    /**
+     * @PHPCRODM\Nodename
+     */
     public $nodename;
 
-    public function setParent($parent)
+    public function setParentDocument($parent)
     {
         $this->parent = $parent;
     }

--- a/tests/Doctrine/Tests/Models/References/ParentTestObj.php
+++ b/tests/Doctrine/Tests/Models/References/ParentTestObj.php
@@ -18,12 +18,12 @@ class ParentTestObj
     /** @PHPCRODM\String */
     public $name;
 
-    public function getParent()
+    public function getParentDocument()
     {
         return $this->parent;
     }
 
-    public function setParent($parent)
+    public function setParentDocument($parent)
     {
         $this->parent = $parent;
     }

--- a/tests/Doctrine/Tests/Models/References/RefManyWithParentTestObjForCascade.php
+++ b/tests/Doctrine/Tests/Models/References/RefManyWithParentTestObjForCascade.php
@@ -18,7 +18,7 @@ class RefManyWithParentTestObjForCascade
     public function setReferences($references)
     {
         foreach ($references as $reference) {
-            $reference->setParent($this);
+            $reference->setParentDocument($this);
         }
 
         $this->references = $references;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
@@ -234,7 +234,7 @@ class MoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $user = $this->dm->find(null, '/functional/lsmith/dbu');
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsTeamUser', $user);
         $root = $this->dm->find(null, '/');
-        $user->setParent($root);
+        $user->setParentDocument($root);
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
@@ -37,7 +37,7 @@ class ReorderTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $parent = $this->dm->find(null, $this->node->getPath());
 
         $node1 = new Generic();
-        $node1->setParent($parent);
+        $node1->setParentDocument($parent);
         $node1->setNodename('source');
         $this->dm->persist($node1);
 
@@ -45,13 +45,13 @@ class ReorderTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         foreach ($this->childrenNames as $childName) {
             $child = new Generic();
             $child->setNodename($childName);
-            $child->setParent($node1);
+            $child->setParentDocument($node1);
             $this->dm->persist($child);
         }
 
         $node2 = new Generic();
         $node2->setNodename('target');
-        $node2->setParent($parent);
+        $node2->setParentDocument($parent);
         $this->dm->persist($node2);
 
         $this->dm->flush();
@@ -192,7 +192,7 @@ class ReorderTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testReorderParentProxy()
     {
         $first = $this->dm->find(null, '/functional/source/first');
-        $parent = $first->getParent();
+        $parent = $first->getParentDocument();
         $this->dm->reorder($parent, 'first', 'second', false);
         $this->dm->flush();
         $this->assertSame(array('second', 'first', 'third', 'fourth'), $this->getChildrenNames($parent->getChildren()));


### PR DESCRIPTION
this avoids collisions with domain models. we can't just remove the old methods so for now we still could have collisions, but eventually we can remove the deprecated methods.
