### PR TITLE
drop php 5 support for version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
+  - 7.1
 
 sudo: false
 
@@ -18,22 +15,12 @@ env:
 
 matrix:
   include:
-    - php: 5.3
-      env: TRANSPORT=doctrine_dbal COMPOSER_FLAGS="--prefer-lowest"
-      dist: precise
-# composer fails to find a solution even though i think there should exist one
-#    - php: 5.3
-#      env: TRANSPORT=jackrabbit COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.0
-      env: TRANSPORT=doctrine_dbal SYMFONY_VERSION="2.7"
-    - php: 7.0
-      env: TRANSPORT=jackrabbit SYMFONY_VERSION="2.7"
-    - php: 7.0
-      env: TRANSPORT=doctrine_dbal SYMFONY_VERSION="2.8" PHPBENCH="yes"
-    - php: 7.0
-      env: TRANSPORT=jackrabbit SYMFONY_VERSION="2.8" PHPBENCH="yes"
-    - php: hhvm
-      dist: trusty
+    - php: 7.1
+      env: TRANSPORT=jackrabbit COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.1
+      env: TRANSPORT=doctrine_dbal SYMFONY_VERSION="3.3" PHPBENCH="yes"
+    - php: 7.1
+      env: TRANSPORT=jackrabbit SYMFONY_VERSION="3.3" PHPBENCH="yes"
 
 before_script:
   - composer self-update || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.1
+  - 7.0
 
 sudo: false
 
@@ -17,6 +18,8 @@ matrix:
   include:
     - php: 7.1
       env: TRANSPORT=jackrabbit COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.0
+      env: TRANSPORT=doctrine_dbal SYMFONY_VERSION="3.3"
     - php: 7.1
       env: TRANSPORT=doctrine_dbal SYMFONY_VERSION="3.3" PHPBENCH="yes"
     - php: 7.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Requirements
 
-* php >= 5.3
+* PHP 7.1
 * libxml version >= 2.7.0 (due to a bug in libxml [http://bugs.php.net/bug.php?id=36501](http://bugs.php.net/bug.php?id=36501))
 * [composer](http://getcomposer.org/)
 * See also the `require` section of [composer.json](composer.json)

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "7.1.*",
+        "php": "^7.0",
         "doctrine/common": "^2.4",
         "doctrine/annotations": "^1.2",
         "doctrine/data-fixtures": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.3.9|~7.0",
+        "php": "7.1.*",
         "doctrine/common": "^2.4",
         "doctrine/annotations": "^1.2",
         "doctrine/data-fixtures": "^1.0",
@@ -21,16 +21,16 @@
         "phpcr/phpcr-implementation": "^2.1.0",
         "phpcr/phpcr-utils": "^1.2.8",
         "doctrine/instantiator": "^1.0.1",
-        "symfony/console": "^2.3|^3.0"
+        "symfony/console": "^3.3"
     },
     "require-dev": {
-        "symfony/yaml": "^2.3|^3.0",
-        "symfony/phpunit-bridge": "^2.7|^3.0",
+        "symfony/yaml": "^3.3",
+        "symfony/phpunit-bridge": "^3.2",
         "liip/rmt": "~1.2",
-        "phpunit/phpunit": "^4.8|5.*"
+        "phpunit/phpunit": "5.*"
     },
     "suggest": {
-        "symfony/yaml": "^2.3|^3.0",
+        "symfony/yaml": "^3.2",
         "jackalope/jackalope-doctrine-dbal": "^1.3.0",
         "jackalope/jackalope-jackrabbit": "^1.3.0"
     },


### PR DESCRIPTION
reduced to only drop 5.x and 7.0 support and add 7.1 testing. adding php 7.2 support is blocked by the dependencies needing to support it first. will be done in a separate PR.