### PR TITLE
allow to add uuid as id to proxies

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -1464,8 +1464,12 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function newInstance()
     {
-        if (!$this->instantiator instanceof InstantiatorInterface) {
-            $this->instantiator = new Instantiator();
+        if ($this->prototype === null) {
+            if (PHP_VERSION_ID === 50429 || PHP_VERSION_ID === 50513) {
+                $this->_prototype = $this->reflClass->newInstanceWithoutConstructor();
+            } else {
+                $this->_prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
+            }
         }
 
         return $this->instantiator->instantiate($this->name);

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -1466,9 +1466,9 @@ class ClassMetadata implements ClassMetadataInterface
     {
         if ($this->prototype === null) {
             if (PHP_VERSION_ID === 50429 || PHP_VERSION_ID === 50513) {
-                $this->_prototype = $this->reflClass->newInstanceWithoutConstructor();
+                $this->prototype = $this->reflClass->newInstanceWithoutConstructor();
             } else {
-                $this->_prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
+                $this->prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
             }
         }
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -29,8 +29,6 @@ use ReflectionClass;
 use Doctrine\Common\Persistence\Mapping\ReflectionService;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
 use Doctrine\Common\ClassLoader;
-use Doctrine\Instantiator\Instantiator;
-use Doctrine\Instantiator\InstantiatorInterface;
 
 /**
  * Metadata class
@@ -96,6 +94,13 @@ class ClassMetadata implements ClassMetadataInterface
      * @var ReflectionProperty[]
      */
     public $reflFields = array();
+
+    /**
+     * The prototype from which new instances of the mapped class are created.
+     *
+     * @var object
+     */
+    private $prototype;
 
     /**
      * READ-ONLY: The ID generator used for generating IDs for this class.
@@ -1114,7 +1119,6 @@ class ClassMetadata implements ClassMetadataInterface
             return false;
         }
         return in_array($fieldName, $this->fieldMappings)
-            || isset($this->inheritedFields[$fieldName])
             || $this->identifier === $fieldName
             || $this->localeMapping === $fieldName
             || $this->node === $fieldName
@@ -1472,7 +1476,7 @@ class ClassMetadata implements ClassMetadataInterface
             }
         }
 
-        return $this->instantiator->instantiate($this->name);
+        return clone $this->prototype;
     }
 
     /**

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -566,11 +566,14 @@ class UnitOfWork
      */
     public function refreshDocumentForProxy($className, Proxy $document)
     {
-        $id = $this->determineDocumentId($document);
-        if (UUIDHelper::isUUID($id)) {
-            $node = $this->session->getNodeByIdentifier($id);
+        $identifier = $this->determineDocumentId($document);
+        if (UUIDHelper::isUUID($identifier)) {
+            $node = $this->session->getNodeByIdentifier($identifier);
+            // switch the registration to come back on the line
+            $this->unregisterDocument($document);
+            $this->registerDocument($document, $node->getPath());
         } else {
-            $node = $this->session->getNode($id);
+            $node = $this->session->getNode($identifier);
         }
 
         $hints = array('refresh' => true, 'fallback' => true);

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2666,7 +2666,7 @@ class UnitOfWork
             $id = $this->getDocumentId($document);
 
             try {
-                $this->dm->getNodeByPathOrUuid($id);
+                $node = $this->dm->getNodeByPathOrUuid($id);
                 $this->doRemoveAllTranslations($document, $class);
                 $node->remove();
             } catch (PathNotFoundException $e) {

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2666,11 +2666,7 @@ class UnitOfWork
             $id = $this->getDocumentId($document);
 
             try {
-                if (UUIDHelper::isUUID($id)) {
-                    $node = $this->session->getNodeByIdentifier($id);
-                } else {
-                    $node = $this->session->getNode($id);
-                }
+                $this->dm->getNodeByPathOrUuid($id);
                 $this->doRemoveAllTranslations($document, $class);
                 $node->remove();
             } catch (PathNotFoundException $e) {
@@ -3476,11 +3472,7 @@ class UnitOfWork
             throw new InvalidArgumentException(sprintf("The document at '%s' is not full versionable", $id));
         }
 
-        if (UUIDHelper::isUUID($id)) {
-            $node = $this->session->getNodeByIdentifier($id);
-        } else {
-            $node = $this->session->getNode($id);
-        }
+        $node = $this->dm->getNodeByPathOrUuid($id);
         $node->addMixin('mix:versionable');
 
         return $id;

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -566,6 +566,14 @@ class UnitOfWork
      */
     public function refreshDocumentForProxy($className, Proxy $document)
     {
+        $identifier = $this->determineDocumentId($document);
+        $node = $this->dm->getNodeByPathOrUuid($identifier);
+        if (UUIDHelper::isUUID($identifier)) {
+            // switch document registration to path as usual
+            $this->unregisterDocument($document);
+            $this->registerDocument($document, $node->getPath());
+        }
+
         $hints = array('refresh' => true, 'fallback' => true);
 
         $oid = spl_object_hash($document);
@@ -573,7 +581,7 @@ class UnitOfWork
             $hints['locale'] = $this->documentLocales[$oid]['current'];
         }
 
-        $this->getOrCreateDocument($className, $this->dm->getNodeForDocument($document), $hints);
+        $this->getOrCreateDocument($className, $node, $hints);
     }
 
     /**

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -566,7 +566,12 @@ class UnitOfWork
      */
     public function refreshDocumentForProxy($className, Proxy $document)
     {
-        $node = $this->session->getNode($this->determineDocumentId($document));
+        $id = $this->determineDocumentId($document);
+        if (UUIDHelper::isUUID($id)) {
+            $node = $this->session->getNodeByIdentifier($id);
+        } else {
+            $node = $this->session->getNode($id);
+        }
 
         $hints = array('refresh' => true, 'fallback' => true);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
@@ -2,8 +2,12 @@
 
 namespace Doctrine\Tests\ODM\PHPCR;
 
+use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use PHPCR\ItemNotFoundException;
+use PHPCR\Util\UUIDHelper;
+use PHPCR\PathNotFoundException;
 
 /**
  * @group unit
@@ -11,38 +15,56 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 class DocumentManagerTest extends PHPCRTestCase
 {
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::find
-     */
-    public function testFind()
-    {
-        $fakeUuid = \PHPCR\Util\UUIDHelper::generateUUID();
-        $session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNodeByIdentifier'));
-        $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new \PHPCR\ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
 
-        $dm = DocumentManager::create($session, $config);
-
-        $nonExistent = $dm->find(null, $fakeUuid);
-
-        $this->assertNull($nonExistent);
-    }
+	 * @covers Doctrine\ODM\PHPCR\DocumentManager::find
+	 */
+	public function testFindExceptionWhenUuidNotFound()
+	{
+		$fakeUuid = UUIDHelper::generateUUID();
+		$session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNodeByIdentifier'));
+		$session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
+		$config = new Configuration();
+		
+		$dm = DocumentManager::create($session, $config);
+		
+		$nonExistent = $dm->find(null, $fakeUuid);
+	
+		$this->assertNull($nonExistent);
+	}
 
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::findTranslation
+     * @covers Doctrine\ODM\PHPCR\DocumentManager::find
      */
-    public function testFindTranslation()
+    public function testFindExceptionWhenIdNotFound()
     {
-        $fakeUuid = \PHPCR\Util\UUIDHelper::generateUUID();
-        $session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNodeByIdentifier'));
-        $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new \PHPCR\ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
+        $fakeId = 'fakeId';
+        $session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNode'));
+        $session->expects($this->once())->method('getNode')->will($this->throwException(new PathNotFoundException(sprintf('403: %s', $fakeId))));
+        $config = new Configuration();
 
         $dm = DocumentManager::create($session, $config);
 
-        $nonExistent = $dm->findTranslation(null, $fakeUuid, 'en');
+        $nonExistent = $dm->find(null, $fakeId);
 
         $this->assertNull($nonExistent);
     }
+	
+	/**
+	 * @covers Doctrine\ODM\PHPCR\DocumentManager::findTranslation
+	 */
+	public function testFindTranslation()
+	{
+		$fakeUuid = UUIDHelper::generateUUID();
+		$session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNodeByIdentifier'));
+		$session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
+		$config = new Configuration();
+	
+		$dm = DocumentManager::create($session, $config);
+	
+		$nonExistent = $dm->findTranslation(null, $fakeUuid, 'en');
+	
+		$this->assertNull($nonExistent);
+	}
     
     /**
      * @covers Doctrine\ODM\PHPCR\DocumentManager::create
@@ -51,7 +73,7 @@ class DocumentManagerTest extends PHPCRTestCase
     public function testNewInstanceFromConfiguration()
     {
         $session = $this->getMock('PHPCR\SessionInterface');
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
+        $config = new Configuration();
 
         $dm = DocumentManager::create($session, $config);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -173,12 +173,6 @@ class UnitOfWorkTest extends PHPCRTestCase
 
         $this->assertEquals(2, $this->uow->getDocumentState($userAsReference));
         $this->assertEquals($userAsReference, $this->uow->getDocumentById($userAsReference->id));
-
-        $this->session
-            ->expects($this->any())
-            ->method('getNode')
-            ->with($this->equalTo('/somepath'))
-            ->will($this->returnValue($this->createNode('/somepath', 'persisted-username')));
     }
 
     public function testGetOrCreateProxyWithUuid()
@@ -189,13 +183,7 @@ class UnitOfWorkTest extends PHPCRTestCase
         $userAsReference = $this->uow->getOrCreateProxy($uuid, get_class($user));
 
         $this->assertEquals(2, $this->uow->getDocumentState($userAsReference));
-        $this->assertEquals($userAsReference, $this->uow->getDocumentById($userAsReference->id));
-
-        $this->session
-            ->expects($this->any())
-            ->method('getNodeByIdentifier')
-            ->with($this->equalTo($uuid))
-            ->will($this->returnValue($this->createNode('/somepath', 'persisted-username')));
+        $this->assertEquals($userAsReference, $this->uow->getDocumentById($uuid));
     }
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 
 use Jackalope\Factory;
 use Jackalope\Node;
+use PHPCR\Util\UUIDHelper;
 
 /**
  * TODO: remove Jackalope dependency
@@ -39,7 +40,6 @@ class UnitOfWorkTest extends PHPCRTestCase
         $this->factory = new Factory;
         $this->session = $this->getMock('Jackalope\Session', array(), array($this->factory), '', false);
         $this->objectManager = $this->getMock('Jackalope\ObjectManager', array(), array($this->factory), '', false);
-
         $this->type = 'Doctrine\Tests\ODM\PHPCR\UoWUser';
         $this->dm = DocumentManager::create($this->session);
         $this->uow = new UnitOfWork($this->dm);
@@ -53,19 +53,22 @@ class UnitOfWorkTest extends PHPCRTestCase
         $cmf->setMetadataFor($this->type, $metadata);
     }
 
-    protected function createNode($id, $username)
+    protected function createNode($id, $username, $uuid = null)
     {
         $repository = $this->getMockBuilder('Jackalope\Repository')->disableOriginalConstructor()->getMock();
         $this->session->expects($this->any())
             ->method('getRepository')
             ->with()
             ->will($this->returnValue($repository));
-
         $nodeData = array(
             "jcr:primaryType" => "rep:root",
             "jcr:system" => array(),
             'username' => $username,
         );
+
+        if (null !== $uuid) {
+            $nodeData['jcr:uuid'] = $uuid;
+        }
         return new Node($this->factory, $nodeData, $id, $this->session, $this->objectManager);
     }
 
@@ -160,6 +163,49 @@ class UnitOfWorkTest extends PHPCRTestCase
         $dm = DocumentManager::create($this->session, $config);
         $uow = new UnitOfWork($dm);
         $this->assertEquals('like-a-uuid', $method->invoke($uow));
+    }
+
+    public function testGetOrCreateProxy()
+    {
+        $user = $this->uow->getOrCreateDocument($this->type, $this->createNode('/somepath', 'foo'));
+        $this->uow->clear();
+        $userAsReference = $this->uow->getOrCreateProxy($user->id, get_class($user));
+
+        $this->assertEquals(2, $this->uow->getDocumentState($userAsReference));
+        $this->assertEquals($userAsReference, $this->uow->getDocumentById($userAsReference->id));
+
+        $this->session
+            ->expects($this->any())
+            ->method('getNode')
+            ->will($this->returnValue($this->createNode('/somepath', 'persisted-username')));
+
+        $userAsReference->username = 'updatedName';
+        $this->uow->scheduleInsert($userAsReference);
+
+        $this->assertCount(0, $this->uow->getScheduledInserts());
+        $this->assertCount(0, $this->uow->getScheduledRemovals());
+    }
+
+    public function testGetOrCreateProxyWithUuid()
+    {
+        $uuid = UUIDHelper::generateUUID();
+        $user = $this->uow->getOrCreateDocument($this->type, $this->createNode('/somepath', 'foo', $uuid));
+        $this->uow->clear();
+        $userAsReference = $this->uow->getOrCreateProxy($uuid, get_class($user));
+
+        $this->assertEquals(2, $this->uow->getDocumentState($userAsReference));
+        $this->assertEquals($userAsReference, $this->uow->getDocumentById($userAsReference->id));
+
+        $this->session
+            ->expects($this->any())
+            ->method('getNodeByIdentifier')
+            ->will($this->returnValue($this->createNode('/somepath', 'persisted-username')));
+
+        $userAsReference->username = 'updatedName';
+        $this->uow->scheduleInsert($userAsReference);
+
+        $this->assertCount(0, $this->uow->getScheduledInserts());
+        $this->assertCount(0, $this->uow->getScheduledRemovals());
     }
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -177,13 +177,8 @@ class UnitOfWorkTest extends PHPCRTestCase
         $this->session
             ->expects($this->any())
             ->method('getNode')
+            ->with($this->equalTo('/somepath'))
             ->will($this->returnValue($this->createNode('/somepath', 'persisted-username')));
-
-        $userAsReference->username = 'updatedName';
-        $this->uow->scheduleInsert($userAsReference);
-
-        $this->assertCount(0, $this->uow->getScheduledInserts());
-        $this->assertCount(0, $this->uow->getScheduledRemovals());
     }
 
     public function testGetOrCreateProxyWithUuid()
@@ -199,13 +194,8 @@ class UnitOfWorkTest extends PHPCRTestCase
         $this->session
             ->expects($this->any())
             ->method('getNodeByIdentifier')
+            ->with($this->equalTo($uuid))
             ->will($this->returnValue($this->createNode('/somepath', 'persisted-username')));
-
-        $userAsReference->username = 'updatedName';
-        $this->uow->scheduleInsert($userAsReference);
-
-        $this->assertCount(0, $this->uow->getScheduledInserts());
-        $this->assertCount(0, $this->uow->getScheduledRemovals());
     }
 }
 

--- a/tests/phpunit_doctrine_dbal.xml.dist
+++ b/tests/phpunit_doctrine_dbal.xml.dist
@@ -16,8 +16,7 @@
 
     <testsuites>
         <testsuite name="Project Test Suite">
-            <file>/home/maximilian/websites/Cmf/phpcr-odm/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php</file>
-            <!-- <directory>./</directory> -->
+            <directory>./</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/phpunit_doctrine_dbal.xml.dist
+++ b/tests/phpunit_doctrine_dbal.xml.dist
@@ -16,7 +16,8 @@
 
     <testsuites>
         <testsuite name="Project Test Suite">
-            <directory>./</directory>
+            <file>/home/maximilian/websites/Cmf/phpcr-odm/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php</file>
+            <!-- <directory>./</directory> -->
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
As described in:
https://gist.github.com/ElectricMaxxx/68a7d033a6357e757329
i would wish to create proxies (after calling `$dm->getReference('MyClassName', 'uuid');`) with the uuid as the id. This PR will make it possible that the request on the backend is able to handle the uuid. 
Normally `$session->getNode($id);` will fetch the node. Now there will be a check if the `$id` is an uuid and fetch the node by `$session->getNodeByIdentifier($id);` , which is able to look for a node by its uuid.

I tried to create more tests for those documents that live as proxies in the UoW, but i do not get it to solve the mocking and i do not know if it is clever to do so, cause if i would mock some implementation depending, we would lose the decoupled view on the backend.
