### PR TITLE
should depend on `doctrine/common ~2.4` instead fixed #624

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "doctrine/common": "~2.4.0",
+        "doctrine/common": "~2.4",
         "phpcr/phpcr": "~2.1.1",
         "phpcr/phpcr-implementation": "~2.1.0",
         "phpcr/phpcr-utils": ">=1.1.0,<1.3.x-dev"


### PR DESCRIPTION
fixed #624 