### PR TITLE
Fix for #687 - loading nodes in referencemanycollection with path strategy

### DIFF
--- a/doctrine-phpcr-odm-mapping.xsd
+++ b/doctrine-phpcr-odm-mapping.xsd
@@ -304,6 +304,7 @@
         <xs:restriction base="xs:token">
             <xs:enumeration value="WEAK"/>
             <xs:enumeration value="HARD"/>
+            <xs:enumeration value="PATH"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/tests/Doctrine/Tests/Models/References/RefManyTestObjPathStrategy.php
+++ b/tests/Doctrine/Tests/Models/References/RefManyTestObjPathStrategy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Doctrine\Tests\Models\References;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * @PHPCRODM\Document()
+ */
+class RefManyTestObjPathStrategy
+{
+    /** @PHPCRODM\Id */
+    public $id;
+    /** @PHPCRODM\ReferenceMany(targetDocument="RefRefTestObj", cascade="persist", property="myReferences", strategy="path") */
+    public $references;
+
+    public function __construct()
+    {
+        $this->references = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+}


### PR DESCRIPTION
Based on suggestion in #687 I added parameter referenceType to ReferenceManyCollection 
so that nodes can be loaded either from a list of uuids or from a list of paths.

The test is in ReferenceTest::testReferenceManyPath, I had to call $referrer->references->refresh(); to invoke the failing behavior.