### PR TITLE
Read translated custom property name

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
@@ -62,7 +62,7 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
             $node->setProperty($propName, $propValue);
 
             if (null === $propValue) {
-                $nullFields[] = $field;
+                $nullFields[] = $mapping['property'];
             }
         }
         if (empty($nullFields)) {
@@ -88,7 +88,8 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
         }
 
         foreach ($metadata->translatableFields as $field) {
-            $propName = $this->getTranslatedPropertyName($locale, $field);
+            $mapping = $metadata->mappings[$field];
+            $propName = $this->getTranslatedPropertyName($locale, $mapping['property']);
             if ($node->hasProperty($propName)) {
                 return true;
             }
@@ -110,10 +111,10 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
 
         // we have a translation, now update the document fields
         foreach ($metadata->translatableFields as $field) {
-            $propName = $this->getTranslatedPropertyName($locale, $field);
+            $mapping = $metadata->mappings[$field];
+            $propName = $this->getTranslatedPropertyName($locale, $mapping['property']);
             if ($node->hasProperty($propName)) {
                 $value = $node->getPropertyValue($propName);
-                $mapping = $metadata->mappings[$field];
                 if (true === $mapping['multivalue']) {
                     if (isset($mapping['assoc'])) {
                         $transMapping = $this->getTranslatedPropertyNameAssoc($locale, $mapping);
@@ -139,7 +140,8 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
     public function removeTranslation($document, NodeInterface $node, ClassMetadata $metadata, $locale)
     {
         foreach ($metadata->translatableFields as $field) {
-            $propName = $this->getTranslatedPropertyName($locale, $field);
+            $mapping = $metadata->mappings[$field];
+            $propName = $this->getTranslatedPropertyName($locale, $mapping['property']);
 
             if ($node->hasProperty($propName)) {
                 $prop = $node->getProperty($propName);

--- a/tests/Doctrine/Tests/Models/Translation/Article.php
+++ b/tests/Doctrine/Tests/Models/Translation/Article.php
@@ -65,6 +65,11 @@ class Article
      */
     protected $settings;
 
+    /**
+     * @PHPCRODM\String(assoc="", property="custom-settings", translated=true, nullable=true)
+     */
+    public $customNameSettings;
+
     public function __construct()
     {
         $this->children = new ArrayCollection();


### PR DESCRIPTION
Follow up to: https://github.com/doctrine/phpcr-odm/pull/602

I wonder what else I missed, maybe "assoc" fields. Will add some better tests in this PR.