### PR TITLE
be sure to have Nodename annotation consistently lowercase

### DIFF
--- a/benchmarks/PersistBench.php
+++ b/benchmarks/PersistBench.php
@@ -5,7 +5,7 @@ namespace Doctrine\Benchmarks\ODM\PHPCR;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\References\ParentNoNodeNameTestObj;
+use Doctrine\Tests\Models\References\ParentNoNodenameTestObj;
 use Doctrine\Tests\Models\References\ParentTestObj;
 use Doctrine\Tests\Models\Translation\Comment;
 use Doctrine\Tests\ODM\PHPCR\Functional\TestUser;
@@ -53,7 +53,7 @@ class PersistBench extends PHPCRFunctionalTestCase
         $parent2->nodename = "root2";
         $parent2->setParentDocument($this->root);
 
-        $child = new ParentNoNodeNameTestObj();
+        $child = new ParentNoNodenameTestObj();
         $child->setParentDocument($parent1);
         $child->name = "child";
 

--- a/lib/Doctrine/ODM/PHPCR/Id/IdException.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/IdException.php
@@ -10,7 +10,7 @@ class IdException extends PHPCRException
     public static function noIdentificationParameters($document, $parent, $nodename)
     {
         $message = sprintf(
-            'Property "%s" mapped as ParentDocument and property "%s" mapped as NodeName '.
+            'Property "%s" mapped as ParentDocument and property "%s" mapped as Nodename '.
                 'may not be empty in document of class "%s"',
             $parent,
             $nodename,
@@ -34,7 +34,7 @@ class IdException extends PHPCRException
     public static function noIdNoName($document, $fieldName)
     {
         $message = sprintf(
-            'NodeName property "%s" may not be empty in document of class "%s"',
+            'Nodename property "%s" may not be empty in document of class "%s"',
             $fieldName,
             ClassUtils::getClass($document)
         );
@@ -59,7 +59,7 @@ class IdException extends PHPCRException
     public static function illegalName($document, $fieldName, $nodeName)
     {
         $message = sprintf(
-            'NodeName property "%s" of document "%s" contains the illegal PHPCR value "%s".',
+            'Nodename property "%s" of document "%s" contains the illegal PHPCR value "%s".',
             $fieldName,
             ClassUtils::getClass($document),
             $nodeName

--- a/tests/Doctrine/Tests/Models/CMS/CmsBlogInvalidChild.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsBlogInvalidChild.php
@@ -16,7 +16,7 @@ class CmsBlogInvalidChild
     /** @PHPCRODM\Id(strategy="parent") */
     public $id;
 
-    /** @PHPCRODM\NodeName() */
+    /** @PHPCRODM\Nodename() */
     public $name;
 
     /** @PHPCRODM\ParentDocument() */

--- a/tests/Doctrine/Tests/Models/CMS/CmsBlogPost.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsBlogPost.php
@@ -16,7 +16,7 @@ class CmsBlogPost
     /** @PHPCRODM\Id(strategy="parent") */
     public $id;
 
-    /** @PHPCRODM\NodeName() */
+    /** @PHPCRODM\Nodename() */
     public $name;
 
     /** @PHPCRODM\ParentDocument() */

--- a/tests/Doctrine/Tests/Models/References/ParentNoNodenameTestObj.php
+++ b/tests/Doctrine/Tests/Models/References/ParentNoNodenameTestObj.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 /**
  * @PHPCRODM\Document(referenceable=true)
  */
-class ParentNoNodeNameTestObj
+class ParentNoNodenameTestObj
 {
     /** @PHPCRODM\Id */
     public $id;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\UnitOfWork;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsAddress;
-use Doctrine\Tests\Models\References\ParentNoNodeNameTestObj;
+use Doctrine\Tests\Models\References\ParentNoNodenameTestObj;
 use Doctrine\Tests\Models\References\ParentTestObj;
 use Doctrine\Tests\Models\Translation\Comment;
 use Doctrine\Tests\Models\CMS\CmsArticleFolder;
@@ -86,7 +86,7 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals(32, strlen(key($scheduledMoves)), 'Size of key is 32 chars (oid)');
         $this->assertEquals(array($user1, '/foobar'), current($scheduledMoves));
     }
-    
+
     public function testMoveParentNoNodeName()
     {
         $root = $this->dm->find(null, 'functional');
@@ -101,7 +101,7 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $parent2->nodename = "root2";
         $parent2->setParentDocument($root);
 
-        $child = new ParentNoNodeNameTestObj();
+        $child = new ParentNoNodenameTestObj();
         $child->setParentDocument($parent1);
         $child->name = "child";
 


### PR DESCRIPTION
fix #737, fix #739

i prefer to go with consistent Nodename over potentially doing a BC break for people on systems that are case sensitive with these. that way it will continue to work but we avoid confusion.