### PR TITLE
fix php 5.3 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   include:
     - php: 5.3
       env: TRANSPORT=doctrine_dbal COMPOSER_FLAGS="--prefer-lowest"
+      dist: precise
 # composer fails to find a solution even though i think there should exist one
 #    - php: 5.3
 #      env: TRANSPORT=jackrabbit COMPOSER_FLAGS="--prefer-lowest"


### PR DESCRIPTION
travis moved to the trusty distribution which does not provide the ancient php 5.3 version anymore.