### PR TITLE
replaced pre/postBindTranslation events with a postCreateTranslation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2014-10-07**: **BC break** dropped the pre/postBindTranslation events as they were previously
+                  not clearly defined when they would be triggered. they are replaced by
+                  preCreateTranslation which is triggered only before a new translation is added.
 * **2014-10-06**: we no longer unload translations after flush(). furthermore when doing multiple
                   find() calls on a translated document we no longer fresh the state, so any
                   changes to the document state that have not been persisted will no longer be lost

--- a/lib/Doctrine/ODM/PHPCR/Event.php
+++ b/lib/Doctrine/ODM/PHPCR/Event.php
@@ -39,8 +39,7 @@ final class Event
     const loadClassMetadata = 'loadClassMetadata';
 
     const postLoadTranslation = 'postLoadTranslation';
-    const preBindTranslation = 'preBindTranslation';
-    const postBindTranslation = 'postBindTranslation';
+    const preCreateTranslation = 'preCreateTranslation';
     const preRemoveTranslation = 'preRemoveTranslation';
     const postRemoveTranslation = 'postRemoveTranslation';
 
@@ -55,8 +54,7 @@ final class Event
         self::postMove => self::postMove,
         self::postLoad => self::postLoad,
         self::postLoadTranslation => self::postLoadTranslation,
-        self::preBindTranslation => self::preBindTranslation,
-        self::postBindTranslation => self::postBindTranslation,
+        self::preCreateTranslation => self::preCreateTranslation,
         self::preRemoveTranslation => self::preRemoveTranslation,
         self::postRemoveTranslation => self::postRemoveTranslation,
     );

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -730,12 +730,12 @@ class UnitOfWork
         $oid = spl_object_hash($document);
 
         // only trigger the events if we bind a new translation
-        $suppressEvents = isset($this->documentTranslations[$oid][$locale]);
-
-        if (!$suppressEvents && $invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::preBindTranslation)) {
+        if (empty($this->documentTranslations[$oid][$locale])
+            && $invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::preCreateTranslation)
+        ) {
             $this->eventListenersInvoker->invoke(
                 $class,
-                Event::preBindTranslation,
+                Event::preCreateTranslation,
                 $document,
                 new LifecycleEventArgs($document, $this->dm),
                 $invoke
@@ -746,16 +746,6 @@ class UnitOfWork
 
         foreach ($class->translatableFields as $field) {
             $this->documentTranslations[$oid][$locale][$field] = $class->reflFields[$field]->getValue($document);
-        }
-
-        if (!$suppressEvents && $invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::postBindTranslation)) {
-            $this->eventListenersInvoker->invoke(
-                $class,
-                Event::postBindTranslation,
-                $document,
-                new LifecycleEventArgs($document, $this->dm),
-                $invoke
-            );
         }
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventComputingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventComputingTest.php
@@ -115,8 +115,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
              ->getEventManager()
              ->addEventListener(
                 array(
-                    Event::preBindTranslation,
-                    Event::postBindTranslation,
+                    Event::preCreateTranslation,
                     Event::postLoadTranslation,
                     Event::preRemoveTranslation,
                     Event::postRemoveTranslation,
@@ -132,11 +131,6 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $user->status = 'active';
 
         $this->dm->persist($user);
-
-        // postBindTranslation event should change the name to bindTranslation
-        $this->dm->bindTranslation($user, 'en');
-        $this->assertEquals('postBindTranslation', $user->username);
-
         $this->dm->flush();
         $this->dm->clear();
 
@@ -146,7 +140,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->assertEquals('loadTranslation', $user->username);
 
         // name had been changed pre binding translation
-        $this->assertEquals('preBindTranslation', $user->name);
+        $this->assertEquals('preCreateTranslation', $user->name);
 
         $this->dm->name = 'neuer Name';
         $this->dm->bindTranslation($user, 'de');
@@ -215,16 +209,10 @@ class TestEventDocumentChanger
         $document->username .= '-postmove';
     }
 
-    public function preBindTranslation(LifecycleEventArgs $e)
+    public function preCreateTranslation(LifecycleEventArgs $e)
     {
         $document = $e->getObject();
-        $document->name = 'preBindTranslation';
-    }
-
-    public function postBindTranslation(LifecycleEventArgs $e)
-    {
-        $document = $e->getObject();
-        $document->username = 'postBindTranslation';
+        $document->name = 'preCreateTranslation';
     }
 
     public function postLoadTranslation(LifecycleEventArgs $e)

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
@@ -155,8 +155,7 @@ class EventManagerTest extends PHPCRFunctionalTestCase
             ->getEventManager()
             ->addEventListener(
                 array(
-                    Event::preBindTranslation,
-                    Event::postBindTranslation,
+                    Event::preCreateTranslation,
                     Event::postLoadTranslation,
                     Event::preRemoveTranslation,
                     Event::postRemoveTranslation,
@@ -170,16 +169,14 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $page->content = "long story";
 
         $this->dm->persist($page);
-        $this->assertFalse($this->listener->postBindTranslation);
-        $this->assertFalse($this->listener->preBindTranslation);
+        $this->assertFalse($this->listener->preCreateTranslation);
         $this->assertFalse($this->listener->postLoadTranslation);
         $this->assertFalse($this->listener->postRemoveTranslation);
         $this->assertFalse($this->listener->postRemoveTranslation);
 
         $this->dm->bindTranslation($page, 'en');
 
-        $this->assertTrue($this->listener->preBindTranslation);
-        $this->assertTrue($this->listener->postBindTranslation);
+        $this->assertTrue($this->listener->preCreateTranslation);
         $this->assertFalse($this->listener->postLoadTranslation);
         $this->assertFalse($this->listener->postRemoveTranslation);
 
@@ -227,8 +224,7 @@ class TestPersistenceListener
     public $pagePostMove = false;
 
     public $postLoadTranslation = false;
-    public $preBindTranslation = false;
-    public $postBindTranslation = false;
+    public $preCreateTranslation = false;
     public $preRemoveTranslation = false;
     public $postRemoveTranslation = false;
 
@@ -341,14 +337,9 @@ class TestPersistenceListener
         $this->preFlush = true;
     }
 
-    public function preBindTranslation(LifecycleEventArgs $e)
+    public function preCreateTranslation(LifecycleEventArgs $e)
     {
-        $this->preBindTranslation = true;
-    }
-
-    public function postBindTranslation(LifecycleEventArgs $e)
-    {
-        $this->postBindTranslation = true;
+        $this->preCreateTranslation = true;
     }
 
     public function postLoadTranslation(LifecycleEventArgs $e)


### PR DESCRIPTION
supersedes https://github.com/doctrine/phpcr-odm/pull/571
fixes https://github.com/doctrine/phpcr-odm/issues/569
