### PR TITLE
do not fail build on deprecation warnings

### DIFF
--- a/tests/phpunit_doctrine_dbal.xml.dist
+++ b/tests/phpunit_doctrine_dbal.xml.dist
@@ -1,5 +1,7 @@
 <phpunit colors="true" bootstrap="bootstrap.php" backupGlobals="false" cacheTokens="true">
     <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+
         <!-- Disable E_USER_DEPRECATED until 3.0 -->
         <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
         <ini name="error_reporting" value="-16385"/>

--- a/tests/phpunit_jackrabbit.xml.dist
+++ b/tests/phpunit_jackrabbit.xml.dist
@@ -1,5 +1,7 @@
 <phpunit colors="true" bootstrap="bootstrap.php" backupGlobals="false" cacheTokens="true">
     <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+	
         <!-- Disable E_USER_DEPRECATED until 3.0 -->
         <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
         <ini name="error_reporting" value="-16385"/>


### PR DESCRIPTION
build on master is failing. this is the fix from #706 ported into a separate PR, so that we can merge this first and have it in the 1.3 maintenance branch.