### PR TITLE
Added preBind translation

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Event.php
+++ b/lib/Doctrine/ODM/PHPCR/Event.php
@@ -40,6 +40,7 @@ final class Event
 
     const postLoadTranslation = 'postLoadTranslation';
     const preCreateTranslation = 'preCreateTranslation';
+    const preUpdateTranslation = 'preUpdateTranslation';
     const preRemoveTranslation = 'preRemoveTranslation';
     const postRemoveTranslation = 'postRemoveTranslation';
 
@@ -55,6 +56,7 @@ final class Event
         self::postLoad => self::postLoad,
         self::postLoadTranslation => self::postLoadTranslation,
         self::preCreateTranslation => self::preCreateTranslation,
+        self::preUpdateTranslation => self::preUpdateTranslation,
         self::preRemoveTranslation => self::preRemoveTranslation,
         self::postRemoveTranslation => self::postRemoveTranslation,
     );

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -753,6 +753,14 @@ class UnitOfWork
                 new LifecycleEventArgs($document, $this->dm),
                 $invoke
             );
+        } elseif ($invoke = $this->eventListenersInvoker->getSubscribedSystems($class, Event::preUpdateTranslation)) {
+            $this->eventListenersInvoker->invoke(
+                $class,
+                Event::preUpdateTranslation,
+                $document,
+                new LifecycleEventArgs($document, $this->dm),
+                $invoke
+            );
         }
 
         $this->setLocale($document, $class, $locale);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventComputingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventComputingTest.php
@@ -116,6 +116,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
              ->addEventListener(
                 array(
                     Event::preCreateTranslation,
+                    Event::preUpdateTranslation,
                     Event::postLoadTranslation,
                     Event::preRemoveTranslation,
                     Event::postRemoveTranslation,
@@ -142,8 +143,13 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         // name had been changed pre binding translation
         $this->assertEquals('preCreateTranslation', $user->name);
 
+        $this->dm->bindTranslation($user, 'en');
+        // name has been changed when translation was updated
+        $this->assertEquals('preUpdateTranslation', $user->name);
+
         $this->dm->name = 'neuer Name';
         $this->dm->bindTranslation($user, 'de');
+
         $this->dm->flush();
         $this->dm->clear();
 
@@ -213,6 +219,12 @@ class TestEventDocumentChanger
     {
         $document = $e->getObject();
         $document->name = 'preCreateTranslation';
+    }
+
+    public function preUpdateTranslation(LifecycleEventArgs $e)
+    {
+        $document = $e->getObject();
+        $document->name = 'preUpdateTranslation';
     }
 
     public function postLoadTranslation(LifecycleEventArgs $e)


### PR DESCRIPTION
Added yet another event.

Use case: We have a content serializer which serializes dynamic content data to multiple nodes, when the translation is bound we need to store the current content, and later resetore it in loadTranslation.

This event overlaps with the `preCreateTranslation` event, which is only called when the translation is created, this information could be passed in the `loadTranslation` event.