### PR TITLE
fix changeset calculation with translated documents

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChangesetCalculationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChangesetCalculationTest.php
@@ -134,6 +134,19 @@ class ChangesetCalculationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
         $this->dm->flush();
 
         $this->assertEquals(0, $this->listener->count);
+
+        $user1 = $this->dm->findTranslation(null, $user1->id, 'en');
+        $user1->status = 'active';
+        $this->dm->findTranslation(null, $user1->id, 'fr');
+
+        $this->dm->flush();
+
+        $this->assertEquals(1, $this->listener->count);
+        $this->dm->clear();
+
+        $user1 = $this->dm->findTranslation(null, $user1->id, 'en');
+        $this->assertEquals('active', $user1->status);
+
     }
 }
 


### PR DESCRIPTION
it seems that translated documents are always considered changed by the changeset calculation. i guess on phpcr level this is caught as no node actually changes, so this does not lead to massive write queries.

however, when listening to events, this can create severe problems. in my case, i have a list of 80 items to chose from in an admin. those are all loaded, thus all considered changed and instead of 1 event for my changed page, i get 81 events and have no indication that only 1 really did change.
