### PR TITLE
revert BC break glitch

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -3556,9 +3556,9 @@ class UnitOfWork
      */
     protected function createAssoc(array $properties, array $mapping)
     {
-        $keys = $properties[$mapping['assoc']];
-        $values = $properties[$mapping['property']];
-        $nulls = isset($properties[$mapping['assocNulls']]) ? $properties[$mapping['assocNulls']] : array();
+        $keys = (array) $properties[$mapping['assoc']];
+        $values = (array) $properties[$mapping['property']];
+        $nulls = isset($properties[$mapping['assocNulls']]) ? ((array) $properties[$mapping['assocNulls']]) : array();
 
         // make sure we start with first value
         reset($values);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -195,7 +195,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     }
 
     /**
-     * @expectedException Doctrine\ODM\PHPCR\Exception\RuntimeException
+     * @expectedException \Doctrine\ODM\PHPCR\Exception\RuntimeException
      */
     public function testBadUuidSetting()
     {


### PR DESCRIPTION
i was not able to reproduce the problem, but users reported a problem with 80f6f501a569812b03a6d610f422ff173d08c613 that the new code stumbled over having just a string in the $keys.

ideally we would figure out what can cause that situation, but at least this will revert the break for such situations, making the code behave as before.
