### PR TITLE
Only throw exceptions in one place

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/BuilderConverterPhpcr.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/BuilderConverterPhpcr.php
@@ -643,17 +643,17 @@ class BuilderConverterPhpcr
 
         if ($field === $classMeta->nodename) {
             throw new InvalidArgumentException(sprintf(
-                'Cannot use nodename property "%s->%s" in a field operand; use "localname()" instead.',
-                $classMeta->name,
-                $field
+                'Cannot use nodename property "%s" of class "%s" as a dynamic operand use "localname()" instead.',
+                $field,
+                $classMeta->name
             ));
         }
 
         if ($classMeta->hasAssociation($field)) {
             throw new InvalidArgumentException(sprintf(
-                'Cannot use association property "%s->%s" in a field operand.',
-                $classMeta->name,
-                $field
+                'Cannot use association property "%s" of class "%s" as a dynamic operand.',
+                $field,
+                $classMeta->name
             ));
         }
 
@@ -770,29 +770,6 @@ class BuilderConverterPhpcr
             $dynOp = $ordering->getChildOfType(
                 QBConstants::NT_OPERAND_DYNAMIC
             );
-
-            if ($dynOp instanceof OperandDynamicField) {
-                $alias = $dynOp->getAlias();
-                $field = $dynOp->getField();
-
-                $classMeta = $this->aliasMetadata[$alias];
-
-                if ($field === $classMeta->nodename) {
-                    throw new InvalidArgumentException(sprintf(
-                        'It is not possible to order by a nodename property "%s->%s"',
-                        $classMeta->name,
-                        $field
-                    ));
-                }
-
-                if ($classMeta->hasAssociation($field)) {
-                    throw new InvalidArgumentException(sprintf(
-                        'It is not possible to order by an association field "%s->%s"',
-                        $classMeta->name,
-                        $field
-                    ));
-                }
-            }
 
             $phpcrDynOp = $this->dispatch($dynOp);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/BuilderConverterPhpcrTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/BuilderConverterPhpcrTest.php
@@ -563,8 +563,8 @@ class BuilderConverterPhpcrTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('alias_1.ok_field', null),
-            array('alias_1.nodenameProperty', 'It is not possible to order by a nodename property "MyClassName->nodenameProperty"'),
-            array('alias_1.associationfield', 'It is not possible to order by an association field "MyClassName->associationfield"'),
+            array('alias_1.nodenameProperty', 'Cannot use nodename property "nodenameProperty" of class "MyClassName" as a dynamic operand use "localname()" instead.'),
+            array('alias_1.associationfield', 'Cannot use association property "associationfield" of class "MyClassName" as a dynamic operand.')
         );
     }
 


### PR DESCRIPTION
Drops the custom error message on `orderBy`. Note that by the logic of the recently merged code the same customization should also be applied to the walkers for the following nodes, not just orderBy:

```
OperandDynamicField
OperandDynamicFullTextSearchScore
OperandDynamicLength
OperandDynamicLocalName
OperandDynamicLowerCase
OperandDynamicLowerCase
OperandDynamicName
OperandDynamicUpperCase
OperandDynamicUpperCase
```

I could do this before tomorrow, but it wouldn't be wise for a stable release.
