### PR TITLE
no longer refresh translations on a load translation call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* **2014-10-06**: we no longer unload translations after flush(). furthermore when doing multiple
+                  find() calls on a translated document we no longer fresh the state, so any
+                  changes to the document state that have not been persisted will no longer be lost
+
 1.2.0-rc5
 ---------
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
@@ -184,8 +184,9 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $this->assertFalse($this->listener->postRemoveTranslation);
 
         $this->dm->flush();
+        $this->dm->clear();
 
-        $this->dm->findTranslation('Doctrine\Tests\Models\CMS\CmsPageTranslatable', $page->id, 'en');
+        $page = $this->dm->findTranslation('Doctrine\Tests\Models\CMS\CmsPageTranslatable', $page->id, 'en');
 
         $this->assertTrue($this->listener->postLoadTranslation);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
@@ -862,4 +862,24 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $a = $this->dm->find(null, '/functional/' . $this->testNodeName);
         $this->assertEquals($assoc, $a->assoc);
     }
+
+    public function testAdditionalFindCallsDoNotRefresh()
+    {
+        $a = new Article();
+        $a->id = '/functional/' . $this->testNodeName;
+        $a->topic = 'Hello';
+        $a->text = 'Some text';
+        $this->dm->persist($a);
+        $this->dm->flush();
+
+        $a->topic = 'Guten tag';
+
+        $trans = $this->dm->findTranslation(
+            null,
+            '/functional/' . $this->testNodeName,
+            'en'
+        );
+
+        $this->assertEquals('Guten tag', $trans->topic);
+    }
 }


### PR DESCRIPTION
attempt to fix https://github.com/doctrine/phpcr-odm/issues/557

but how to test this?
