### PR TITLE
failing test for calling same with empty string

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
@@ -399,7 +399,21 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException 
+     * @depends testFrom
+     */
+    public function testSameEmpty()
+    {
+        $qb = $this->createQb();
+        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->where()->same('', 'a');
+        $q = $qb->getQuery();
+        $res = $q->execute();
+
+        $this->assertCount(0, $res);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Alias name "a" is not known
      */
     public function testConditionWithNonExistingAlias()


### PR DESCRIPTION
this simple tests fails when using jackrabbit - not sure what the expected behaviour is, let's have a look at the spec?
