### PR TITLE
Support child restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+dev-master
+----------
+
+* **2016-06-08**  [Feature] Allow children of a document to be restricted to a
+                  certain class or forbidden.
+
 1.3.1
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "bin": ["bin/phpcrodm", "bin/phpcrodm.php"],
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3-dev"
+            "dev-master": "1.4-dev"
         }
     }
 }

--- a/doctrine-phpcr-odm-mapping.xsd
+++ b/doctrine-phpcr-odm-mapping.xsd
@@ -44,6 +44,10 @@
         <xs:anyAttribute namespace="##other"/>
     </xs:complexType>
 
+    <xs:complexType name="child-class">
+        <xs:attribute name="name" type="xs:string"/>
+    </xs:complexType>
+
     <xs:complexType name="mixin">
         <xs:attribute name="type" type="xs:NMTOKEN"/>
     </xs:complexType>
@@ -138,6 +142,7 @@
             <xs:element name="document-listeners" type="phpcr:document-listeners" minOccurs="0" maxOccurs="1" />
             -->
             <xs:element name="id" type="phpcr:id" minOccurs="0" maxOccurs="1" />
+            <xs:element name="child-class" type="phpcr:child-class" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="uuid" type="phpcr:uuid" minOccurs="0" maxOccurs="1" />
             <xs:element name="locale" type="phpcr:locale" minOccurs="0" maxOccurs="1" />
             <xs:element name="field" type="phpcr:field" minOccurs="0" maxOccurs="unbounded"/>
@@ -159,6 +164,7 @@
         <xs:attribute name="translator" type="xs:NMTOKEN"/>
         <xs:attribute name="versionable" type="phpcr:versionable-type" />
         <xs:attribute name="referenceable" type="xs:boolean" default="false" />
+        <xs:attribute name="is-leaf" type="xs:boolean" default="false" />
         <xs:attribute name="node-type" type="xs:NMTOKEN" />
         <xs:attribute name="repository-class" type="xs:string"/>
         <xs:anyAttribute namespace="##other"/>

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Document.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Document.php
@@ -66,4 +66,14 @@ class Document
      * @var boolean
      */
     public $uniqueNodeType;
+
+    /**
+     * @var array
+     */
+    public $childClasses = array();
+
+    /**
+     * @var boolean
+     */
+    public $isLeaf;
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -256,6 +256,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         $class->validateIdentifier();
         $class->validateReferenceable();
         $class->validateReferences();
+        $class->validateChildClasses();
         $class->validateLifecycleCallbacks($this->getReflectionService());
         $class->validateTranslatables();
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
@@ -111,6 +111,12 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
             $metadata->setTranslator($documentAnnot->translator);
         }
 
+        if (array() !== $documentAnnot->childClasses) {
+            $metadata->setChildClasses($documentAnnot->childClasses);
+        }
+
+        $metadata->setIsLeaf($documentAnnot->isLeaf);
+
         foreach ($reflClass->getProperties() as $property) {
             if ($metadata->isInheritedField($property->name)
                 && $metadata->name !== $property->getDeclaringClass()->getName()

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
@@ -83,6 +83,18 @@ class XmlDriver extends FileDriver
             $class->setUniqueNodeType((bool) $xmlRoot['uniqueNodeType']);
         }
 
+        if (isset($xmlRoot['is-leaf'])) {
+            if (!in_array($value = $xmlRoot['is-leaf'], array('true', 'false'))) {
+                throw new MappingException(sprintf(
+                    'Value of is-leaf must be "true" or "false", got "%s" for class "%s"',
+                    $value, $className
+                ));
+            }
+
+            $class->setIsLeaf($value == 'true' ? true : false);
+        }
+
+
         if (isset($xmlRoot->mixins)) {
             $mixins = array();
             foreach ($xmlRoot->mixins->mixin as $mixin) {
@@ -257,6 +269,14 @@ class XmlDriver extends FileDriver
             $mapping['uuid'] = true;
             $mapping['fieldName'] = $mapping['name'];
             $class->mapField($mapping);
+        }
+
+        if (isset($xmlRoot->{'child-class'})) {
+            $childClasses = array();
+            foreach ($xmlRoot->{'child-class'} as $requiredClass) {
+                $childClasses[] = $requiredClass['name'];
+            }
+            $class->setChildClasses($childClasses);
         }
 
         $class->validateClassMapping();

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
@@ -255,6 +255,14 @@ class YamlDriver extends FileDriver
             }
         }
 
