### PR TITLE
getting the referenced nodes from a property no longer can index the target by uuid

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/ReferenceManyCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ReferenceManyCollection.php
@@ -80,8 +80,8 @@ class ReferenceManyCollection extends PersistentCollection
     public function refresh()
     {
         try {
-            $this->referencedNodes = $this->dm->getNodeForDocument($this->document)->getPropertiesValues($this->property);
-            $this->referencedNodes = array_keys($this->referencedNodes[$this->property]);
+            $property = $this->dm->getNodeForDocument($this->document)->getProperty($this->property);
+            $this->referencedNodes = $property->getString();
         } catch (InvalidArgumentException $e) {
             $this->referencedNodes = array();
         }

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2613,7 +2613,7 @@ class UnitOfWork
                                     }
 
                                     if ($referencingNode->hasProperty($referencingField['property'])) {
-                                        if (!array_key_exists($uuid, $referencingNode->getPropertyValue($referencingField['property']))) {
+                                        if (!in_array($uuid, $referencingNode->getProperty($referencingField['property'])->getString())) {
                                             if (!$collection instanceof PersistentCollection || !$collection->isDirty()) {
                                                 // update the reference collection: add us to it
                                                 $collection->add($document);


### PR DESCRIPTION
Plus this thing is even more performant as nodes are not requested when not needed.
