### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         "doctrine/instantiator": "~1.0.1"
     },
     "require-dev": {
-        "symfony/yaml": "~2.0",
+        "symfony/yaml": "~2.3|~3.0",
         "liip/rmt": "~1.1"
     },
     "suggest":{
-        "symfony/yaml": "~2.0",
+        "symfony/yaml": "~2.3|~3.0",
         "jackalope/jackalope-doctrine-dbal": "~1.0",
         "jackalope/jackalope-jackrabbit": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "psr-0": { "Doctrine\\ODM\\PHPCR": "lib/" }
     },
     "bin": ["bin/phpcrodm", "bin/phpcrodm.php"],
+    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "1.3-dev"


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0