### PR TITLE
Register system node types in dedicated class

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/NodeTypeRegistrator.php
+++ b/lib/Doctrine/ODM/PHPCR/NodeTypeRegistrator.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\PHPCR;
+
+use Doctrine\ODM\PHPCR\Translation\Translation;
+use PHPCR\SessionInterface;
+
+/**
+ * Encapsulates the logic for registering system node types.
+ */
+final class NodeTypeRegistrator
+{
+    private $phpcrNamespace = 'phpcr';
+    private $phpcrNamespaceUri = 'http://www.doctrine-project.org/projects/phpcr_odm';
+    private $localeNamespace = Translation::LOCALE_NAMESPACE;
+    private $localeNamespaceUri = Translation::LOCALE_NAMESPACE_URI;
+
+    /**
+     * Register the system node types on the given session.
+     *
+     * @param SessionInterface
+     */
+    public function registerNodeTypes(SessionInterface $session)
+    {
+        $cnd = <<<CND
+// register phpcr_locale namespace
+<$this->localeNamespace='$this->localeNamespaceUri'>
+// register phpcr namespace
+<$this->phpcrNamespace='$this->phpcrNamespaceUri'>
+[phpcr:managed]
+mixin
+- phpcr:class (STRING)
+- phpcr:classparents (STRING) multiple
+CND
+        ;
+
+        $nodeTypeManager = $session->getWorkspace()->getNodeTypeManager();
+        $nodeTypeManager->registerNodeTypesCnd($cnd, true);
+    }
+}

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/RegisterSystemNodeTypesCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/RegisterSystemNodeTypesCommand.php
@@ -24,28 +24,23 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use PHPCR\Util\Console\Command\NodeTypeRegisterCommand;
 use Doctrine\ODM\PHPCR\Translation\Translation;
+use Doctrine\ODM\PHPCR\NodeTypeRegistrator;
 
 /**
  * Command to register the phcpr-odm required node types.
  *
  * This command registers the necessary node types to get phpcr odm working
  */
-class RegisterSystemNodeTypesCommand extends NodeTypeRegisterCommand
+class RegisterSystemNodeTypesCommand extends Command
 {
-    private $phpcrNamespace = 'phpcr';
-    private $phpcrNamespaceUri = 'http://www.doctrine-project.org/projects/phpcr_odm';
-    private $localeNamespace = Translation::LOCALE_NAMESPACE;
-    private $localeNamespaceUri = Translation::LOCALE_NAMESPACE_URI;
-
     /**
      * @see Command
      */
     protected function configure()
     {
-        $this
-        ->setName('doctrine:phpcr:register-system-node-types')
-        ->setDescription('Register system node types in the PHPCR repository')
-        ->setHelp(<<<EOT
+        $this->setName('doctrine:phpcr:register-system-node-types');
+        $this->setDescription('Register system node types in the PHPCR repository');
+        $this->setHelp(<<<EOT
 Register system node types in the PHPCR repository.
 
 This command registers the node types necessary for the ODM to work.
@@ -54,27 +49,16 @@ EOT
     }
 
     /**
-     * @see Command
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $cnd = <<<CND
-// register phpcr_locale namespace
-<$this->localeNamespace='$this->localeNamespaceUri'>
-// register phpcr namespace
-<$this->phpcrNamespace='$this->phpcrNamespaceUri'>
-[phpcr:managed]
-mixin
-- phpcr:class (STRING)
-- phpcr:classparents (STRING) multiple
-CND
-        ;
-
         /** @var $session \PHPCR\SessionInterface */
         $session = $this->getHelper('phpcr')->getSession();
+        $registrator = new NodeTypeRegistrator();
+
         try {
-            // automatically overwrite - we are inside our phpcr namespace, nothing can go wrong
-            $this->updateFromCnd($output, $session, $cnd, true);
+            $registrator->registerNodeTypes($session);
         } catch (\Exception $e) {
             $output->writeln('<error>'.$e->getMessage().'</error>');
 


### PR DESCRIPTION
Fixes #712 

This is a quick fix to decouple the registration of system types from the console command.