### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/yaml": "^3.3",
         "symfony/phpunit-bridge": "^3.2",
         "liip/rmt": "~1.2",
-        "phpunit/phpunit": "5.*"
+        "phpunit/phpunit": "~5.7.21"
     },
     "suggest": {
         "symfony/yaml": "^3.2",

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentClassMapperTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentClassMapperTest.php
@@ -8,8 +8,9 @@ use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
+use PHPUnit\Framework\TestCase;
 
-class DocumentClassMapperTest extends \PHPUnit_Framework_Testcase
+class DocumentClassMapperTest extends Testcase
 {
     const CLASS_GENERIC = 'Doctrine\ODM\PHPCR\Document\Generic';
     const CLASS_TEST_1 = 'Test\Class1';

--- a/tests/Doctrine/Tests/ODM/PHPCR/Event/MoveEventArgsTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Event/MoveEventArgsTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Doctrine\ODM\PHPCR\Event\MoveEventArgs;
+use PHPUnit\Framework\TestCase;
 
-class MoveEventArgsTest extends \PHPUnit_Framework_TestCase
+class MoveEventArgsTest extends TestCase
 {
     private $object;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/AssignedIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/AssignedIdGeneratorTest.php
@@ -2,8 +2,9 @@
 
 use Doctrine\ODM\PHPCR\Id\AssignedIdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
 
-class AssignedIdGeneratorTest extends \PHPUnit_Framework_TestCase
+class AssignedIdGeneratorTest extends TestCase
 {
     /**
      * @covers Doctrine\ODM\PHPCR\Id\AssignedIdGenerator::generate

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/IdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/IdGeneratorTest.php
@@ -2,8 +2,9 @@
 
 use Doctrine\ODM\PHPCR\Id\IdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
 
-class IdGeneratorTest extends \PHPUnit_Framework_TestCase
+class IdGeneratorTest extends TestCase
 {
     /**
      * @covers Doctrine\ODM\PHPCR\Id\IdGenerator::create

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/ParentIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/ParentIdGeneratorTest.php
@@ -4,8 +4,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Id;
 
 use Doctrine\ODM\PHPCR\Id\ParentIdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
 
-class ParentIdGeneratorTest extends \PHPUnit_Framework_TestCase
+class ParentIdGeneratorTest extends TestCase
 {
     /**
      * @covers Doctrine\ODM\PHPCR\Id\ParentIdGenerator::generate

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/RepositoryIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/RepositoryIdGeneratorTest.php
@@ -2,8 +2,9 @@
 
 use Doctrine\ODM\PHPCR\Id\RepositoryIdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
 
-class RepositoryIdGeneratorTest extends \PHPUnit_Framework_TestCase
+class RepositoryIdGeneratorTest extends TestCase
 {
     /**
      * @covers Doctrine\ODM\PHPCR\Id\RepositoryIdGenerator::generate

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -5,8 +5,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractMappingDriverTest extends TestCase
 {
     /**
      * @return \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -6,8 +6,9 @@ use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Event;
+use PHPUnit\Framework\TestCase;
 
-class ClassMetadataFactoryTest extends \PHPUnit_Framework_TestCase
+class ClassMetadataFactoryTest extends TestCase
 {
     /**
      * @var \Doctrine\ODM\PHPCR\DocumentManager

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
@@ -8,8 +8,9 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use PHPUnit\Framework\TestCase;
 
-class ClassMetadataTest extends \PHPUnit_Framework_TestCase
+class ClassMetadataTest extends TestCase
 {
     public function testGetTypeOfField()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
@@ -6,8 +6,9 @@ use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use PHPCR\RepositoryFactoryInterface;
 use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
 
-abstract class PHPCRFunctionalTestCase extends \PHPUnit_Framework_TestCase
+abstract class PHPCRFunctionalTestCase extends TestCase
 {
     /**
      * @var SessionInterface[]

--- a/tests/Doctrine/Tests/ODM/PHPCR/PHPCRTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/PHPCRTestCase.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ODM\PHPCR;
 
-abstract class PHPCRTestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class PHPCRTestCase extends TestCase
 {
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractLeafNodeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractLeafNodeTest.php
@@ -2,7 +2,9 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-class AbstractLeafNodeTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractLeafNodeTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractNodeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractNodeTest.php
@@ -2,7 +2,9 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-class AbstractNodeTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractNodeTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConverterPhpcrTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConverterPhpcrTest.php
@@ -9,8 +9,9 @@ use Doctrine\ODM\PHPCR\Query\Builder\ConverterPhpcr;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
+use PHPUnit\Framework\TestCase;
 
-class ConverterPhpcrTest extends \PHPUnit_Framework_TestCase
+class ConverterPhpcrTest extends TestCase
 {
     protected $parentNode;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/LeafNodeTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/LeafNodeTestCase.php
@@ -3,8 +3,9 @@
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use PHPUnit\Framework\TestCase;
 
-abstract class LeafNodeTestCase extends \PHPUnit_Framework_TestCase
+abstract class LeafNodeTestCase extends TestCase
 {
     /**
      * @var AbstractNode

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/NodeTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/NodeTestCase.php
@@ -4,8 +4,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
 use Doctrine\ODM\PHPCR\Query\Builder\Builder;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
+use PHPUnit\Framework\TestCase;
 
-abstract class NodeTestCase extends \PHPUnit_Framework_TestCase
+abstract class NodeTestCase extends TestCase
 {
     protected $node;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
@@ -3,11 +3,12 @@
 namespace Doctrine\Tests\ODM\PHPCR\Query;
 
 use Doctrine\ODM\PHPCR\Query\Query;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group unit
  */
-class QueryTest extends \PHPUnit_Framework_Testcase
+class QueryTest extends Testcase
 {
     public function setUp()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DocumentConvertTranslationCommandTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DocumentConvertTranslationCommandTest.php
@@ -7,8 +7,9 @@ use Doctrine\ODM\PHPCR\Tools\Helper\TranslationConverter;
 use PHPCR\SessionInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
+use PHPUnit\Framework\TestCase;
 
-class DocumentConvertTranslationCommandTest extends \PHPUnit_Framework_TestCase
+class DocumentConvertTranslationCommandTest extends TestCase
 {
     /**
      * @var DocumentConvertTranslationCommand

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DumpQueryBuilderReferenceCommandTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DumpQueryBuilderReferenceCommandTest.php
@@ -4,8 +4,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Tools\Command;
 
 use Doctrine\ODM\PHPCR\Tools\Console\Command\DumpQueryBuilderReferenceCommand;
 use Symfony\Component\Console\Tester\CommandTester;
+use PHPUnit\Framework\TestCase;
 
-class DumpQueryBuilderReferenceCommandTest extends \PHPUnit_Framework_TestCase
+class DumpQueryBuilderReferenceCommandTest extends TestCase
 {
     /**
      * @var DumpQueryBuilderReferenceCommand

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Helper/UniqueNodeTypeHelperTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Helper/UniqueNodeTypeHelperTest.php
@@ -4,13 +4,14 @@ namespace Doctrine\Tests\ODM\PHPCR\Tools\Helper;
 
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Tools\Helper\UniqueNodeTypeHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Verify the behavior of the UniqueNodeTypeHelper class that is used
  * to confirm that any documents set to use unique node types do not
  * conflict with any other mappings.
  */
-class UniqueNodeTypeHelperTest extends \PHPUnit_Framework_TestCase
+class UniqueNodeTypeHelperTest extends TestCase
 {
     /**
      * Configure a mocked DocumentManager that will return the supplied

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Test/QueryBuilderTesterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Test/QueryBuilderTesterTest.php
@@ -4,8 +4,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Tools\Test;
 
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Tools\Test\QueryBuilderTester;
+use PHPUnit\Framework\TestCase;
 
-class QueryBuilderTesterTest extends \PHPUnit_Framework_TestCase
+class QueryBuilderTesterTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).