### PR TITLE
Use getMockBuilder instead of getMock

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
@@ -54,7 +54,7 @@ class DocumentManagerTest extends PHPCRTestCase
      */
     public function testNewInstanceFromConfiguration()
     {
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
         $config = new \Doctrine\ODM\PHPCR\Configuration();
 
         $dm = DocumentManager::create($session, $config);
@@ -68,7 +68,7 @@ class DocumentManagerTest extends PHPCRTestCase
      */
     public function testGetMetadataFactory()
     {
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
 
         $dm = DocumentManager::create($session);
 
@@ -80,7 +80,7 @@ class DocumentManagerTest extends PHPCRTestCase
      */
     public function testGetClassMetadataFor()
     {
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
 
         $dm = DocumentManager::create($session);
 
@@ -95,7 +95,7 @@ class DocumentManagerTest extends PHPCRTestCase
      */
     public function testContains()
     {
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
 
         $dm = DocumentManager::create($session);
 
@@ -115,7 +115,7 @@ class DocumentManagerTest extends PHPCRTestCase
      */
     public function testGetRepository()
     {
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
 
         $dm = new DocumentManagerGetClassMetadata($session);
 
@@ -131,7 +131,7 @@ class DocumentManagerTest extends PHPCRTestCase
      */
     public function testEscapeFullText()
     {
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
 
         $dm = DocumentManager::create($session);
 
@@ -144,11 +144,11 @@ class DocumentManagerTest extends PHPCRTestCase
      */
     public function testCreateQueryBuilder()
     {
-        $session = $this->getMock('PHPCR\SessionInterface');
-        $workspace = $this->getMock('PHPCR\WorkspaceInterface');
-        $queryManager = $this->getMock('PHPCR\Query\QueryManagerInterface');
-        $qomf = $this->getMock('PHPCR\Query\QOM\QueryObjectModelFactoryInterface');
-        $baseQuery = $this->getMock('PHPCR\Query\QueryInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $workspace = $this->getMockBuilder('PHPCR\WorkspaceInterface')->getMock();
+        $queryManager = $this->getMockBuilder('PHPCR\Query\QueryManagerInterface')->getMock();
+        $qomf = $this->getMockBuilder('PHPCR\Query\QOM\QueryObjectModelFactoryInterface')->getMock();
+        $baseQuery = $this->getMockBuilder('PHPCR\Query\QueryInterface')->getMock();
 
         $session->expects($this->once())
             ->method('getWorkspace')

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/RepositoryIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/RepositoryIdGeneratorTest.php
@@ -12,7 +12,7 @@ class RepositoryIdGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $id = 'moo';
         $cm = new RepositoryClassMetadataProxy($id);
-        $repository = $this->getMock('Doctrine\ODM\PHPCR\Id\RepositoryIdInterface');
+        $repository = $this->getMockBuilder('Doctrine\ODM\PHPCR\Id\RepositoryIdInterface')->getMock();
         $repository
             ->expects($this->once())
             ->method('generateId')
@@ -39,7 +39,7 @@ class RepositoryIdGeneratorTest extends \PHPUnit_Framework_TestCase
         $id = 'moo';
         $generator = new RepositoryIdGenerator;
         $cm = new ClassMetadataProxy($id);
-        $repository = $this->getMock('Doctrine\ODM\PHPCR\Id\RepositoryIdInterface');
+        $repository = $this->getMockBuilder('Doctrine\ODM\PHPCR\Id\RepositoryIdInterface')->getMock();
         $repository
             ->expects($this->once())
             ->method('generateId')

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -348,7 +348,7 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($class->identifier));
         $this->assertEmpty($class->fieldMappings);
 
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
         $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session);
         $dm->getConfiguration()->setMetadataDriverImpl($this->loadDriver());
         $cmf = new ClassMetadataFactory($dm);
@@ -756,7 +756,7 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
         $this->loadMetadataForClassname($className);
 
         $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\StringExtendedMappingObject';
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
         $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session);
         $dm->getConfiguration()->setMetadataDriverImpl($this->loadDriver());
         $cmf = new ClassMetadataFactory($dm);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -35,7 +35,7 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $session = $this->getMock('PHPCR\SessionInterface');
+        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
         $this->dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConverterPhpcrTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConverterPhpcrTest.php
@@ -19,7 +19,7 @@ class ConverterPhpcrTest extends \PHPUnit_Framework_TestCase
         $me = $this;
         // note: this "factory" seems unnecessary in current jackalope
         //       implementation
-        $this->qomfFactory = $this->getMock('Jackalope\FactoryInterface');
+        $this->qomfFactory = $this->getMockBuilder('Jackalope\FactoryInterface')->getMock();
 
         $this->qomf = new QueryObjectModelFactory($this->qomfFactory);
 
@@ -651,7 +651,7 @@ class ConverterPhpcrTest extends \PHPUnit_Framework_TestCase
                 );
 
                 // return something ..
-                $qom = $me->getMock('PHPCR\Query\QOM\QueryObjectModelInterface');
+                $qom = $me->getMockBuilder('PHPCR\Query\QOM\QueryObjectModelInterface')->getMock();
                 return $qom;
             }));
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
@@ -107,7 +107,7 @@ class QueryBuilderTest extends NodeTestCase
         $property = $reflection->getProperty('converter');
         $property->setAccessible(true);
 
-        $this->node->setConverter($this->getMock('Doctrine\ODM\PHPCR\Query\Builder\ConverterInterface'));
+        $this->node->setConverter($this->getMockBuilder('Doctrine\ODM\PHPCR\Query\Builder\ConverterInterface')->getMock());
 
         $clone = clone $this->node;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
@@ -11,11 +11,11 @@ class QueryTest extends \PHPUnit_Framework_Testcase
 {
     public function setUp()
     {
-        $this->phpcrQuery = $this->getMock('PHPCR\Query\QueryInterface');
+        $this->phpcrQuery = $this->getMockBuilder('PHPCR\Query\QueryInterface')->getMock();
         $this->dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->arrayCollection = $this->getMock('Doctrine\Common\Collections\ArrayCollection');
+        $this->arrayCollection = $this->getMockBuilder('Doctrine\Common\Collections\ArrayCollection')->getMock();
         $this->query = new Query($this->phpcrQuery, $this->dm);
         $this->aliasQuery = new Query($this->phpcrQuery, $this->dm, 'a');
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DocumentConvertTranslationCommandTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DocumentConvertTranslationCommandTest.php
@@ -32,11 +32,10 @@ class DocumentConvertTranslationCommandTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->mockSession = $this->getMock('PHPCR\SessionInterface');
-        $mockHelper = $this->getMock(
-            'Symfony\Component\Console\Helper\HelperInterface',
-            array('getSession', 'setHelperSet', 'getHelperSet', 'getName')
-        );
+        $this->mockSession = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $mockHelper = $this->getMockBuilder('PHPCR\Util\Console\Helper\PhpcrHelper')
+            ->disableOriginalConstructor()
+            ->getMock();
         $mockHelper
             ->expects($this->once())
             ->method('getSession')

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -36,9 +36,13 @@ class UnitOfWorkTest extends PHPCRTestCase
         }
 
         $this->factory = new Factory;
-        $this->session = $this->getMock('Jackalope\Session', array(), array($this->factory), '', false);
+        $this->session = $this->getMockBuilder('Jackalope\Session')
+            ->disableOriginalConstructor()
+            ->getMock();
         
-        $this->objectManager = $this->getMock('Jackalope\ObjectManager', array(), array($this->factory), '', false);
+        $this->objectManager = $this->getMockBuilder('Jackalope\ObjectManager')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->type = 'Doctrine\Tests\ODM\PHPCR\UoWUser';
         $this->dm = DocumentManager::create($this->session);


### PR DESCRIPTION
Do not use the deprecated `getMock` method.

Fixes #709 