### PR TITLE
Allow sub localizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 1.3.0
 -----
 
+* **2015-07-13**: Adjusted the regular expression for locales, to allow for sublocales
+                  but preventing arbitrary non alphanumeric characters.
+
 * **2015-06-19**: Deprecated Binary, Boolean, Date, Decimal, Double, Float, Int, Long, Name,
                   Path, String and Uri annotations in favor of `@Field(type="...")`.
 

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AbstractTranslationStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AbstractTranslationStrategy.php
@@ -36,7 +36,8 @@ abstract class AbstractTranslationStrategy implements TranslationStrategyInterfa
     protected $dm;
 
     /**
-     * Prefix to namespace properties or child nodes
+     * Prefix to namespace properties or child nodes.
+     *
      * @var string
      */
     protected $prefix = Translation::LOCALE_NAMESPACE;
@@ -47,9 +48,9 @@ abstract class AbstractTranslationStrategy implements TranslationStrategyInterfa
     }
 
     /**
-     * Set the prefix to use to determine the name of the property where translations are stored
+     * Set the namespace alias for translation extra properties
      *
-     * @param $prefix
+     * @param string $prefix
      */
     public function setPrefix($prefix)
     {

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
@@ -175,7 +175,7 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
         $locales = array();
         foreach ($node->getProperties($this->prefix . ':*') as $prop) {
             $matches = null;
-            if (preg_match('/' . $this->prefix . ':([a-zA-Z1-9_]+)-[^-]*/', $prop->getName(), $matches)) {
+            if (preg_match('/' . $this->prefix . ':([a-zA-Z1-9_]+)-/', $prop->getName(), $matches)) {
                 if (is_array($matches) && count($matches) > 1 && !in_array($matches[1], $locales)) {
                     $locales[] = $matches[1];
                 }

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
@@ -175,7 +175,7 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
         $locales = array();
         foreach ($node->getProperties("*{$this->prefix}*") as $prop) {
             $matches = null;
-            if (preg_match('/' . $this->prefix . ':(..)-[^-]*/', $prop->getName(), $matches)) {
+            if (preg_match('/' . $this->prefix . ':([a-z]{2}_?[a-z]{0,2})-[^-]*/', $prop->getName(), $matches)) {
                 if (is_array($matches) && count($matches) > 1 && !in_array($matches[1], $locales)) {
                     $locales[] = $matches[1];
                 }

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
@@ -173,9 +173,9 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
     public function getLocalesFor($document, NodeInterface $node, ClassMetadata $metadata)
     {
         $locales = array();
-        foreach ($node->getProperties("*{$this->prefix}*") as $prop) {
+        foreach ($node->getProperties($this->prefix . ':*') as $prop) {
             $matches = null;
-            if (preg_match('/' . $this->prefix . ':([a-z]{2}_?[a-z]{0,2})-[^-]*/', $prop->getName(), $matches)) {
+            if (preg_match('/' . $this->prefix . ':([a-zA-Z1-9_]+)-[^-]*/', $prop->getName(), $matches)) {
                 if (is_array($matches) && count($matches) > 1 && !in_array($matches[1], $locales)) {
                     $locales[] = $matches[1];
                 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
@@ -8,20 +8,33 @@ use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 
 class AttributeTranslationStrategyTest extends PHPCRTestCase
 {
-    public function testSetPrefixAndGetPropertyName()
+    private $dm;
+    private $method;
+    private $strategy;
+
+    public function setUp()
     {
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
+        $this->dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $s = new AttributeTranslationStrategy($dm);
-        $s->setPrefix('test');
+        $this->strategy = new AttributeTranslationStrategy($this->dm);
+        $this->strategy->setPrefix('test');
 
         $class = new \ReflectionClass('Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy');
-        $method = $class->getMethod('getTranslatedPropertyName');
-        $method->setAccessible(true);
+        $this->method = $class->getMethod('getTranslatedPropertyName');
+        $this->method->setAccessible(true);
+    }
 
-        $name = $method->invokeArgs($s, array('fr', 'field'));
+    public function testSetPrefixAndGetPropertyName()
+    {
+        $name = $this->method->invokeArgs($this->strategy, array('fr', 'field'));
         $this->assertEquals('test:fr-field', $name);
+    }
+
+    public function testSubRegion()
+    {
+        $name = $this->method->invokeArgs($this->strategy, array('en_GB', 'field'));
+        $this->assertEquals('test:en_GB-field', $name);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
@@ -40,6 +40,10 @@ class AttributeTranslationStrategyTest extends PHPCRTestCase
 
     public function testGetLocalesFor()
     {
+        if (version_compare(PHP_VERSION, '5.3.3', '<=')) {
+            $this->markTestSkipped('Prophesize does not work on PHP 5.3.3');
+        }
+
         $classMetadata = $this->prophesize('Doctrine\ODM\PHPCR\Mapping\ClassMetadata');
         $document = new \stdClass;
         $localizedPropNames = array(
@@ -47,7 +51,7 @@ class AttributeTranslationStrategyTest extends PHPCRTestCase
             'test:de_at-prop2' => 'de_at',
             'test:en_Hans_CN_nedis_rozaj_x_prv1_prv2-prop3' => 'en_Hans_CN_nedis_rozaj_x_prv1_prv2',
             'i18n:de-asdf' => false, // prefix is incorrect
-            'de_asdf' => false, // no prefix
+            'asdf' => false, // no prefix
             'de_asdf' => false, // no property name
         );
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/LocaleChooserTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/LocaleChooserTest.php
@@ -94,4 +94,19 @@ class LocaleChooserTest extends PHPCRTestCase
         $locale = $this->localeChooser->getLocale();
         $this->assertEquals('en', $locale);
     }
+
+    public function testSubRegion()
+    {
+        $orderEnGB = array('en', 'de');
+        $this->localeChooser = new LocaleChooser(array('en_GB' => $orderEnGB, 'en' => $this->orderEn, 'de' => $this->orderDe), 'en');
+
+        $order = $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'en_GB');
+        $this->assertEquals($orderEnGB, $order);
+
+        $this->localeChooser->setLocale('en_GB');
+        $locale = $this->localeChooser->getLocale();
+        $this->assertEquals('en_GB', $locale);
+        $order = $this->localeChooser->getDefaultLocalesOrder();
+        $this->assertEquals($orderEnGB, $order);
+    }
 }


### PR DESCRIPTION
It seems that locales such as `de_at` are not included when `->getLocalesFor` is called.