### PR TITLE
handle filtering on nodename properties in DocumentRepository::findBy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+
+* **2014-08-07**: properly handle fields mapped to nodename in DocumentRepository::findBy()
+
 1.2.0-RC1
 ---------
 

--- a/lib/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -148,6 +148,13 @@ class DocumentRepository implements ObjectRepository
 
         if ($orderBy) {
             foreach ($orderBy as $field => $order) {
+                if ($field === $this->getClassMetadata()->nodename) {
+                    throw new InvalidArgumentException(sprintf(
+                        'It is not possible to order by a nodename property "%s"',
+                        $field
+                    ));
+                }
+
                 $order = strtolower($order);
                 if (!in_array($order, array('asc', 'desc'))) {
                     throw new InvalidArgumentException(sprintf(
@@ -187,7 +194,11 @@ class DocumentRepository implements ObjectRepository
      */
     protected function constraintField(ConstraintFactory $where, $field, $value, $alias)
     {
-    	$where->eq()->field($alias.'.'.$field)->literal($value);
+        if ($field === $this->getClassMetadata()->nodename) {
+            $where->eq()->name($alias)->literal($value);
+        } else {
+            $where->eq()->field($alias.'.'.$field)->literal($value);
+        }
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentRepositoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\Tests\Models\CMS\CmsUser;
 
 /**
@@ -116,6 +117,27 @@ class DocumentRepositoryTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTe
         // test descending order
         $users6 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' =>'active'), array('name' => 'desc'));
         $this->assertEquals('/functional/lsmith', $users6->key());
+    }
+
+    public function testFindByOnNodename()
+    {
+        $parent = new CmsUser();
+        $parent->username = "lsmith";
+        $parent->status = "active";
+        $parent->name = "Lukas";
+
+        $user = new CmsTeamUser();
+        $user->username = "beberlei";
+        $user->status = "active";
+        $user->name = "Benjamin";
+        $user->parent = $parent;
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $users = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsTeamUser')->findBy(array('nodename' =>'beberlei'));
+        $this->assertCount(1, $users);
+        $this->assertEquals($user->username, $users['/functional/lsmith/beberlei']->username);
     }
 
     public function testFindOneBy()


### PR DESCRIPTION
fix for https://github.com/doctrine/phpcr-odm/issues/458
