### PR TITLE
DocumentRepository->findBy calls a new protected method contraintField t...

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -185,7 +185,8 @@ class DocumentRepository implements ObjectRepository
      * @param mixed $value The value to search for
      * @param string The alias used
      */
-    protected function constraintField(ConstraintFactory $where, $field, $value, $alias) {
+    protected function constraintField(ConstraintFactory $where, $field, $value, $alias)
+    {
     	$where->eq()->field($alias.'.'.$field)->literal($value);
     }
 


### PR DESCRIPTION
...o build the query

This new method allows us to just override the constraintField method instead of having to rewrite the whole method. 

I also fixed an error in the doc.
