### PR TITLE
Make tests compatibile with doctrine/annotations 1.3

### DIFF
--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-
 /**
  * @group mapping
  */
@@ -11,8 +9,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
 {
     protected function loadDriver()
     {
-        $cache = new \Doctrine\Common\Cache\ArrayCache();
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader($cache);
+        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
         return new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver($reader);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -21,8 +21,7 @@ class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMetadataFor($fqn)
     {
-        $cache = new \Doctrine\Common\Cache\ArrayCache();
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader($cache);
+        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
         $annotationDriver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver($reader);
         $annotationDriver->addPaths(array(__DIR__ . '/Model'));
         $this->dm->getConfiguration()->setMetadataDriverImpl($annotationDriver);


### PR DESCRIPTION
`AnnotationReader` constructor for `doctrine/annotations` >=1.3: `public function __construct(DocParser $parser = null)`
`AnnotationReader` constructor for `doctrine/annotations` <1.2: `public function __construct()`

No idea why cache was injected there in the tests 🎉 