+        if (isset($element['child_classes'])) {
+            $class->setChildClasses($element['child_classes']);
+        }
+
+        if (isset($element['is_leaf'])) {
+            $class->setIsLeaf($element['is_leaf']);
+        }
+
         $class->validateClassMapping();
     }
 

--- a/tests/Doctrine/Tests/Models/CMS/CmsArticleFolder.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsArticleFolder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\Models\CMS;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * @PHPCRODM\Document(childClasses={"Doctrine\Tests\Models\CMS\CmsArticle"})
+ */
+class CmsArticleFolder
+{
+    /**
+     * @PHPCRODM\Id
+     */
+    public $id;
+
+    /**
+     * @PHPCRODM\Children()
+     */
+    public $articles;
+}

--- a/tests/Doctrine/Tests/Models/CMS/CmsBlogFolder.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsBlogFolder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Doctrine\Tests\Models\CMS;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * @PHPCRODM\Document(
+ *     childClasses={
+ *         "Doctrine\Tests\Models\CMS\CmsBlogPost"
+ *     }
+ * )
+ */
+class CmsBlogFolder
+{
+    /**
+     * @PHPCRODM\Id()
+     */
+    public $id;
+
+    /**
+     * @PHPCRODM\Children()
+     */
+    public $posts;
+}

--- a/tests/Doctrine/Tests/Models/CMS/CmsBlogInvalidChild.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsBlogInvalidChild.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Documents;
+
+namespace Doctrine\Tests\Models\CMS;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+
+/**
+ * @PHPCRODM\Document()
+ */
+class CmsBlogInvalidChild
+{
+    /** @PHPCRODM\Id(strategy="parent") */
+    public $id;
+
+    /** @PHPCRODM\NodeName() */
+    public $name;
+
+    /** @PHPCRODM\ParentDocument() */
+    public $parent;
+}

--- a/tests/Doctrine/Tests/Models/CMS/CmsBlogPost.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsBlogPost.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Documents;
+
+namespace Doctrine\Tests\Models\CMS;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+
+/**
+ * @PHPCRODM\Document(isLeaf=true)
+ */
+class CmsBlogPost
+{
+    /** @PHPCRODM\Id(strategy="parent") */
+    public $id;
+
+    /** @PHPCRODM\NodeName() */
+    public $name;
+
+    /** @PHPCRODM\ParentDocument() */
+    public $parent;
+}

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -798,4 +798,36 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
 
         return $this->loadMetadataForClassname($className);
     }
