### PR TITLE
Fix QueryBuilder cloning issue (deep clone converter dependency)

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/QueryBuilder.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/QueryBuilder.php
@@ -440,10 +440,12 @@ class QueryBuilder extends AbstractNode
     }
 
     /**
-     * Deep clone on converter, so it resets it's constraints.
+     * Ensure cloned query builder objects have unique instances of the converter.
      */
     public function __clone()
     {
-        $this->converter = clone $this->converter;
+        if (null !== $this->converter) {
+            $this->converter = clone $this->converter;
+        }
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/QueryBuilder.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/QueryBuilder.php
@@ -438,4 +438,12 @@ class QueryBuilder extends AbstractNode
     {
         return $this->primaryAlias;
     }
+
+    /**
+     * Deep clone on converter, so it resets it's constraints.
+     */
+    public function __clone()
+    {
+        $this->converter = clone $this->converter;
+    }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
@@ -111,9 +111,10 @@ class QueryBuilderTest extends NodeTestCase
 
         $clone = clone $this->node;
 
-        $hash = spl_object_hash($property->getValue($this->node));
-        $hashClone = spl_object_hash($property->getValue($clone));
-
-        $this->assertNotEquals($hash, $hashClone, 'Cloned instance of QueryBuilder does not have an unique Converter instance.');
+        $this->assertNotSame(
+            $property->getValue($this->node),
+            $property->getValue($clone),
+            'Cloned instance of QueryBuilder does not have an unique Converter instance.'
+        );
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
@@ -100,4 +100,20 @@ class QueryBuilderTest extends NodeTestCase
         $this->node->fromDocument('Foobar', 'f');
         $this->assertEquals('f', $this->node->getPrimaryAlias());
     }
+
+    public function testCloningQueryBuilderUniqueConverterInstance()
+    {
+        $reflection = new \ReflectionClass(get_class($this->node));
+        $property = $reflection->getProperty('converter');
+        $property->setAccessible(true);
+
+        $this->node->setConverter($this->getMock('Doctrine\ODM\PHPCR\Query\Builder\ConverterInterface'));
+
+        $clone = clone $this->node;
+
+        $hash = spl_object_hash($property->getValue($this->node));
+        $hashClone = spl_object_hash($property->getValue($clone));
+
+        $this->assertNotEquals($hash, $hashClone, 'Cloned instance of QueryBuilder does not have an unique Converter instance.');
+    }
 }


### PR DESCRIPTION
Deep clone converter dependency on QueryBuilder, so constraints are reset when cloning a QueryBuilder instance.

Fixed issue https://github.com/Sylius/Sylius/issues/3752