### PR TITLE
Temporary revert getField() removal

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -1210,6 +1210,17 @@ class ClassMetadata implements ClassMetadataInterface
 
     /**
      * {@inheritDoc}
+     * @deprecated use getFieldMapping instead
+     */
+    public function getField($fieldName)
+    {
+        @trigger_error(__METHOD__.'() is deprecated since 1.1.4 and will be removed in 2.0, use getFieldMapping() instead.', E_USER_DEPRECATED);
+
+        return $this->getFieldMapping($fieldName);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public function hasAssociation($fieldName)
     {


### PR DESCRIPTION
Some slow moving vendor dependencies (like JMS Serializer, ref
schmittjoh/serializer#605) hold up the development at the moment. Keeping
this method for the moment will fix it.

This PR should be reverted before 2.0.0 is released.