### PR TITLE
fixing DocumentManagerInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
   allow_failures:
     - php: 7.0
   include:
-    - php: 5.3.3
+    - php: 5.3
       env: TRANSPORT=doctrine_dbal COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.3.3
+    - php: 5.3
       env: TRANSPORT=jackrabbit COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: TRANSPORT=doctrine_dbal SYMFONY="3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* **2015-08-27** **BC break** Missing parameter in `DocumentManagerInterface::getDocumentsByPhpcrQuery`
+                 added. If you have your own implementation that is not based
+                 on DocumentManagerDecorator, you will need to adjust that method.
+
 1.3.0-rc2
 ---------
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
         "doctrine/common": "~2.4",
         "doctrine/annotations": "~1.2",
         "doctrine/data-fixtures": "~1.0,>=1.0.0",

--- a/lib/Doctrine/ODM/PHPCR/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/PHPCR/Decorator/DocumentManagerDecorator.php
@@ -225,9 +225,9 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritDoc}
      */
-    public function getDocumentsByPhpcrQuery(QueryInterface $query, $className = null)
+    public function getDocumentsByPhpcrQuery(QueryInterface $query, $className = null, $primarySelector = null)
     {
-        return $this->wrapped->getDocumentsByPhpcrQuery($query, $className);
+        return $this->wrapped->getDocumentsByPhpcrQuery($query, $className, $primarySelector);
     }
 
     /**
@@ -235,7 +235,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
      */
     public function persist($document)
     {
-        return $this->wrapped->persist($document);
+        $this->wrapped->persist($document);
     }
 
     /**
@@ -423,6 +423,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
+     * {@inheritDoc}
      */
     public function clear($className = null)
     {

--- a/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
@@ -233,12 +233,13 @@ interface DocumentManagerInterface extends ObjectManager
     /**
      * Get document results from a PHPCR query instance
      *
-     * @param QueryInterface $query     The query instance as acquired through createPhpcrQuery().
-     * @param string         $className Document class.
+     * @param QueryInterface $query           The query instance as acquired through createPhpcrQuery().
+     * @param string|null    $className       Document class.
+     * @param string|null    $primarySelector Name of the selector for the document to return in case of a join query.
      *
      * @return array of document instances
      */
-    public function getDocumentsByPhpcrQuery(QueryInterface $query, $className = null);
+    public function getDocumentsByPhpcrQuery(QueryInterface $query, $className = null, $primarySelector = null);
 
     /**
      * Bind the translatable fields of the document in the specified locale.
@@ -487,6 +488,24 @@ interface DocumentManagerInterface extends ObjectManager
      * @return UnitOfWork
      */
     public function getUnitOfWork();
+
+    /**
+     * Flushes all changes to objects that have been queued up to now to the database.
+     * This effectively synchronizes the in-memory state of managed objects with the
+     * database.
+     *
+     * This is different from the ObjectManager in that it accepts an optional
+     * argument to limit the flush to one or more specific documents.
+     *
+     * @param object|array|null $document optionally limit to a specific
+     *      document or an array of documents
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException if $document is neither null nor a
+     *      document or an array of documents
+     */
+    public function flush($document = null);
 
     /**
      * Closes the DocumentManager. All entities that are currently managed


### PR DESCRIPTION
fix bugs revealed in #655 

we seem to miss a mess detector check to tell when the interface and an implementation do not match.