### PR TITLE
Fix updating new Id for children after a move.

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2774,7 +2774,7 @@ class UnitOfWork
                 if ($childClass->identifier) {
                     $childClass->setIdentifierValue($child, $newId);
                     if (! $child instanceof Proxy || $child->__isInitialized()) {
-                        $this->originalData[$oid][$childClass->identifier] = $newId;
+                        $this->originalData[$childOid][$childClass->identifier] = $newId;
                     }
                 }
             }


### PR DESCRIPTION
The assignment was using the object id of the parent, instead of the child.