### PR TITLE
also escape single quotes

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -512,7 +512,7 @@ class DocumentManager implements ObjectManager
         $illegalCharacters = array(
             '!' => '\\!', '(' => '\\(', ':' => '\\:', '^' => '\\^',
             '[' => '\\[', ']' => '\\]', '{' => '\\{', '}' => '\\}',
-            '\"' => '\\\"', '?' => '\\?',
+            '\"' => '\\\"', '?' => '\\?', "'" => "''",
         );
 
         return strtr($string, $illegalCharacters);


### PR DESCRIPTION
is there a reason we left out single quotes?

see http://jackrabbit.apache.org/api/1.4/org/apache/jackrabbit/util/Text.html#escapeIllegalJcrChars(java.lang.String)

```
simplename ::= onecharsimplename | twocharsimplename | threeormorecharname
 onecharsimplename ::= (* Any Unicode character except: '.', '/', ':', '[', ']', '*', ''', '"', '|' or any whitespace character *)
 twocharsimplename ::= '.' onecharsimplename | onecharsimplename '.' | onecharsimplename onecharsimplename
 threeormorecharname ::= nonspace string nonspace
 string ::= char | string char
 char ::= nonspace | ' '
 nonspace ::= (* Any Unicode character except: '/', ':', '[', ']', '*', ''', '"', '|' or any whitespace character *)
```
