### PR TITLE
fixed issues in PreUpdateEventArgs due to different changeset structure

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/PHPCR/Event/PreUpdateEventArgs.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\PHPCR\Event;
+
+use Doctrine\Common\Persistence\Event\PreUpdateEventArgs as BasePreUpdateEventArgs;
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ODM\PHPCR\DocumentManager;
+
+class PreUpdateEventArgs extends BasePreUpdateEventArgs
+{
+    /**
+     * @var array
+     */
+    private $documentChangeSet;
+
+    /**
+     * Constructor.
+     *
+     * @param object          $document
+     * @param DocumentManager $objectManager
+     * @param array           $changeSet
+     */
+    public function __construct($document, DocumentManager $documentManager, array &$changeSet)
+    {
+        $fieldChangeSet = array();
+        if (isset($changeSet['fields'])) {
+            $fieldChangeSet = &$changeSet['fields'];
+        }
+
+        parent::__construct($document, $documentManager, $fieldChangeSet);
+
+        $this->documentChangeSet = &$changeSet;
+    }
+
+    /**
+     * Retrieves the document changeset.
+     *
+     * Currently this structure contains 2 keys:
+     *  'fields' - changes to field values
+     *  'reorderings' - changes in the order of collections
+     *
+     * @return array
+     */
+    public function getDocumentChangeSet()
+    {
+        return $this->documentChangeSet;
+    }
+}


### PR DESCRIPTION
fix https://github.com/doctrine/phpcr-odm-documentation/issues/60

this is a rather large refactoring, undoing the copy of the 'originalData' in the changeset structure that added in the development of 1.2.0 to handle recomputing changesets (see https://github.com/doctrine/phpcr-odm/pull/529). this data structure is no longer necessary since we changed the changeset structure to match that of the ORM in order to properly support `PreUpdateEventArgs` which already contains the data from the changed fields.

there is still an open question about the behavior of the ORM:
http://www.doctrine-project.org/jira/browse/DDC-3248

but it seems like the behavior will be kept .. so we can merge as is imho but I opened https://github.com/doctrine/common/pull/333 as a followup
