### PR TITLE
Cascade children

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -839,7 +839,7 @@ class UnitOfWork
      */
     private function cascadeScheduleInsert($class, $document, &$visited)
     {
-        foreach (array_merge($class->referenceMappings, $class->referrersMappings) as $fieldName) {
+        foreach (array_merge($class->referenceMappings, $class->referrersMappings, $class->childrenMappings) as $fieldName) {
             $mapping = $class->mappings[$fieldName];
             if (!($mapping['cascade'] & ClassMetadata::CASCADE_PERSIST)) {
                 continue;


### PR DESCRIPTION
Support for cacading children.

More work probably needs to be done, but quite tired so will just leave this here :)

This allows:

```php

$child1 = new Child();
$child2 = new Child();

$document->myChildren = [ $child1, $child2 ];
$dm->persist($document);
$dm->flush();
```