+
+    public function testLoadChildClassesMapping()
+    {
+        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesObject';
+
+        return $this->loadMetadataForClassname($className);
+    }
+
+    /**
+     * @depends testLoadChildClassesMapping
+     * @param ClassMetadata $class
+     */
+    public function testChildClassesMapping($class)
+    {
+        $this->assertEquals(array('stdClass'), $class->getChildClasses());
+    }
+
+    public function testLoadIsLeafMapping()
+    {
+        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\IsLeafObject';
+
+        return $this->loadMetadataForClassname($className);
+    }
+
+    /**
+     * @depends testLoadIsLeafMapping
+     * @param ClassMetadata $class
+     */
+    public function testIsLeafMapping($class)
+    {
+        $this->assertTrue($class->isLeaf());
+    }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -144,6 +144,15 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObjectNoStrategy');
     }
 
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
+     * @expectedExceptionMessage Cannot map a document as a leaf and define child classes for "Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesAndLeafObject"
+     */
+    public function testValidateChildClassesIfLeafConflict()
+    {
+        $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesAndLeafObject');
+    }
+
     public function testValidateTranslatable()
     {
         $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObject');

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildClassesAndLeafObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildClassesAndLeafObject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * A class that contains mapped children via properties
+ *
+ * @PHPCRODM\Document(childClasses={
+ *     "stdClass",
+ * }, isLeaf=true)
+ */
+class ChildClassesAndLeafObject
+{
+    /** @PHPCRODM\Id */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildClassesObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildClassesObject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * A class that contains mapped children via properties
+ *
+ * @PHPCRODM\Document(childClasses={
+ *     "stdClass",
+ * }, isLeaf=false)
+ */
+class ChildClassesObject
+{
+    /** @PHPCRODM\Id */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/IsLeafObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/IsLeafObject.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * A class that contains mapped children via properties
+ *
+ * @PHPCRODM\Document(isLeaf=true)
+ */
+class IsLeafObject
+{
+    /** @PHPCRODM\Id */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ChildClassesObject.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ChildClassesObject.dcm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
+    https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
+    <document name="Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesObject" isLeaf="false">
+        <child-class name="stdClass" />
+        <id name="id" />
+    </document>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.IsLeafObject.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/xml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.IsLeafObject.dcm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
+    https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
+    <document name="Doctrine\Tests\ODM\PHPCR\Mapping\Model\IsLeafObject" is-leaf="true">
+        <id name="id" />
+    </document>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ChildClassesObject.dcm.yml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.ChildClassesObject.dcm.yml
@@ -1,0 +1,5 @@
+Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesObject:
+    id: id
+    child_classes: [ "stdClass" ]
+    is_leaf: false
+

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.IsLeafObject.dcm.yml
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/yml/Doctrine.Tests.ODM.PHPCR.Mapping.Model.IsLeafObject.dcm.yml
@@ -1,0 +1,4 @@
+Doctrine\Tests\ODM\PHPCR\Mapping\Model\IsLeafObject:
+    id: id
+    is_leaf: true
+

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -16,17 +16,34 @@ use Jackalope\Node;
  */
 class UnitOfWorkTest extends PHPCRTestCase
 {
-    /** @var DocumentManager */
+    /**
+     * @var DocumentManager
+     */
     private $dm;
-    /** @var UnitOfWork */
+
+    /**
+     * @var UnitOfWork
+     */
     private $uow;
-    /** @var Factory */
+
+    /**
+     * @var Factory
+     */
     private $factory;
-    /** @var \PHPCR\SessionInterface */
+
+    /**
+     * @var \PHPCR\SessionInterface
+     */
     private $session;
-    /** @var \Jackalope\ObjectManager */
+
+    /**
+     * @var \Jackalope\ObjectManager
+     */
     private $objectManager;
-    /** @var string */
+
+    /**
+     * @var string
+     */
     private $type;
 
     public function setUp()


### PR DESCRIPTION
**TODO**
* [x] Wrap up feature
* [x] Documentation (also mention that if a document already is there because the situation was created before the annotation was used or from raw phpcr operations, the child will be on the document as validation only happens during save but not on read)

Doc PR: https://github.com/doctrine/phpcr-odm-documentation/pull/81

This PR allows the restriction of child document types:

```php
/**
 * @PHPCRODM\Document(restrictChildren={
 *   "Doctrine\Tests\Models\CMS\CmsArticle"
 * })
 */
 class ArticleFolder
 {
     // ...
 }
```

- By default children are unrestricted (`childRestrictions = null`)
- Children validated on "insert".
- Children validated on "move".

### Why?

- Ensure structural integrity where it matters.
- Determine which types can be added to a document (e.g. in a tree browser).
- Ultimately this could also be part of the node type definition if we ever implementing that.

### Alternatives

We could also implement this as a separate annotation:

```php
/**
 * @Document()
 * @RestrictChildren({
 *   "AppBundle\Document\Foo"
 *   "AppBundle\Document\Bar"
 * }, restrict="include")
 */
```

 Where ``restrict`` is an enum of `none`, `include` and `exclude`.