### PR TITLE
provide field mapping for superclasses

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -800,7 +800,7 @@ class ClassMetadata implements ClassMetadataInterface
     protected function validateAndCompleteFieldMapping(array $mapping, ClassMetadata $inherited = null, $isField = true, $phpcrLabel = 'property')
     {
         if ($inherited) {
-            if (!isset($mapping['inherited']) && !$inherited->isMappedSuperclass) {
+            if (!isset($mapping['inherited'])) {
                 $this->inheritedFields[$mapping['fieldName']] = $inherited->name;
             }
             if (!isset($mapping['declared'])) {

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
@@ -104,10 +104,8 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
         }
 
         foreach ($reflClass->getProperties() as $property) {
-            if ($metadata->isMappedSuperclass && !$property->isPrivate()
-                || ($metadata->isInheritedField($property->name)
-                    && $metadata->name !== $property->getDeclaringClass()->getName()
-                )
+            if ($metadata->isInheritedField($property->name)
+                && $metadata->name !== $property->getDeclaringClass()->getName()
             ) {
                 continue;
             }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -473,7 +473,47 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('mix:one', 'mix:two'), $class->mixins);
         $this->assertEquals("simple", $class->versionable);
         $this->assertTrue($class->referenceable);
+        $this->assertEquals(
+            'id',
+            $class->identifier,
+            'A driver should always be able to give mapping for a mapped superclass,' . PHP_EOL.
+            'and let classes mapped with other drivers inherit this mapping entirely.'
+        );
+
+        return $class;
     }
+
+    public function testLoadMappedSuperclassChildTypeMapping()
+    {
+        $parentClass = $this->loadMetadataForClassname(
+            'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceParentMappingObject'
+        );
+
+        $mappingDriver = $this->loadDriver();
+        $subClass = new ClassMetadata(
+            $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceChildMappingObject'
+        );
+        $subClass->initializeReflection(new RuntimeReflectionService());
+        $subClass->mapId($parentClass->mappings[$parentClass->identifier], $parentClass);
+
+        $mappingDriver->loadMetadataForClass($className, $subClass);
+
+        return $subClass;
+    }
+
+    /**
+     * @depends testLoadMappedSuperclassChildTypeMapping
+     * @param ClassMetadata $class
+     */
+    public function testMappedSuperclassChildTypeMapping($class)
+    {
+        $this->assertEquals(
+            'id',
+            $class->identifier,
+            'The id mapping should be inherited'
+        );
+    }
+
 
     public function testLoadNodeMapping()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ClassInheritanceChildMappingObject.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ClassInheritanceChildMappingObject.dcm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
+                  https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
+    <document
+        name="Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceChildMappingObject"
+    >
+    </document>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ClassInheritanceParentMappingObject.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ClassInheritanceParentMappingObject.dcm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
+                  https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
+    <mapped-superclass
+        name="Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceParentMappingObject"
+    >
+        <id name="id" />
+    </mapped-superclass>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ClassInheritanceChildMappingObject.dcm.yml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ClassInheritanceChildMappingObject.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceChildMappingObject:
+  fields:

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ClassInheritanceParentMappingObject.dcm.yml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ClassInheritanceParentMappingObject.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceParentMappingObject:
+  id: id


### PR DESCRIPTION
A driver must be able to provide a field mapping for a superclass to
another driver. Here the problem was that the annotation driver was
relying on the reflection to get the mapping for a parent class, making
the wrong assumption that the parent class was mapped with annotations,
and making the wrong assumption that children classes are also mapped
with annotations.

fixes #517
