### PR TITLE
Don't override ID generator when persisting children

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1689,7 +1689,7 @@ class UnitOfWork
                 if ($this->getDocumentById($childId)) {
                     $child = $this->merge($child);
                 } else {
-                    $this->persistNew($targetClass, $child, ClassMetadata::GENERATOR_TYPE_ASSIGNED, $parent);
+                    $this->persistNew($targetClass, $child, null, $parent);
                 }
 
                 $this->computeChangeSet($targetClass, $child);


### PR DESCRIPTION
When persisting a new document with children, the children are automatically persisted as well. However, this persistence of the children is done using an override ID generator (assigned). This means the children are required to have an `@Id` field in order to be persisted.

I don't know why this is done and it didn't work as expected when working with the PHPCR ODM (I don't want to use the assigned ID strategy).

The line is added in https://github.com/doctrine/phpcr-odm/pull/50 . Unfortunately, the related issue can no longer be read as Jira is removed. However, the tests all still pass, so I don't think I've broken the fix.

Again, I'm not an PHPCR ODM expert and don't know if there was a specific reason to do this, but using the one from the ClassMetadata makes a lot more sense in my head.