### PR TITLE
Fixed early exit changeset computation

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1957,6 +1957,7 @@ class UnitOfWork
                 empty($this->scheduledMoves)) {
             $this->invokeGlobalEvent(Event::onFlush, new ManagerEventArgs($this->dm));
             $this->invokeGlobalEvent(Event::postFlush, new ManagerEventArgs($this->dm));
+            $this->changesetComputed = array();
 
             // @deprecated This is to maintain BC with the old behavior, where users may call
             //             flush instead of PHPCR\SessionInterface#save


### PR DESCRIPTION
- For updates to be taken into account (e.g. after binding translations)
  the changeset needs to be reset when exiting the commit function when
  there is nothing to do.
- Otherwise after calling flush, the changeset is still computed and the
  next flush that is called envokes "computeChangeset" but as there are
  still changesets from the previous flush, it doesn't bother
  recalulating them.
- Before the "early exit" code flush would always reset the changeset.
