### PR TITLE
Verify that uuid is only mapped on referenceable documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 1.3.0
 -----
 
+* **2015-04-07**: Class metadata now validates that you can not map the UUID on
+                  Documents that are not referenceable. Either set your
+                  documents `referenceable=true` or remove the UUID mapping.
 * **2015-03-19**: **BC break** changed the type hint of the second parameter of
                   TranslationStrategyInterface::alterQueryForTranslation from
                   SelectorInterface to SourceInterface to fix queries with joins

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -441,6 +441,21 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
+     * Validate whether this class needs to be referenceable.
+     *
+     * The document needs to be either referenceable or full versionable.
+     * Simple versioning does not imply referenceable.
+     *
+     * @throws MappingException if there is an invalid reference mapping
+     */
+    public function validateReferenceable()
+    {
+        if ($this->uuidFieldName && !$this->referenceable && 'full' !== $this->versionable) {
+            throw MappingException::notReferenceable($this->name, $this->uuidFieldName);
+        }
+    }
+
+    /**
      * Validate association targets actually exist.
      *
      * @throws MappingException if there is an invalid reference mapping

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -243,6 +243,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         }
 
         $class->validateIdentifier();
+        $class->validateReferenceable();
         $class->validateReferences();
         $class->validateLifecycleCallbacks($this->getReflectionService());
         $class->validateTranslatables();

--- a/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
@@ -172,4 +172,9 @@ class MappingException extends BaseMappingException implements PHPCRExceptionInt
     {
         return new self("Document '" .$className."' does not have a translation strategy, but the fields ('".implode('\', \'', $fieldNames)."') have been set as translatable.");
     }
+
+    public static function notReferenceable($className, $fieldName)
+    {
+        return new self(sprintf('Document "%s" is not referenceable. You can not map field "%s" to the UUID.', $className, $fieldName));
+    }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -755,4 +755,14 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
 
         return $this->loadMetadataForClassname($className);
     }
+
+    /**
+     * A document that is not referenceable must not have a uuid mapped.
+     */
+    public function testUuidMappingNonReferenceable()
+    {
+        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\UuidMappingObject';
+
+        return $this->loadMetadataForClassname($className);
+    }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -29,6 +29,7 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
 
         $cmf = new ClassMetadataFactory($this->dm);
         $meta = $cmf->getMetadataFor($fqn);
+
         return $meta;
     }
 
@@ -116,6 +117,15 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('mix:baz'), $meta->mixins);
         $this->assertEquals('full', $meta->versionable);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\BarfooRepository', $meta->customRepositoryClassName);
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
+     * @expectedExceptionMessage is not referenceable
+     */
+    public function testValidateUuidNotReferenceable()
+    {
+        $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\UuidMappingObjectNotReferenceable');
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/UuidMappingObjectNotReferenceable.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/UuidMappingObjectNotReferenceable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * An invalid document that has the uuid mapped but is not referenceable.
+ *
+ * @PHPCRODM\Document(referenceable=false)
+ */
+class UuidMappingObjectNotReferenceable
+{
+    /** @PHPCRODM\Id */
+    public $id;
+
+    /** @PHPCRODM\Uuid() */
+    public $uuid;
+}


### PR DESCRIPTION
jackalope started to verify that the uuid is not set on a non-referenceable node, [leading to confusion](https://github.com/jackalope/jackalope/issues/281) when people map the uuid but do not make the document referenceable.