### PR TITLE
do not ignore 'each' deprecation and upgrade to phpunit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  global:
-    # on PHP 7.2 we get deprecations about using each. they supposedly come from phpunit 5 itself. TODO: update to phpunit 6 and see if this goes away.
-    - SYMFONY_DEPRECATIONS_HELPER="/.*each.*/"
   matrix:
     - TRANSPORT=jackrabbit
     - TRANSPORT=doctrine_dbal

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "doctrine/common": "^2.4",
         "doctrine/annotations": "^1.2",
         "doctrine/data-fixtures": "^1.0",
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "symfony/yaml": "^3.3 || ^4.0",
-        "symfony/phpunit-bridge": "^3.2 || ^4.0",
+        "symfony/phpunit-bridge": "^3.3 || ^4.0",
         "liip/rmt": "1.3.*@dev",
         "phpunit/phpunit": "^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/yaml": "^3.3 || ^4.0",
         "symfony/phpunit-bridge": "^3.2 || ^4.0",
         "liip/rmt": "1.3.*@dev",
-        "phpunit/phpunit": "~5.7.21"
+        "phpunit/phpunit": "^6.0"
     },
     "suggest": {
         "symfony/yaml": "^3.2 || ^4.0",

--- a/lib/Doctrine/ODM/PHPCR/Configuration.php
+++ b/lib/Doctrine/ODM/PHPCR/Configuration.php
@@ -21,10 +21,12 @@ namespace Doctrine\ODM\PHPCR;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\ODM\PHPCR\DocumentClassMapperInterface;
 use Doctrine\ODM\PHPCR\Mapping\Driver\BuiltinDocumentsDriver;
 use Doctrine\ODM\PHPCR\Repository\DefaultRepositoryFactory;
 use Doctrine\ODM\PHPCR\Repository\RepositoryFactory;
 use PHPCR\Util\UUIDHelper;
+use Doctrine\Common\Persistence\ObjectRepository;
 
 /**
  * Configuration class
@@ -179,7 +181,7 @@ class Configuration
     /**
      * Gets the cache driver implementation that is used for metadata caching.
      *
-     * @return \Doctrine\ODM\PHPCR\DocumentClassMapperInterface
+     * @return DocumentClassMapperInterface
      */
     public function getDocumentClassMapper()
     {
@@ -193,7 +195,7 @@ class Configuration
     /**
      * Sets the cache driver implementation that is used for metadata caching.
      *
-     * @param \Doctrine\ODM\PHPCR\DocumentClassMapperInterface $documentClassMapper
+     * @param DocumentClassMapperInterface $documentClassMapper
      */
     public function setDocumentClassMapper(DocumentClassMapperInterface $documentClassMapper)
     {
@@ -309,7 +311,7 @@ class Configuration
     {
         $reflectionClass = new \ReflectionClass($className);
 
-        if (! $reflectionClass->implementsInterface('Doctrine\Common\Persistence\ObjectRepository')) {
+        if (! $reflectionClass->implementsInterface(ObjectRepository::class)) {
             throw PHPCRException::invalidDocumentRepository($className);
         }
 

--- a/lib/Doctrine/ODM/PHPCR/Configuration.php
+++ b/lib/Doctrine/ODM/PHPCR/Configuration.php
@@ -288,7 +288,7 @@ class Configuration
     public function getClassMetadataFactoryName()
     {
         if (! isset($this->attributes['classMetadataFactoryName'])) {
-            $this->attributes['classMetadataFactoryName'] = 'Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory';
+            $this->attributes['classMetadataFactoryName'] = Mapping\ClassMetadataFactory::class;
         }
 
         return $this->attributes['classMetadataFactoryName'];
@@ -326,7 +326,7 @@ class Configuration
     public function getDefaultRepositoryClassName()
     {
         return $this->attributes['defaultRepositoryClassName']
-            ?? 'Doctrine\ODM\PHPCR\DocumentRepository';
+            ?? DocumentRepository::class;
     }
 
     /**

--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
@@ -77,7 +77,7 @@ class DocumentClassMapper implements DocumentClassMapperInterface
     {
         $className = $this->expandClassName($dm, $className);
 
-        if ('Doctrine\\ODM\\PHPCR\\Document\\Generic' !== $className) {
+        if (Document\Generic::class !== $className) {
             $node->setProperty('phpcr:class', $className, PropertyType::STRING);
 
             $class = $dm->getClassMetadata($className);

--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
@@ -64,7 +64,7 @@ class DocumentClassMapper implements DocumentClassMapperInterface
 
         // default to the built in generic document class
         if (empty($className)) {
-            $className = 'Doctrine\\ODM\\PHPCR\\Document\\Generic';
+            $className = Document\Generic::class;
         }
 
         return $className;

--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -34,6 +34,8 @@ use Doctrine\ODM\PHPCR\Query\Builder\ConverterPhpcr;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Collections\ArrayCollection;
+use PHPCR\NodeInterface;
+use PHPCR\Query\RowInterface;
 use PHPCR\SessionInterface;
 use PHPCR\Query\QueryInterface;
 use PHPCR\UnsupportedRepositoryOperationException;
@@ -332,8 +334,8 @@ class DocumentManager implements DocumentManagerInterface
         if (!empty($uuids)) {
             $nodes = $this->session->getNodesByIdentifier(array_keys($uuids));
 
+            /** @var NodeInterface $node */
             foreach ($nodes as $node) {
-                /** @var $node \PHPCR\NodeInterface */
                 $id = $node->getPath();
                 $ids[$uuids[$node->getIdentifier()]] = $id;
                 unset($uuids[$id]);
@@ -478,8 +480,8 @@ class DocumentManager implements DocumentManagerInterface
         $result = $query->execute();
 
         $ids = array();
+        /** @var RowInterface $row */
         foreach ($result->getRows() as $row) {
-            /** @var $row \PHPCR\Query\RowInterface */
             $ids[] = $row->getPath($primarySelector);
         }
 

--- a/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
@@ -28,9 +28,13 @@ use Doctrine\Common\EventManager;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\TranslationStrategyInterface;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooserInterface;
 use Doctrine\ODM\PHPCR\Query\Query;
+use PHPCR\NodeInterface;
 use PHPCR\Query\QueryInterface;
 use PHPCR\PropertyType;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use PHPCR\RepositoryException;
+use PHPCR\SessionInterface;
+use PHPCR\UnsupportedRepositoryOperationException;
 
 /**
  * DocumentManager interface
@@ -98,7 +102,7 @@ interface DocumentManagerInterface extends ObjectManager
     /**
      * Access the underlying PHPCR session this manager is using.
      *
-     * @return \PHPCR\SessionInterface
+     * @return SessionInterface
      */
     public function getPhpcrSession();
 
@@ -192,7 +196,7 @@ interface DocumentManagerInterface extends ObjectManager
      * @param string $statement The statement in the specified language
      * @param string $language  The query language
      *
-     * @return \PHPCR\Query\QueryInterface
+     * @return QueryInterface
      */
     public function createPhpcrQuery($statement, $language);
 
@@ -441,7 +445,7 @@ interface DocumentManagerInterface extends ObjectManager
      *
      * @param object $documentVersion The version document as returned by findVersionByName.
      *
-     * @throws \PHPCR\RepositoryException when trying to remove the root version or the last version
+     * @throws RepositoryException when trying to remove the root version or the last version
      */
     public function removeVersion($documentVersion);
 
@@ -475,7 +479,7 @@ interface DocumentManagerInterface extends ObjectManager
      *
      * @throws InvalidArgumentException if there is a document with $id but no
      *      version with $name
-     * @throws \PHPCR\UnsupportedRepositoryOperationException if the implementation
+     * @throws UnsupportedRepositoryOperationException if the implementation
      *      does not support versioning
      */
     public function findVersionByName($className, $id, $versionName);
@@ -519,7 +523,7 @@ interface DocumentManagerInterface extends ObjectManager
      *
      * @param object $document
      *
-     * @return \PHPCR\NodeInterface
+     * @return NodeInterface
      *
      * @throws InvalidArgumentException if $document is not an object.
      * @throws PHPCRException                if $document is not managed

--- a/lib/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -21,6 +21,7 @@ namespace Doctrine\ODM\PHPCR;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Query\Query;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as Constants;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
@@ -66,8 +67,8 @@ class DocumentRepository implements ObjectRepository
     /**
      * Initializes a new <tt>DocumentRepository</tt>.
      *
-     * @param DocumentManagerInterface $dm            The DocumentManager to use.
-     * @param ClassMetadata            $classMetadata The class descriptor.
+     * @param DocumentManagerInterface $dm    The DocumentManager to use.
+     * @param ClassMetadata            $class The class descriptor.
      */
     public function __construct($dm, ClassMetadata $class)
     {
@@ -250,7 +251,7 @@ class DocumentRepository implements ObjectRepository
     }
 
     /**
-     * @return \Doctrine\ODM\PHPCR\Mapping\ClassMetadata
+     * @return ClassMetadata
      */
     public function getClassMetadata()
     {
@@ -335,7 +336,7 @@ class DocumentRepository implements ObjectRepository
      *
      * @param string $alias name of the alias to use, defaults to 'a'
      *
-     * @return \Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder
+     * @return QueryBuilder
      */
     public function createQueryBuilder($alias)
     {

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -671,7 +671,7 @@ class ClassMetadata implements ClassMetadataInterface
     public function setVersioned($versionable)
     {
         if ($versionable && !in_array($versionable, self::$validVersionableAnnotations)) {
-            throw new MappingException("Invalid value in '{$this->name}' for the versionable annotation: '{$versionable}'");
+            throw new MappingException("Invalid value in \"{$this->name}\" for the versionable annotation: \"{$versionable}\"");
         }
         $this->versionable = $versionable;
     }
@@ -965,11 +965,11 @@ class ClassMetadata implements ClassMetadataInterface
         }
 
         if (empty($mapping['fieldName'])) {
-            throw new MappingException("Mapping a property requires to specify the field name in '{$this->name}'.");
+            throw new MappingException("Mapping a property requires to specify the field name in \"{$this->name}\".");
         }
 
         if (!is_string($mapping['fieldName'])) {
-            throw new MappingException("Field name must be of type string in '{$this->name}'.");
+            throw new MappingException("Field name must be of type string in \"{$this->name}\".");
         }
 
         if (!$this->reflClass->hasProperty($mapping['fieldName'])) {
@@ -1434,7 +1434,7 @@ class ClassMetadata implements ClassMetadataInterface
     public function getAssociationTargetClass($fieldName)
     {
         if (empty($this->mappings[$fieldName]['targetDocument'])) {
-            throw new MappingException("Association name expected, '$fieldName' is not an association in '{$this->name}'.");
+            throw new MappingException("Association name expected, \"$fieldName\" is not an association in \"{$this->name}\".");
         }
 
         return $this->mappings[$fieldName]['targetDocument'];
@@ -1445,7 +1445,7 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function getAssociationMappedByTargetField($assocName)
     {
-        throw new BadMethodCallException(__METHOD__."  not yet implemented in '{$this->name}'");
+        throw new BadMethodCallException(__METHOD__."  not yet implemented in \"{$this->name}\"");
     }
 
     /**
@@ -1453,7 +1453,7 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function isAssociationInverseSide($assocName)
     {
-        throw new BadMethodCallException(__METHOD__."  not yet implemented in '{$this->name}'");
+        throw new BadMethodCallException(__METHOD__."  not yet implemented in \"{$this->name}\"");
     }
 
     /**
@@ -1512,15 +1512,15 @@ class ClassMetadata implements ClassMetadataInterface
 
             if (isset($parentMapping['type'])) {
                 if (isset($mapping['type']) && $parentMapping['type'] !== $mapping['type']) {
-                    throw new MappingException("You cannot change the type of a field via inheritance in '{$this->name}'");
+                    throw new MappingException("You cannot change the type of a field via inheritance in \"{$this->name}\"");
                 }
                 $mapping['type'] = $parentMapping['type'];
             }
         }
 
-        if (isset($mapping['property']) && $mapping['property'] == 'jcr:uuid') {
+        if (isset($mapping['property']) && $mapping['property'] === 'jcr:uuid') {
             if (null !== $this->uuidFieldName) {
-                throw new MappingException("You can only designate a single 'Uuid' field in '{$this->name}'");
+                throw new MappingException("You can only designate a single \"Uuid\" field in \"{$this->name}\"");
             }
 
             $this->uuidFieldName = $mapping['fieldName'];

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -768,7 +768,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * Gets the ReflectionProperties of the mapped class.
      *
-     * @return array An array of \ReflectionProperty instances.
+     * @return \ReflectionProperty[]
      */
     public function getReflectionProperties()
     {

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -649,7 +649,10 @@ class ClassMetadata implements ClassMetadataInterface
     public function addLifecycleCallback($callback, $event)
     {
         if (!isset(Event::$lifecycleCallbacks[$event])) {
-            throw new MappingException("$event is not a valid lifecycle callback event");
+            throw new MappingException(sprintf(
+                '%s is not a valid lifecycle callback event',
+                $event
+            ));
         }
         $this->lifecycleCallbacks[$event][] = $callback;
     }
@@ -671,7 +674,11 @@ class ClassMetadata implements ClassMetadataInterface
     public function setVersioned($versionable)
     {
         if ($versionable && !in_array($versionable, self::$validVersionableAnnotations)) {
-            throw new MappingException("Invalid value in \"{$this->name}\" for the versionable annotation: \"{$versionable}\"");
+            throw new MappingException(sprintf(
+                'Invalid value in "%s" for the versionable annotation: "%s"',
+                $this->name,
+                $versionable
+            ));
         }
         $this->versionable = $versionable;
     }
@@ -855,9 +862,12 @@ class ClassMetadata implements ClassMetadataInterface
         $mapping['type'] = 'children';
         $mapping = $this->validateAndCompleteFieldMapping($mapping, $inherited, false, false);
         if (!is_numeric($mapping['fetchDepth'])) {
-            throw new MappingException(
-                sprintf('fetchDepth option must be a numerical value (is "%s") on children mapping "%s" of document %s', $mapping['fetchDepth'], $mapping['fieldName'], $this->name)
-            );
+            throw new MappingException(sprintf(
+                'fetchDepth option must be a numerical value (is "%s") on children mapping "%s" of document %s',
+                $mapping['fetchDepth'],
+                $mapping['fieldName'],
+                $this->name
+            ));
         }
         unset($mapping['property']);
         $this->childrenMappings[$mapping['fieldName']] = $mapping['fieldName'];
@@ -889,11 +899,18 @@ class ClassMetadata implements ClassMetadataInterface
     public function mapMixedReferrers(array $mapping, ClassMetadata $inherited = null)
     {
         if (!(array_key_exists('referenceType', $mapping) && in_array($mapping['referenceType'], array(null, "weak", "hard")))) {
-            throw new MappingException("You have to specify a 'referenceType' for the '" . $this->name . "' mapping which must be null, 'weak' or 'hard': ".$mapping['referenceType']);
+            throw new MappingException(sprintf(
+                'You have to specify a "referenceType" for the "%s" mapping which must be null, "weak" or "hard": %s',
+                $this->name,
+                $mapping['referenceType']
+            ));
         }
 
         if (isset($mapping['referencedBy'])) {
-            throw new MappingException('MixedReferrers has no referredBy attribute, use Referrers for this: ' . $mapping['fieldName']);
+            throw new MappingException(sprintf(
+                'MixedReferrers has no referredBy attribute, use Referrers for this: "%s"',
+                $mapping['fieldName']
+            ));
         }
         if (empty($mapping['cascade'])) {
             $mapping['cascade'] = null;
@@ -965,11 +982,17 @@ class ClassMetadata implements ClassMetadataInterface
         }
 
         if (empty($mapping['fieldName'])) {
-            throw new MappingException("Mapping a property requires to specify the field name in \"{$this->name}\".");
+            throw new MappingException(sprintf(
+                'Mapping a property requires to specify the field name in "%s".',
+                $this->name
+            ));
         }
 
         if (!is_string($mapping['fieldName'])) {
-            throw new MappingException("Field name must be of type string in \"{$this->name}\".");
+            throw new MappingException(sprintf(
+                'Field name must be of type string in "%s".',
+                $this->name
+            ));
         }
 
         if (!$this->reflClass->hasProperty($mapping['fieldName'])) {
@@ -1036,7 +1059,11 @@ class ClassMetadata implements ClassMetadataInterface
         if (empty($mapping['strategy'])) {
             $mapping['strategy'] = 'weak';
         } elseif (!in_array($mapping['strategy'], array(null, 'weak', 'hard', 'path'))) {
-            throw new MappingException("The attribute 'strategy' for the '" . $this->name . "' association has to be either a null, 'weak', 'hard' or 'path': ".$mapping['strategy']);
+            throw new MappingException(sprintf(
+                'The attribute "strategy" for the "%s" association has to be either a null, "weak", "hard" or "path": "%s"',
+                $this->name,
+                $mapping['strategy']
+            ));
         }
         if (empty($mapping['cascade'])) {
             $mapping['cascade'] = 0;
@@ -1075,34 +1102,59 @@ class ClassMetadata implements ClassMetadataInterface
         }
 
         if (!empty($this->versionNameField) && !$this->versionable) {
-            throw new MappingException(sprintf("You cannot use the @VersionName annotation on the non-versionable document %s (field = %s)", $this->name, $this->versionNameField));
+            throw new MappingException(sprintf(
+                'You cannot use the @VersionName annotation on the non-versionable document %s (field = %s)',
+                $this->name,
+                $this->versionNameField
+            ));
         }
 
         if (!empty($this->versionCreatedField) && !$this->versionable) {
-            throw new MappingException(sprintf("You cannot use the @VersionCreated annotation on the non-versionable document %s (field = %s)", $this->name, $this->versionCreatedField));
+            throw new MappingException(sprintf(
+                'You cannot use the @VersionCreated annotation on the non-versionable document %s (field = %s)',
+                $this->name,
+                $this->versionCreatedField
+            ));
         }
 
         if (count($this->translatableFields)) {
             if (!isset($this->localeMapping)) {
-                throw new MappingException("You must define a locale mapping for translatable document '".$this->name."'");
+                throw new MappingException(sprintf(
+                    'You must define a locale mapping for translatable document "%s"',
+                    $this->name
+                ));
             }
         }
 
         // we allow mixed referrers on non-referenceable documents. maybe the mix:referenceable is just not mapped
         if (count($this->referrersMappings)) {
             if (!$this->referenceable) {
-                throw new MappingException('You can not have referrers mapped on document "'.$this->name.'" as the document is not referenceable');
+                throw new MappingException(sprintf(
+                    'You can not have referrers mapped on document "%s" as the document is not referenceable',
+                    $this->name
+                ));
             }
 
             foreach ($this->referrersMappings as $referrerName) {
                 $mapping = $this->mappings[$referrerName];
                 // only a santiy check with reflection. otherwise we could run into endless loops
                 if (!ClassLoader::classExists($mapping['referringDocument'])) {
-                    throw new MappingException(sprintf('Invalid referrer mapping on document "%s" for field "%s": The referringDocument class "%s" does not exist', $this->name, $mapping['fieldName'], $mapping['referringDocument']));
+                    throw new MappingException(sprintf(
+                        'Invalid referrer mapping on document "%s" for field "%s": The referringDocument class "%s" does not exist',
+                        $this->name,
+                        $mapping['fieldName'],
+                        $mapping['referringDocument']
+                    ));
                 }
                 $reflection = new ReflectionClass($mapping['referringDocument']);
                 if (! $reflection->hasProperty($mapping['referencedBy'])) {
-                    throw new MappingException(sprintf('Invalid referrer mapping on document "%s" for field "%s": The referringDocument "%s" has no property "%s"', $this->name, $mapping['fieldName'], $mapping['referringDocument'], $mapping['referencedBy']));
+                    throw new MappingException(sprintf(
+                        'Invalid referrer mapping on document "%s" for field "%s": The referringDocument "%s" has no property "%s"',
+                        $this->name,
+                        $mapping['fieldName'],
+                        $mapping['referringDocument'],
+                        $mapping['referencedBy']
+                    ));
                 }
             }
         }
@@ -1134,7 +1186,10 @@ class ClassMetadata implements ClassMetadataInterface
             return;
         }
 
-        throw new MappingException(sprintf('No id generator could be determined in "%s". Either map a parent and a nodename field and add values to them, or map the id field and configure a mapping strategy', $this->name));
+        throw new MappingException(sprintf(
+            'No id generator could be determined in "%s". Either map a parent and a nodename field and add values to them, or map the id field and configure a mapping strategy',
+            $this->name
+        ));
     }
 
     public function mapManyToOne($mapping, ClassMetadata $inherited = null)
@@ -1434,7 +1489,11 @@ class ClassMetadata implements ClassMetadataInterface
     public function getAssociationTargetClass($fieldName)
     {
         if (empty($this->mappings[$fieldName]['targetDocument'])) {
-            throw new MappingException("Association name expected, \"$fieldName\" is not an association in \"{$this->name}\".");
+            throw new MappingException(sprintf(
+                'Association name expected, "%s" is not an association in "%s".',
+                $fieldName,
+                $this->name
+            ));
         }
 
         return $this->mappings[$fieldName]['targetDocument'];
@@ -1445,7 +1504,11 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function getAssociationMappedByTargetField($assocName)
     {
-        throw new BadMethodCallException(__METHOD__."  not yet implemented in \"{$this->name}\"");
+        throw new BadMethodCallException(sprintf(
+            '%s not yet implemented in "%s"',
+            __METHOD__,
+            $this->name
+        ));
     }
 
     /**
@@ -1453,7 +1516,11 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function isAssociationInverseSide($assocName)
     {
-        throw new BadMethodCallException(__METHOD__."  not yet implemented in \"{$this->name}\"");
+        throw new BadMethodCallException(sprintf(
+            '%s not yet implemented in "%s"',
+            __METHOD__,
+            $this->name
+        ));
     }
 
     /**
@@ -1512,7 +1579,10 @@ class ClassMetadata implements ClassMetadataInterface
 
             if (isset($parentMapping['type'])) {
                 if (isset($mapping['type']) && $parentMapping['type'] !== $mapping['type']) {
-                    throw new MappingException("You cannot change the type of a field via inheritance in \"{$this->name}\"");
+                    throw new MappingException(sprintf(
+                        'You cannot change the type of a field via inheritance in "%s"',
+                        $this->name
+                    ));
                 }
                 $mapping['type'] = $parentMapping['type'];
             }
@@ -1520,7 +1590,10 @@ class ClassMetadata implements ClassMetadataInterface
 
         if (isset($mapping['property']) && $mapping['property'] === 'jcr:uuid') {
             if (null !== $this->uuidFieldName) {
-                throw new MappingException("You can only designate a single \"Uuid\" field in \"{$this->name}\"");
+                throw new MappingException(sprintf(
+                    'You can only designate a single "Uuid" field in "%s"',
+                    $this->name
+                ));
             }
 
             $this->uuidFieldName = $mapping['fieldName'];

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ODM\PHPCR\Mapping;
 
+use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
 use Doctrine\Common\Persistence\Mapping\ReflectionService;
@@ -52,12 +54,12 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      *  The used metadata driver.
      *
-     * @var \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver
+     * @var MappingDriver
      */
     private $driver;
 
     /**
-     * @var \Doctrine\Common\EventManager
+     * @var EventManager
      */
     private $evm;
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
@@ -19,14 +19,15 @@
 
 namespace Doctrine\ODM\PHPCR\Mapping\Driver;
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver as AbstractAnnotationDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ODM\PHPCR\Event;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as ODM;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\Annotations\Document;
+use Doctrine\ODM\PHPCR\Mapping\Annotations\MappedSuperclass;
 
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.
@@ -47,16 +48,17 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
      * Document annotation classes, ordered by precedence.
      */
     protected $entityAnnotationClasses = array(
-        'Doctrine\\ODM\\PHPCR\\Mapping\\Annotations\\Document' => 0,
-        'Doctrine\\ODM\\PHPCR\\Mapping\\Annotations\\MappedSuperclass' => 1,
+        Document::class => 0,
+        MappedSuperclass::class => 1,
     );
 
     /**
      * {@inheritdoc}
+     *
+     * @param PhpcrClassMetadata $metadata
      */
     public function loadMetadataForClass($className, ClassMetadata $metadata)
     {
-        /** @var $metadata \Doctrine\ODM\PHPCR\Mapping\ClassMetadata */
         $reflClass = $metadata->getReflectionClass();
 
         $documentAnnots = array();

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
@@ -21,6 +21,7 @@ namespace Doctrine\ODM\PHPCR\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\Common\Persistence\Mapping\MappingException as DoctrineMappingException;
 use SimpleXmlElement;
@@ -48,10 +49,11 @@ class XmlDriver extends FileDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @param PhpcrClassMetadata $class
      */
     public function loadMetadataForClass($className, ClassMetadata $class)
     {
-        /** @var $class \Doctrine\ODM\PHPCR\Mapping\ClassMetadata */
         try {
             $xmlRoot = $this->getElement($className);
         } catch (DoctrineMappingException $e) {
@@ -282,9 +284,13 @@ class XmlDriver extends FileDriver
         $class->validateClassMapping();
     }
 
-    private function addReferenceMapping(ClassMetadata $class, $reference, $type)
+    /**
+     * @param PhpcrClassMetadata $class
+     * @param \SimpleXMLElement  $reference
+     * @param string             $type
+     */
+    private function addReferenceMapping(PhpcrClassMetadata $class, $reference, $type)
     {
-        /** @var $class \Doctrine\ODM\PHPCR\Mapping\ClassMetadata */
         $attributes = (array) $reference->attributes();
         $mapping = $attributes["@attributes"];
         $mapping['strategy'] = isset($mapping['strategy']) ? strtolower($mapping['strategy']) : null;

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
@@ -22,6 +22,7 @@ namespace Doctrine\ODM\PHPCR\Mapping\Driver;
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\Common\Persistence\Mapping\MappingException as DoctrineMappingException;
 use Symfony\Component\Yaml\Yaml;
@@ -52,7 +53,7 @@ class YamlDriver extends FileDriver
      */
     public function loadMetadataForClass($className, ClassMetadata $class)
     {
-        /** @var $class \Doctrine\ODM\PHPCR\Mapping\ClassMetadata */
+        /** @var PhpcrClassMetadata $class */
         try {
             $element = $this->getElement($className);
         } catch (DoctrineMappingException $e) {
@@ -268,7 +269,7 @@ class YamlDriver extends FileDriver
 
     private function addMappingFromReference(ClassMetadata $class, $fieldName, $reference, $type)
     {
-        /** @var $class \Doctrine\ODM\PHPCR\Mapping\ClassMetadata */
+        /** @var PhpcrClassMetadata $class */
         $mapping = array_merge(array('fieldName' => $fieldName), $reference);
 
         $mapping['cascade'] = (isset($reference['cascade'])) ? $this->getCascadeMode($reference['cascade']) : 0;

--- a/lib/Doctrine/ODM/PHPCR/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Proxy/ProxyFactory.php
@@ -29,6 +29,7 @@ use Doctrine\Common\Proxy\ProxyDefinition;
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
 use ReflectionProperty;
 
 /**
@@ -113,7 +114,7 @@ class ProxyFactory extends AbstractProxyFactory
     /**
      * Generates a closure capable of initializing a proxy
      *
-     * @param \Doctrine\ODM\PHPCR\Mapping\ClassMetadata $classMetadata
+     * @param PhpcrClassMetadata $classMetadata
      *
      * @return \Closure
      */
@@ -169,12 +170,12 @@ class ProxyFactory extends AbstractProxyFactory
     /**
      * Generates a closure capable of finalizing a cloned proxy
      *
-     * @param \Doctrine\ODM\PHPCR\Mapping\ClassMetadata $classMetadata
-     * @param \ReflectionProperty                       $reflectionId
+     * @param PhpcrClassMetadata  $classMetadata
+     * @param \ReflectionProperty $reflectionId
      *
      * @return \Closure
      *
-     * @throws \Doctrine\Common\Proxy\Exception\UnexpectedValueException
+     * @throws UnexpectedValueException
      */
     private function createCloner(ClassMetadata $classMetadata, ReflectionProperty $reflectionId = null)
     {

--- a/lib/Doctrine/ODM/PHPCR/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Repository/DefaultRepositoryFactory.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ODM\PHPCR\Repository;
 
+use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 
 /**
@@ -60,7 +61,7 @@ class DefaultRepositoryFactory implements RepositoryFactory
      * @param DocumentManagerInterface  $dm             The DocumentManager instance.
      * @param string                    $documentName   The name of the document.
      *
-     * @return \Doctrine\Common\Persistence\ObjectRepository
+     * @return ObjectRepository
      */
     protected function createRepository(DocumentManagerInterface $dm, $documentName)
     {

--- a/lib/Doctrine/ODM/PHPCR/Repository/RepositoryFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Repository/RepositoryFactory.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ODM\PHPCR\Repository;
 
+use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 
 /**
@@ -34,7 +35,7 @@ interface RepositoryFactory
      * @param DocumentManagerInterface  $dm             The DocumentManager instance.
      * @param string                    $documentName   The name of the document.
      *
-     * @return \Doctrine\Common\Persistence\ObjectRepository
+     * @return ObjectRepository
      */
     public function getRepository(DocumentManagerInterface $dm, $documentName);
 }

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/DumpQueryBuilderReferenceCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/DumpQueryBuilderReferenceCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
 
 /**
  * Command to generate the official query builder reference.
@@ -290,7 +291,7 @@ HERE
 
                 $cardinalityMap = $inst->getCardinalityMap();
                 $doc = $this->parseDocComment($refl->getDocComment(), 0);
-                $isLeaf = $refl->isSubclassOf('Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode');
+                $isLeaf = $refl->isSubclassOf(AbstractLeafNode::class);
 
                 $parentName = null;
                 $inheritedMethods = array();

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/RegisterSystemNodeTypesCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/RegisterSystemNodeTypesCommand.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ODM\PHPCR\Tools\Console\Command;
 
+use PHPCR\SessionInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -53,7 +54,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var $session \PHPCR\SessionInterface */
+        /** @var SessionInterface $session */
         $session = $this->getHelper('phpcr')->getSession();
         $registrator = new NodeTypeRegistrator();
 

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -20,6 +20,7 @@
 namespace Doctrine\ODM\PHPCR;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\Event\OnClearEventArgs;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Common\Persistence\Event\ManagerEventArgs;
@@ -46,6 +47,7 @@ use PHPCR\RepositoryInterface;
 use PHPCR\PropertyType;
 use PHPCR\NodeInterface;
 use PHPCR\RepositoryException;
+use PHPCR\SessionInterface;
 use PHPCR\UnsupportedRepositoryOperationException;
 use PHPCR\PathNotFoundException;
 use PHPCR\ItemNotFoundException;
@@ -54,7 +56,8 @@ use PHPCR\Util\UUIDHelper;
 use PHPCR\Util\PathHelper;
 use PHPCR\Util\NodeHelper;
 use Jackalope\Session as JackalopeSession;
-use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
+use PHPCR\Version\VersionHistoryInterface;
+use PHPCR\Version\VersionInterface;
 
 /**
  * Unit of work class
@@ -101,13 +104,13 @@ class UnitOfWork
 
     /**
      * Track version history of the version documents we create, indexed by spl_object_hash
-     * @var \PHPCR\Version\VersionHistoryInterface[]
+     * @var VersionHistoryInterface[]
      */
     private $documentHistory = array();
 
     /**
      * Track version objects of the version documents we create, indexed by spl_object_hash
-     * @var \PHPCR\Version\VersionInterface[]
+     * @var VersionInterface[]
      */
     private $documentVersion = array();
 
@@ -222,7 +225,7 @@ class UnitOfWork
     private $uuidGenerator;
 
     /**
-     * \PHPCR\SessionInterface
+     * @var SessionInterface
      */
     private $session;
 
@@ -232,7 +235,7 @@ class UnitOfWork
     private $eventListenersInvoker;
 
     /**
-     * @var \Doctrine\Common\EventManager
+     * @var EventManager
      */
     private $eventManager;
 
@@ -2976,7 +2979,7 @@ class UnitOfWork
 
         $result = array();
         foreach ($versions as $version) {
-            /** @var $version \PHPCR\Version\VersionInterface */
+            /** @var $version VersionInterface */
             $result[$version->getName()] = array(
                 'name' => $version->getName(),
                 'labels' => array(),

--- a/tests/Doctrine/Tests/Models/References/RefCascadeManyTestObj.php
+++ b/tests/Doctrine/Tests/Models/References/RefCascadeManyTestObj.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Models\References;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
@@ -18,6 +19,6 @@ class RefCascadeManyTestObj
 
     public function __construct()
     {
-        $this->references = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->references = new ArrayCollection();
     }
 }

--- a/tests/Doctrine/Tests/Models/References/RefManyTestObj.php
+++ b/tests/Doctrine/Tests/Models/References/RefManyTestObj.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Models\References;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
@@ -16,6 +17,6 @@ class RefManyTestObj
 
     public function __construct()
     {
-        $this->references = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->references = new ArrayCollection();
     }
 }

--- a/tests/Doctrine/Tests/Models/References/RefManyTestObjPathStrategy.php
+++ b/tests/Doctrine/Tests/Models/References/RefManyTestObjPathStrategy.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Models\References;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
@@ -16,6 +17,6 @@ class RefManyTestObjPathStrategy
 
     public function __construct()
     {
-        $this->references = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->references = new ArrayCollection();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/ConfigurationTest.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\ODM\PHPCR;
+use Doctrine\ODM\PHPCR\Configuration;
+use Doctrine\ODM\PHPCR\PHPCRException;
 
 /**
  * @group unit
@@ -8,13 +10,13 @@ namespace Doctrine\Tests\ODM\PHPCR;
 class ConfigurationTest extends PHPCRTestCase
 {
     /**
-     * @covers Doctrine\ODM\PHPCR\Configuration::addDocumentNamespace
-     * @covers Doctrine\ODM\PHPCR\Configuration::getDocumentNamespace
-     * @covers Doctrine\ODM\PHPCR\Configuration::setDocumentNamespaces
+     * @covers \Doctrine\ODM\PHPCR\Configuration::addDocumentNamespace
+     * @covers \Doctrine\ODM\PHPCR\Configuration::getDocumentNamespace
+     * @covers \Doctrine\ODM\PHPCR\Configuration::setDocumentNamespaces
      */
     public function testDocumentNamespace()
     {
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
+        $config = new Configuration();
 
         $config->addDocumentNamespace('foo', 'Documents\Bar');
         $this->assertEquals('Documents\Bar', $config->getDocumentNamespace('foo'));
@@ -24,7 +26,7 @@ class ConfigurationTest extends PHPCRTestCase
         $config->setDocumentNamespaces(array('foo' => 'Documents\Bar'));
         $this->assertEquals('Documents\Bar', $config->getDocumentNamespace('foo'));
 
-        $this->setExpectedException('Doctrine\ODM\PHPCR\PHPCRException');
+        $this->expectException(PHPCRException::class);
         $config->getDocumentNamespace('bar');
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/ConfigurationTest.php
@@ -1,6 +1,6 @@
 <?php
-
 namespace Doctrine\Tests\ODM\PHPCR;
+
 use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\PHPCRException;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/ConfigurationTest.php
@@ -21,7 +21,7 @@ class ConfigurationTest extends PHPCRTestCase
         $config->addDocumentNamespace('foo', 'Documents\Bar');
         $this->assertEquals('Documents\Bar', $config->getDocumentNamespace('foo'));
 
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
+        $config = new Configuration();
 
         $config->setDocumentNamespaces(array('foo' => 'Documents\Bar'));
         $this->assertEquals('Documents\Bar', $config->getDocumentNamespace('foo'));

--- a/tests/Doctrine/Tests/ODM/PHPCR/Decorator/DocumentManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Decorator/DocumentManagerDecoratorTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Decorator;
 use Doctrine\ODM\PHPCR\Decorator\DocumentManagerDecorator;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 
 /**
  * @group unit
@@ -13,15 +14,15 @@ class DocumentManagerDecoratorTest extends PHPCRTestCase
 {
     public function testCheckIfAllPublicMethodsAreDecorated()
     {
-        $dmMethods = get_class_methods('Doctrine\ODM\PHPCR\DocumentManager');
+        $dmMethods = get_class_methods(DocumentManager::class);
         $dmMethods = array_diff($dmMethods, array('__construct', 'create'));
         sort($dmMethods);
 
-        $dmiMethods = get_class_methods('Doctrine\ODM\PHPCR\DocumentManagerInterface');
+        $dmiMethods = get_class_methods(DocumentManagerInterface::class);
         $dmiMethods = array_diff($dmiMethods, array('__construct'));
         sort($dmiMethods);
 
-        $dmdMethods = get_class_methods('\Doctrine\Tests\ODM\PHPCR\Decorator\OwnDocumentManager');
+        $dmdMethods = get_class_methods(OwnDocumentManager::class);
         $dmdMethods = array_diff($dmdMethods, array('__construct'));
         sort($dmdMethods);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentClassMapperTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentClassMapperTest.php
@@ -16,7 +16,7 @@ use Jackalope\Property;
 
 class DocumentClassMapperTest extends Testcase
 {
-    const CLASS_GENERIC = 'Doctrine\ODM\PHPCR\Document\Generic';
+    const CLASS_GENERIC = Generic::class;
     const CLASS_TEST_1 = 'Test\Class1';
     const CLASS_TEST_2 = 'Test\Class2';
     const CLASS_TEST_3 = 'Test\Class3';
@@ -59,7 +59,7 @@ class DocumentClassMapperTest extends Testcase
         $className = $this->mapper->getClassName($this->dm, $this->node);
 
         $this->assertEquals(
-            'Doctrine\ODM\PHPCR\Document\Generic',
+            Generic::class,
             $className
         );
     }
@@ -69,10 +69,10 @@ class DocumentClassMapperTest extends Testcase
      */
     public function testGetClassNameOnlySpecified()
     {
-        $className = $this->mapper->getClassName($this->dm, $this->node, 'Doctrine\Tests\ODM\PHPCR\BaseClass');
+        $className = $this->mapper->getClassName($this->dm, $this->node, BaseClass::class);
 
         $this->assertEquals(
-            'Doctrine\Tests\ODM\PHPCR\BaseClass',
+            BaseClass::class,
             $className
         );
     }
@@ -103,35 +103,35 @@ class DocumentClassMapperTest extends Testcase
 
     public function testGetClassNameNull()
     {
-        $this->mockNodeHasClass('Doctrine\Tests\ODM\PHPCR\BaseClass');
+        $this->mockNodeHasClass(BaseClass::class);
         $className = $this->mapper->getClassName($this->dm, $this->node);
 
         $this->assertEquals(
-            'Doctrine\Tests\ODM\PHPCR\BaseClass',
+            BaseClass::class,
             $className
         );
     }
 
     public function testGetClassNameMatch()
     {
-        $this->mockNodeHasClass('Doctrine\Tests\ODM\PHPCR\BaseClass');
+        $this->mockNodeHasClass(BaseClass::class);
 
-        $className = $this->mapper->getClassName($this->dm, $this->node, 'Doctrine\Tests\ODM\PHPCR\BaseClass');
+        $className = $this->mapper->getClassName($this->dm, $this->node, BaseClass::class);
 
         $this->assertEquals(
-            'Doctrine\Tests\ODM\PHPCR\BaseClass',
+            BaseClass::class,
             $className
         );
     }
 
     public function testGetClassNameExtend()
     {
-        $this->mockNodeHasClass('Doctrine\Tests\ODM\PHPCR\ExtendingClass');
+        $this->mockNodeHasClass(ExtendingClass::class);
 
-        $className = $this->mapper->getClassName($this->dm, $this->node, 'Doctrine\Tests\ODM\PHPCR\BaseClass');
+        $className = $this->mapper->getClassName($this->dm, $this->node, BaseClass::class);
 
         $this->assertEquals(
-            'Doctrine\Tests\ODM\PHPCR\ExtendingClass',
+            ExtendingClass::class,
             $className
         );
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR;
 
+use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\PHPCRException;
@@ -9,6 +10,11 @@ use PHPCR\SessionInterface;
 use PHPCR\Transaction\UserTransactionInterface;
 use PHPCR\UnsupportedRepositoryOperationException;
 use PHPCR\WorkspaceInterface;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\PHPCR\DocumentRepository;
+use PHPCR\Query\QueryManagerInterface;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
+use PHPCR\Query\QueryInterface;
 
 /**
  * @group unit
@@ -23,7 +29,7 @@ class DocumentManagerTest extends PHPCRTestCase
         $fakeUuid = \PHPCR\Util\UUIDHelper::generateUUID();
         $session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNodeByIdentifier'));
         $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new \PHPCR\ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
+        $config = new Configuration();
 
         $dm = DocumentManager::create($session, $config);
 
@@ -40,7 +46,7 @@ class DocumentManagerTest extends PHPCRTestCase
         $fakeUuid = \PHPCR\Util\UUIDHelper::generateUUID();
         $session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNodeByIdentifier'));
         $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new \PHPCR\ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
+        $config = new Configuration();
 
         $dm = DocumentManager::create($session, $config);
 
@@ -50,53 +56,53 @@ class DocumentManagerTest extends PHPCRTestCase
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::create
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::getConfiguration
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::create
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::getConfiguration
      */
     public function testNewInstanceFromConfiguration()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
+        $session = $this->createMock(SessionInterface::class);
+        $config = new Configuration();
 
         $dm = DocumentManager::create($session, $config);
 
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\DocumentManager', $dm);
+        $this->assertInstanceOf(DocumentManager::class, $dm);
         $this->assertSame($config, $dm->getConfiguration());
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::getMetadataFactory
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::getMetadataFactory
      */
     public function testGetMetadataFactory()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $session = $this->createMock(SessionInterface::class);
 
         $dm = DocumentManager::create($session);
 
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory', $dm->getMetadataFactory());
+        $this->assertInstanceOf(ClassMetadataFactory::class, $dm->getMetadataFactory());
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::getClassMetadata
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::getClassMetadata
      */
     public function testGetClassMetadataFor()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $session = $this->createMock(SessionInterface::class);
 
         $dm = DocumentManager::create($session);
 
         $cmf = $dm->getMetadataFactory();
-        $cmf->setMetadataFor('stdClass', new \Doctrine\ODM\PHPCR\Mapping\ClassMetadata('stdClass'));
+        $cmf->setMetadataFor('stdClass', new ClassMetadata('stdClass'));
 
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Mapping\ClassMetadata', $dm->getClassMetadata('stdClass'));
+        $this->assertInstanceOf(ClassMetadata::class, $dm->getClassMetadata('stdClass'));
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::contains
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::contains
      */
     public function testContains()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $session = $this->createMock(SessionInterface::class);
 
         $dm = DocumentManager::create($session);
 
@@ -112,27 +118,27 @@ class DocumentManagerTest extends PHPCRTestCase
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::getRepository
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::getRepository
      */
     public function testGetRepository()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $session = $this->createMock(SessionInterface::class);
 
         $dm = new DocumentManagerGetClassMetadata($session);
 
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\DocumentRepository', $dm->getRepository('foo'));
+        $this->assertInstanceOf(DocumentRepository::class, $dm->getRepository('foo'));
         $this->assertInstanceOf('stdClass', $dm->getRepository('foo2'));
 
         // call again to test the cache
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\DocumentRepository', $dm->getRepository('foo'));
+        $this->assertInstanceOf(DocumentRepository::class, $dm->getRepository('foo'));
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::escapeFullText
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::escapeFullText
      */
     public function testEscapeFullText()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $session = $this->createMock(SessionInterface::class);
 
         $dm = DocumentManager::create($session);
 
@@ -145,11 +151,11 @@ class DocumentManagerTest extends PHPCRTestCase
      */
     public function testCreateQueryBuilder()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
-        $workspace = $this->getMockBuilder('PHPCR\WorkspaceInterface')->getMock();
-        $queryManager = $this->getMockBuilder('PHPCR\Query\QueryManagerInterface')->getMock();
-        $qomf = $this->getMockBuilder('PHPCR\Query\QOM\QueryObjectModelFactoryInterface')->getMock();
-        $baseQuery = $this->getMockBuilder('PHPCR\Query\QueryInterface')->getMock();
+        $session = $this->createMock(SessionInterface::class);
+        $workspace = $this->createMock(WorkspaceInterface::class);
+        $queryManager = $this->createMock(QueryManagerInterface::class);
+        $qomf = $this->createMock(QueryObjectModelFactoryInterface::class);
+        $baseQuery = $this->createMock(QueryInterface::class);
 
         $session->expects($this->once())
             ->method('getWorkspace')
@@ -169,7 +175,7 @@ class DocumentManagerTest extends PHPCRTestCase
 
     public function testGetDocumentIdReturnsValueOfUnitOfWork()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $session = $this->createMock(SessionInterface::class);
 
         $dm = DocumentManager::create($session);
 
@@ -184,14 +190,13 @@ class DocumentManagerTest extends PHPCRTestCase
         $this->assertEquals('/foo', $dm->getDocumentId($obj));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testGetDocumentIdForNonManagedDocumentsReturnsNull()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        /** @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject $session */
+        $session = $this->createMock(SessionInterface::class);
         $dm = DocumentManager::create($session);
         $obj = new \stdClass;
+        $this->expectException(PHPCRException::class);
         $dm->getDocumentId($obj);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
@@ -6,15 +6,18 @@ use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\PHPCRException;
+use PHPCR\ItemNotFoundException;
 use PHPCR\SessionInterface;
 use PHPCR\Transaction\UserTransactionInterface;
 use PHPCR\UnsupportedRepositoryOperationException;
+use PHPCR\Util\UUIDHelper;
 use PHPCR\WorkspaceInterface;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use PHPCR\Query\QueryManagerInterface;
 use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Query\QueryInterface;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 
 /**
  * @group unit
@@ -22,13 +25,13 @@ use PHPCR\Query\QueryInterface;
 class DocumentManagerTest extends PHPCRTestCase
 {
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::find
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::find
      */
     public function testFind()
     {
-        $fakeUuid = \PHPCR\Util\UUIDHelper::generateUUID();
-        $session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNodeByIdentifier'));
-        $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new \PHPCR\ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
+        $fakeUuid = UUIDHelper::generateUUID();
+        $session = $this->getMockForAbstractClass(SessionInterface::class, array('getNodeByIdentifier'));
+        $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
         $config = new Configuration();
 
         $dm = DocumentManager::create($session, $config);
@@ -39,13 +42,13 @@ class DocumentManagerTest extends PHPCRTestCase
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\DocumentManager::findTranslation
+     * @covers \Doctrine\ODM\PHPCR\DocumentManager::findTranslation
      */
     public function testFindTranslation()
     {
-        $fakeUuid = \PHPCR\Util\UUIDHelper::generateUUID();
-        $session = $this->getMockForAbstractClass('PHPCR\SessionInterface', array('getNodeByIdentifier'));
-        $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new \PHPCR\ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
+        $fakeUuid = UUIDHelper::generateUUID();
+        $session = $this->getMockForAbstractClass(SessionInterface::class, array('getNodeByIdentifier'));
+        $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
         $config = new Configuration();
 
         $dm = DocumentManager::create($session, $config);
@@ -170,7 +173,7 @@ class DocumentManagerTest extends PHPCRTestCase
 
         $dm = DocumentManager::create($session);
         $qb = $dm->createQueryBuilder();
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder', $qb);
+        $this->assertInstanceOf(QueryBuilder::class, $qb);
     }
 
     public function testGetDocumentIdReturnsValueOfUnitOfWork()
@@ -212,7 +215,7 @@ class DocumentManagerGetClassMetadata extends DocumentManager
     public function getClassMetadata($class)
     {
         ++$this->callCount;
-        $metadata = new \Doctrine\ODM\PHPCR\Mapping\ClassMetadata('stdClass');
+        $metadata = new ClassMetadata('stdClass');
         switch ($this->callCount) {
             case '1':
                 break;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Event/MoveEventArgsTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Event/MoveEventArgsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event\MoveEventArgs;
 use PHPUnit\Framework\TestCase;
 
@@ -14,9 +15,7 @@ class MoveEventArgsTest extends TestCase
 
     public function setUp()
     {
-        $this->dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->dm = $this->createMock(DocumentManager::class);
         $this->object = new \stdClass;
 
         $this->eventArgs = new MoveEventArgs(

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -2,10 +2,12 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\DocumentRepository;
-use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
 use PHPCR\Util\UUIDHelper;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
@@ -14,10 +16,10 @@ use PHPCR\Util\NodeHelper;
 /**
  * @group functional
  */
-class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class BasicCrudTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -28,13 +30,13 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\User';
+        $this->type = User::class;
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->node = $this->resetFunctionalNode($this->dm);
 
@@ -89,7 +91,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $user = $this->node->addNode('userWithAlias');
         $user->setProperty('username', 'dbu');
         $user->setProperty('numbers', array(3, 1, 2));
-        $user->setProperty('phpcr:class', $this->type, \PHPCR\PropertyType::STRING);
+        $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
 
         $userWithAlias = $this->dm->find(null, '/functional/userWithAlias');
@@ -216,7 +218,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $userNew = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\User3', '/functional/test3');
+        $userNew = $this->dm->find(User3::class, '/functional/test3');
 
         $this->assertNotNull($userNew, "Have to hydrate user object!");
         $this->assertEquals($user->username, $userNew->username);
@@ -315,7 +317,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $userNew = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\User2', '/functional/user');
+        $userNew = $this->dm->find(User2::class, '/functional/user');
 
         $this->assertNotNull($userNew, "Have to hydrate user object!");
         $this->assertEquals($user->username, $userNew->username);
@@ -471,12 +473,12 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $userNew = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\User5', '/functional/test');
+        $userNew = $this->dm->find(User5::class, '/functional/test');
 
         $userNew->username = "test2";
         $this->dm->flush();
 
-        $userNew = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\User5', '/functional/test');
+        $userNew = $this->dm->find(User5::class, '/functional/test');
 
         $this->assertNotNull($userNew, "Have to hydrate user object!");
         $this->assertEquals('test2', $userNew->username);
@@ -496,7 +498,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $userNew = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\User6', '/functional/'.$user->nodename);
+        $userNew = $this->dm->find(User6::class, '/functional/'.$user->nodename);
         $this->assertEquals($userNew->nodename, $user->nodename);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
@@ -65,9 +66,6 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals($user->numbers, $userNew->numbers);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testInsertTwice()
     {
         $user = new User();
@@ -82,6 +80,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $user->username = "toast";
         $user->numbers = array(1, 2, 3);
         $user->id = '/functional/test';
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->persist($user);
     }
 
@@ -194,9 +193,6 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals($testUuid, $flushedUser->uuid);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\RuntimeException
-     */
     public function testBadUuidSetting()
     {
         $newUser = new UserWithUuid();
@@ -204,6 +200,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $newUser->id = '/functional/test';
         $newUser->uuid = 'bad-uuid';
 
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\RuntimeException::class);
         $this->dm->persist($newUser);
     }
 
@@ -345,9 +342,6 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals($user->username, $userNew->username);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testRemoveAndInsertBeforeFlush()
     {
         $this->dm->clear();
@@ -359,6 +353,7 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $user = new User2();
         $user->username = "test";
         $user->id = '/functional/user';
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->persist($user);
     }
 
@@ -604,8 +599,6 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     /**
      * Create a node with a bad name and explicitly persist it without
      * adding it to any parent's children collection.
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
      */
     public function testIllegalNodename()
     {
@@ -617,14 +610,13 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $user->parent = $functional;
         $this->dm->persist($user);
 
+        $this->expectException(IdException::class);
         $this->dm->flush();
     }
 
     /**
      * Retrieve an existing node and try to move it by assigning it
      * an illegal name.
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
      */
     public function testIllegalNodenameMove()
     {
@@ -638,6 +630,8 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $user->nodename = 'bad/name';
+
+        $this->expectException(IdException::class);
         $this->dm->flush();
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -612,7 +612,6 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->expectException(IdException::class);
         $this->expectExceptionMessage('Nodename property "nodename" of document "Doctrine\Tests\ODM\PHPCR\Functional\User5" contains the illegal PHPCR value "bad/name"');
         $this->dm->persist($user);
-
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -608,10 +608,11 @@ class BasicCrudTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $user->username = 'test';
         $user->nodename = 'bad/name';
         $user->parent = $functional;
-        $this->dm->persist($user);
 
         $this->expectException(IdException::class);
-        $this->dm->flush();
+        $this->expectExceptionMessage('Nodename property "nodename" of document "Doctrine\Tests\ODM\PHPCR\Functional\User5" contains the illegal PHPCR value "bad/name"');
+        $this->dm->persist($user);
+
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
@@ -5,6 +5,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\PHPCRException;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsArticlePerson;
+use Doctrine\Tests\Models\CMS\CmsUser;
 
 class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 {
@@ -38,7 +41,7 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $group2->name = "Test!";
         $group2->id = '/functional/group2';
 
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = "beberlei";
         $user->name = "Benjamin";
         $user->addGroup($group1);
@@ -58,7 +61,7 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
     public function testCascadePersistForManagedDocument()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = "beberlei";
         $user->name = "Benjamin";
         $this->dm->persist($user);
@@ -88,11 +91,11 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
     public function testCascadePersistSingleDocument()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = "beberlei";
         $user->name = "Benjamin";
 
-        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article = new CmsArticle();
         $article->text = "foo";
         $article->topic = "bar";
         $article->user = $user;
@@ -111,7 +114,7 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
     public function testCascadeManagedDocumentCollectionDuringFlush()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = "beberlei";
         $user->name = "Benjamin";
         $this->dm->persist($user);
@@ -142,14 +145,14 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
     public function testCascadeManagedDocumentReferenceDuringFlush()
     {
-        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article = new CmsArticle();
         $article->text = "foo";
         $article->topic = "bar";
         $article->id = '/functional/article';
 
         $this->dm->persist($article);
 
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = "beberlei";
         $user->name = "Benjamin";
         $article->user = $user;
@@ -165,12 +168,12 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
     public function testCascadeManagedDocumentReferrerDuringFlush()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = "dbu";
         $user->name = "David";
         $this->dm->persist($user);
 
-        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article = new CmsArticle();
         $article->text = "foo";
         $article->topic = "bar";
         $article->id = '/functional/article_referrer';
@@ -206,12 +209,12 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
      */
     public function testCascadeManagedDocumentReferrerDuringFlushArray()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = "dbu";
         $user->name = "David";
         $this->dm->persist($user);
 
-        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article = new CmsArticle();
         $article->text = "foo";
         $article->topic = "bar";
         $article->id = '/functional/article_referrer';
@@ -233,58 +236,54 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
     public function testCascadeReferenceArray()
     {
-        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article = new CmsArticle();
         $article->text = "foo";
         $article->topic = "bar";
         $article->id = '/functional/article';
         $article->user = array();
 
-        $this->dm->persist($article);
-
         $this->expectException(PHPCRException::class);
-        $this->dm->flush();
+        $this->expectExceptionMessage('Referenced document is not stored correctly in a reference-one property. Do not use array notation');
+        $this->dm->persist($article);
     }
 
     public function testCascadeReferenceNoObject()
     {
-        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
-        $article->text = "foo";
-        $article->topic = "bar";
+        $article = new CmsArticle();
+        $article->text = 'foo';
+        $article->topic = 'bar';
         $article->id = '/functional/article';
-        $article->user = "This is not an object";
-
-        $this->dm->persist($article);
+        $article->user = 'This is not an object';
 
         $this->expectException(PHPCRException::class);
-        $this->dm->flush();
+        $this->expectExceptionMessage('A reference field may only contain mapped documents, found <string> in field "user" of "Doctrine\Tests\Models\CMS\CmsArticle');
+        $this->dm->persist($article);
     }
 
     public function testCascadeReferenceManyNoArray()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
-        $user->name = "foo";
-        $user->username = "bar";
+        $user = new CmsUser();
+        $user->name = 'foo';
+        $user->username = 'bar';
         $user->id = '/functional/user';
         $user->groups = $this;
 
-        $this->dm->persist($user);
-
         $this->expectException(PHPCRException::class);
-        $this->dm->flush();
+        $this->expectExceptionMessage('Referenced documents are not stored correctly in a reference-many property. Use array notation or a (ReferenceMany)Collection');
+        $this->dm->persist($user);
     }
 
     public function testCascadeReferenceManyNoObject()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
-        $user->name = "foo";
-        $user->username = "bar";
+        $user = new CmsUser();
+        $user->name = 'foo';
+        $user->username = 'bar';
         $user->id = '/functional/user';
-        $user->groups = array("this is a bad idea");
-
-        $this->dm->persist($user);
+        $user->groups = array('this is a bad idea');
 
         $this->expectException(PHPCRException::class);
-        $this->dm->flush();
+        $this->expectExceptionMessage('A reference field may only contain mapped documents, found <string> in field "groups" of "Doctrine\Tests\Models\CMS\CmsUser');
+        $this->dm->persist($user);
     }
 
     /**
@@ -292,20 +291,20 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
      */
     public function testCascadeManagedDocumentReferrerMtoMDuringFlush()
     {
-        $article1 = new \Doctrine\Tests\Models\CMS\CmsArticle();
-        $article1->text = "foo";
-        $article1->topic = "bar";
+        $article1 = new CmsArticle();
+        $article1->text = 'foo';
+        $article1->topic = 'bar';
         $article1->id = '/functional/article_m2m_referrer_1';
         $this->dm->persist($article1);
 
-        $article2 = new \Doctrine\Tests\Models\CMS\CmsArticle();
-        $article2->text = "foo2";
-        $article2->topic = "bar2";
+        $article2 = new CmsArticle();
+        $article2->text = 'foo2';
+        $article2->topic = 'bar2';
         $article2->id = '/functional/article_m2m_referrer_2';
         $this->dm->persist($article2);
 
-        $superman = new \Doctrine\Tests\Models\CMS\CmsArticlePerson();
-        $superman->name = "superman";
+        $superman = new CmsArticlePerson();
+        $superman->name = 'superman';
 
         $this->dm->persist($superman);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
@@ -8,8 +8,10 @@ use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsArticlePerson;
 use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use Doctrine\Tests\Models\CMS\CmsGroup;
 
-class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class CascadePersistTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var DocumentManager
@@ -21,29 +23,29 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->node = $this->resetFunctionalNode($this->dm);
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $class = $this->dm->getClassMetadata(CmsUser::class);
         $class->mappings['groups']['cascade'] = ClassMetadata::CASCADE_PERSIST;
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
+        $class = $this->dm->getClassMetadata(CmsGroup::class);
         $class->mappings['users']['cascade'] = ClassMetadata::CASCADE_PERSIST;
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle');
+        $class = $this->dm->getClassMetadata(CmsArticle::class);
         $class->mappings['user']['cascade'] = ClassMetadata::CASCADE_PERSIST;
     }
 
     public function testCascadePersistCollection()
     {
-        $group1 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group1->name = "Test!";
+        $group1 = new CmsGroup();
+        $group1->name = 'Test!';
         $group1->id = '/functional/group1';
 
-        $group2 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group2->name = "Test!";
+        $group2 = new CmsGroup();
+        $group2->name = 'Test!';
         $group2->id = '/functional/group2';
 
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
         $user->addGroup($group1);
         $user->addGroup($group2);
 
@@ -55,24 +57,24 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
         $this->dm->clear();
 
-        $pUser = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', $user->id);
+        $pUser = $this->dm->find(CmsUser::class, $user->id);
         $this->assertEquals(2, count($pUser->groups));
     }
 
     public function testCascadePersistForManagedDocument()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $group1 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group1->name = "Test!";
+        $group1 = new CmsGroup();
+        $group1->name = 'Test!';
         $group1->id = '/functional/group1';
 
-        $group2 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group2->name = "Test!";
+        $group2 = new CmsGroup();
+        $group2->name = 'Test!';
         $group2->id = '/functional/group2';
 
         $user->addGroup($group1);
@@ -85,19 +87,19 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
         $this->dm->clear();
 
-        $pUser = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', $user->id);
+        $pUser = $this->dm->find(CmsUser::class, $user->id);
         $this->assertEquals(2, count($pUser->groups));
     }
 
     public function testCascadePersistSingleDocument()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $article = new CmsArticle();
-        $article->text = "foo";
-        $article->topic = "bar";
+        $article->text = 'foo';
+        $article->topic = 'bar';
         $article->user = $user;
         $article->id = '/functional/article';
 
@@ -108,28 +110,28 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
         $this->dm->clear();
 
-        $article = $this->dm->find('Doctrine\Tests\Models\CMS\CmsArticle', $article->id);
+        $article = $this->dm->find(CmsArticle::class, $article->id);
         $this->assertEquals($user->id, $article->user->getId());
     }
 
     public function testCascadeManagedDocumentCollectionDuringFlush()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
 
-        $group1 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group1->name = "Test!";
+        $group1 = new CmsGroup();
+        $group1->name = 'Test!';
         $group1->id = '/functional/group1';
 
-        $group2 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group2->name = "Test!";
+        $group2 = new CmsGroup();
+        $group2->name = 'Test!';
         $group2->id = '/functional/group2';
 
-        $user = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', $user->id);
+        $user = $this->dm->find(CmsUser::class, $user->id);
         $user->addGroup($group1);
         $user->addGroup($group2);
 
@@ -139,22 +141,22 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
         $this->dm->clear();
 
-        $pUser = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', $user->id);
+        $pUser = $this->dm->find(CmsUser::class, $user->id);
         $this->assertEquals(2, count($pUser->groups));
     }
 
     public function testCascadeManagedDocumentReferenceDuringFlush()
     {
         $article = new CmsArticle();
-        $article->text = "foo";
-        $article->topic = "bar";
+        $article->text = 'foo';
+        $article->topic = 'bar';
         $article->id = '/functional/article';
 
         $this->dm->persist($article);
 
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
         $article->user = $user;
 
         $this->assertFalse($this->dm->contains($user));
@@ -162,20 +164,20 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
         $this->dm->clear();
 
-        $article = $this->dm->find('Doctrine\Tests\Models\CMS\CmsArticle', $article->id);
+        $article = $this->dm->find(CmsArticle::class, $article->id);
         $this->assertEquals($user->id, $article->user->getId());
     }
 
     public function testCascadeManagedDocumentReferrerDuringFlush()
     {
         $user = new CmsUser();
-        $user->username = "dbu";
-        $user->name = "David";
+        $user->username = 'dbu';
+        $user->name = 'David';
         $this->dm->persist($user);
 
         $article = new CmsArticle();
-        $article->text = "foo";
-        $article->topic = "bar";
+        $article->text = 'foo';
+        $article->topic = 'bar';
         $article->id = '/functional/article_referrer';
         $user->articlesReferrers->add($article);
 
@@ -187,11 +189,11 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
         $this->dm->clear();
 
-        $user = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', '/functional/dbu');
+        $user = $this->dm->find(CmsUser::class, '/functional/dbu');
         $this->assertNotNull($user);
         $this->assertTrue(1 <= count($user->articlesReferrers));
         $savedArticle = $user->articlesReferrers->first();
-        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsArticle', $savedArticle);
+        $this->assertInstanceOf(CmsArticle::class, $savedArticle);
         $this->assertEquals($article->id, $savedArticle->id);
 
         $savedArticle->user = null;
@@ -210,13 +212,13 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
     public function testCascadeManagedDocumentReferrerDuringFlushArray()
     {
         $user = new CmsUser();
-        $user->username = "dbu";
-        $user->name = "David";
+        $user->username = 'dbu';
+        $user->name = 'David';
         $this->dm->persist($user);
 
         $article = new CmsArticle();
-        $article->text = "foo";
-        $article->topic = "bar";
+        $article->text = 'foo';
+        $article->topic = 'bar';
         $article->id = '/functional/article_referrer';
         $user->articlesReferrers = array($article);
 
@@ -226,19 +228,19 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
         $this->dm->clear();
 
-        $user = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', '/functional/dbu');
+        $user = $this->dm->find(CmsUser::class, '/functional/dbu');
         $this->assertNotNull($user);
         $this->assertTrue(1 <= count($user->articlesReferrers));
         $savedArticle = $user->articlesReferrers->first();
-        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsArticle', $savedArticle);
+        $this->assertInstanceOf(CmsArticle::class, $savedArticle);
         $this->assertEquals($article->id, $savedArticle->id);
     }
 
     public function testCascadeReferenceArray()
     {
         $article = new CmsArticle();
-        $article->text = "foo";
-        $article->topic = "bar";
+        $article->text = 'foo';
+        $article->topic = 'bar';
         $article->id = '/functional/article';
         $article->user = array();
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\PHPCRException;
 
 class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 {
@@ -230,9 +231,6 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->assertEquals($article->id, $savedArticle->id);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testCascadeReferenceArray()
     {
         $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
@@ -242,12 +240,11 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $article->user = array();
 
         $this->dm->persist($article);
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testCascadeReferenceNoObject()
     {
         $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
@@ -257,12 +254,11 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $article->user = "This is not an object";
 
         $this->dm->persist($article);
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testCascadeReferenceManyNoArray()
     {
         $user = new \Doctrine\Tests\Models\CMS\CmsUser();
@@ -272,12 +268,11 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $user->groups = $this;
 
         $this->dm->persist($user);
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testCascadeReferenceManyNoObject()
     {
         $user = new \Doctrine\Tests\Models\CMS\CmsUser();
@@ -287,6 +282,8 @@ class CascadePersistTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $user->groups = array("this is a bad idea");
 
         $this->dm->persist($user);
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRefreshTest.php
@@ -2,9 +2,14 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsArticle;
 
-class CascadeRefreshTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class CascadeRefreshTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var DocumentManager
@@ -16,25 +21,25 @@ class CascadeRefreshTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->node = $this->resetFunctionalNode($this->dm);
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $class = $this->dm->getClassMetadata(CmsUser::class);
         $class->mappings['groups']['cascade'] = ClassMetadata::CASCADE_REFRESH;
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
+        $class = $this->dm->getClassMetadata(CmsGroup::class);
         $class->mappings['users']['cascade'] = ClassMetadata::CASCADE_REFRESH;
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle');
+        $class = $this->dm->getClassMetadata(CmsArticle::class);
         $class->mappings['user']['cascade'] = ClassMetadata::CASCADE_REFRESH;
     }
 
     public function testCascadeRefresh()
     {
-        $group1 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group1->name = "Test!";
+        $group1 = new CmsGroup();
+        $group1->name = 'Test!';
         $group1->id = '/functional/group1';
 
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user = new CmsUser();
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
         $user->addGroup($group1);
 
         $this->dm->persist($user);
@@ -42,14 +47,14 @@ class CascadeRefreshTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
         $this->dm->flush();
 
-        $this->assertEquals(1, count($user->groups));
+        $this->assertCount(1, count($user->groups));
 
-        $group1->name = "Test2";
-        $user->username = "beberlei2";
+        $group1->name = 'Test2';
+        $user->username = 'beberlei2';
 
         $this->dm->refresh($user);
 
-        $this->assertEquals("beberlei", $user->username);
-        $this->assertEquals("Test!", $group1->name);
+        $this->assertEquals('beberlei', $user->username);
+        $this->assertEquals('Test!', $group1->name);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRefreshTest.php
@@ -47,7 +47,7 @@ class CascadeRefreshTest extends PHPCRFunctionalTestCase
 
         $this->dm->flush();
 
-        $this->assertCount(1, count($user->groups));
+        $this->assertCount(1, $user->groups);
 
         $group1->name = 'Test2';
         $user->username = 'beberlei2';

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRemoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRemoveTest.php
@@ -2,9 +2,14 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsArticle;
 
-class CascadeRemoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class CascadeRemoveTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var DocumentManager
@@ -16,16 +21,16 @@ class CascadeRemoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCas
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->node = $this->resetFunctionalNode($this->dm);
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $class = $this->dm->getClassMetadata(CmsUser::class);
         $class->mappings['groups']['cascade'] = ClassMetadata::CASCADE_REMOVE;
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $class = $this->dm->getClassMetadata(CmsUser::class);
         $class->mappings['articlesReferrers']['cascade'] = ClassMetadata::CASCADE_REMOVE;
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
+        $class = $this->dm->getClassMetadata(CmsGroup::class);
         $class->mappings['users']['cascade'] = ClassMetadata::CASCADE_REMOVE;
 
-        $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle');
+        $class = $this->dm->getClassMetadata(CmsArticle::class);
         $class->mappings['user']['cascade'] = ClassMetadata::CASCADE_REMOVE;
     }
 
@@ -47,15 +52,15 @@ class CascadeRemoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCas
 
     public function wrapRemove($closure)
     {
-        $group1 = new \Doctrine\Tests\Models\CMS\CmsGroup();
+        $group1 = new CmsGroup();
         $group1->name = 'Test!';
         $group1->id = '/functional/group1';
 
-        $group2 = new \Doctrine\Tests\Models\CMS\CmsGroup();
+        $group2 = new CmsGroup();
         $group2->name = 'Test!';
         $group2->id = '/functional/group2';
 
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = 'beberlei';
         $user->name = 'Benjamin';
         $user->addGroup($group1);
@@ -80,11 +85,11 @@ class CascadeRemoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCas
 
     public function testCascadeRemoveSingleDocument()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = 'beberlei';
         $user->name = 'Benjamin';
 
-        $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
+        $article = new CmsArticle();
         $article->text = 'foo';
         $article->topic = 'bar';
         $article->user = $user;
@@ -103,7 +108,7 @@ class CascadeRemoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCas
 
     public function testCascadeRemoveReferrer()
     {
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->username = 'beberlei';
         $user->name = 'Benjamin';
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChangesetCalculationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChangesetCalculationTest.php
@@ -4,10 +4,14 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CMS\CmsUserTranslatable;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
-class ChangesetCalculationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class ChangesetCalculationTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var ChangesetListener
@@ -15,7 +19,7 @@ class ChangesetCalculationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
     private $listener;
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -39,14 +43,14 @@ class ChangesetCalculationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
             );
 
         // Create initial user
-        $user1 = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user1 = new CmsUser();
         $user1->name = 'david';
         $user1->username = 'dbu';
         $user1->status = 'active';
         $this->dm->persist($user1);
 
         // Create additional user
-        $user2 = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user2 = new CmsUser();
         $user2->name = 'lukas';
         $user2->username = 'lsmith';
         $user2->status = 'active';
@@ -77,14 +81,14 @@ class ChangesetCalculationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
             );
 
         // Create initial user
-        $user1 = new \Doctrine\Tests\Models\CMS\CmsUserTranslatable();
+        $user1 = new CmsUserTranslatable();
         $user1->name = 'david';
         $user1->username = 'dbu';
         $user1->status = 'active';
         $this->dm->persist($user1);
 
         // Create additional user
-        $user2 = new \Doctrine\Tests\Models\CMS\CmsUserTranslatable();
+        $user2 = new CmsUserTranslatable();
         $user2->name = 'lukas';
         $user2->username = 'lsmith';
         $user2->status = 'active';
@@ -115,7 +119,7 @@ class ChangesetCalculationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
             );
 
         // Create initial user
-        $user1 = new \Doctrine\Tests\Models\CMS\CmsUserTranslatable();
+        $user1 = new CmsUserTranslatable();
         $user1->name = 'david';
         $user1->username = 'dbu';
         $user1->status = 'activ';

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DetachTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DetachTest.php
@@ -2,13 +2,17 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\ODM\PHPCR\UnitOfWork;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
 
-class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class DetachTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -19,43 +23,43 @@ class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\Models\CMS\CmsUser';
+        $this->type = CmsUser::class;
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $user = $this->node->addNode('lsmith');
         $user->setProperty('username', 'lsmith');
         $user->setProperty('numbers', array(3, 1, 2));
-        $user->setProperty('phpcr:class', $this->type, \PHPCR\PropertyType::STRING);
+        $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
     }
 
     public function testDetachNewObject()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $this->dm->detach($user);
 
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $check = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', $user->id);
+        $check = $this->dm->find(CmsUser::class, $user->id);
         $this->assertEquals('beberlei', $check->username);
     }
 
     public function testDetachedKnownObject()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $this->dm->persist($user);
         $this->dm->flush();
@@ -69,7 +73,7 @@ class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testDetach()
     {
         $user = $this->dm->find($this->type, '/functional/lsmith');
-        $user->username = "new-name";
+        $user->username = 'new-name';
 
         $this->dm->detach($user);
         $this->dm->flush();
@@ -82,7 +86,7 @@ class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testDetachWithPerist()
     {
         $user = $this->dm->find($this->type, '/functional/lsmith');
-        $user->username = "new-name";
+        $user->username = 'new-name';
 
         $this->dm->detach($user);
 
@@ -93,7 +97,7 @@ class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testDetachWithMove()
     {
         $user = $this->dm->find($this->type, '/functional/lsmith');
-        $user->username = "new-name";
+        $user->username = 'new-name';
 
         $this->dm->detach($user);
 
@@ -104,7 +108,7 @@ class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testDetachWithRemove()
     {
         $user = $this->dm->find($this->type, '/functional/lsmith');
-        $user->username = "new-name";
+        $user->username = 'new-name';
 
         $this->dm->detach($user);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DetachTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DetachTest.php
@@ -51,9 +51,6 @@ class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals('beberlei', $check->username);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testDetachedKnownObject()
     {
         $user = new CmsUser();
@@ -64,6 +61,8 @@ class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $this->dm->detach($user);
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->persist($user);
     }
 
@@ -80,39 +79,36 @@ class DetachTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals('lsmith', $newUser->username);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testDetachWithPerist()
     {
         $user = $this->dm->find($this->type, '/functional/lsmith');
         $user->username = "new-name";
 
         $this->dm->detach($user);
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->persist($user);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testDetachWithMove()
     {
         $user = $this->dm->find($this->type, '/functional/lsmith');
         $user->username = "new-name";
 
         $this->dm->detach($user);
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->move($user, '/functional/user2');
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testDetachWithRemove()
     {
         $user = $this->dm->find($this->type, '/functional/lsmith');
         $user->username = "new-name";
 
         $this->dm->detach($user);
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->remove($user);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentRepositoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentRepositoryTest.php
@@ -158,36 +158,29 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
         $this->assertEquals($user->username, $users['/functional/lsmith/beberlei']->username);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testFindByOrderNonExistentDirectionString()
     {
-        $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsTeamUser')->findBy(array('nodename' =>'beberlei'), array('username' =>'nowhere'));
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $this->dm->getRepository(CmsTeamUser::class)->findBy(array('nodename' =>'beberlei'), array('username' =>'nowhere'));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testFindByOrderNodename()
     {
-        $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsTeamUser')->findBy(array('nodename' =>'beberlei'), array('nodename' =>'asc'));
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+
+        $this->dm->getRepository(CmsTeamUser::class)->findBy(array('nodename' =>'beberlei'), array('nodename' =>'asc'));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testFindByOnAssociation()
     {
-        $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsTeamUser')->findBy(array('parent' =>'/foo'));
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $this->dm->getRepository(CmsTeamUser::class)->findBy(array('parent' =>'/foo'));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testFindByOrderAssociation()
     {
-        $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsTeamUser')->findBy(array('username' =>'beberlei'), array('parent' => 'asc'));
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $this->dm->getRepository(CmsTeamUser::class)->findBy(array('username' =>'beberlei'), array('parent' => 'asc'));
     }
 
     public function testFindOneBy()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentRepositoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentRepositoryTest.php
@@ -2,10 +2,14 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
+use PHPCR\NodeInterface;
+use Doctrine\ODM\PHPCR\Query\Builder\From;
+use Doctrine\ODM\PHPCR\Query\Builder\SourceDocument;
 
 /**
  * @group functional
@@ -13,7 +17,7 @@ use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
 class DocumentRepositoryTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
     /**
@@ -23,13 +27,13 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\Models\CMS\CmsUser';
+        $this->type = CmsUser::class;
         $this->dm = $this->createDocumentManager();
 
         $session = $this->dm->getPhpcrSession();
@@ -44,18 +48,18 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
 
     public function testCreateQueryBuilder()
     {
-        $rep = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
+        $rep = $this->dm->getRepository(CmsUser::class);
         $qb = $rep->createQueryBuilder('a');
 
         $from = $qb->getChildOfType(QBConstants::NT_FROM);
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Query\Builder\From', $from);
+        $this->assertInstanceOf(From::class, $from);
         $source = $from->getChildOfType(QBConstants::NT_SOURCE);
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Query\Builder\SourceDocument', $source);
+        $this->assertInstanceOf(SourceDocument::class, $source);
 
         $this->assertEquals('a', $source->getAlias());
         $this->assertEquals('a', $qb->getPrimaryAlias());
 
-        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $source->getDocumentFqn());
+        $this->assertEquals(CmsUser::class, $source->getDocumentFqn());
     }
 
     public function testLoadMany()
@@ -74,29 +78,29 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
         $this->dm->persist($user2);
         $this->dm->flush();
 
-        $users = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findMany(array($user1->id, $user2->id));
+        $users = $this->dm->getRepository(CmsUser::class)->findMany(array($user1->id, $user2->id));
         $this->assertSame($user1, $users['/functional/beberlei']);
         $this->assertSame($user2, $users['/functional/lsmith']);
 
-        $users = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findMany(array($user1->node->getIdentifier(), substr($user2->id, 1)));
+        $users = $this->dm->getRepository(CmsUser::class)->findMany(array($user1->node->getIdentifier(), substr($user2->id, 1)));
         $this->assertSame($user1, $users['/functional/beberlei']);
         $this->assertSame($user2, $users['/functional/lsmith']);
 
         $this->dm->clear();
 
-        $users = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findMany(array($user1->id, $user2->id));
+        $users = $this->dm->getRepository(CmsUser::class)->findMany(array($user1->id, $user2->id));
         $this->assertTrue(isset($users['/functional/beberlei']));
         $this->assertTrue(isset($users['/functional/lsmith']));
-        $this->assertInstanceOf('Doctrine\\Tests\\Models\\CMS\\CmsUser', $users['/functional/beberlei']);
-        $this->assertInstanceOf('Doctrine\\Tests\\Models\\CMS\\CmsUser', $users['/functional/lsmith']);
+        $this->assertInstanceOf(CmsUser::class, $users['/functional/beberlei']);
+        $this->assertInstanceOf(CmsUser::class, $users['/functional/lsmith']);
         $this->assertEquals($user1->username, $users['/functional/beberlei']->username);
         $this->assertEquals($user2->username, $users['/functional/lsmith']->username);
 
         $this->dm->clear();
 
         // read second document into memory
-        $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->find($user2->id);
-        $users = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findMany(array($user1->id, $user2->id));
+        $this->dm->getRepository(CmsUser::class)->find($user2->id);
+        $users = $this->dm->getRepository(CmsUser::class)->findMany(array($user1->id, $user2->id));
         $this->assertEquals('/functional/beberlei', $users->key(), 'Documents are not returned in the order they were requested');
     }
 
@@ -116,24 +120,24 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
         $this->dm->persist($user2);
         $this->dm->flush();
 
-        $users1 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('username' =>'beberlei'));
+        $users1 = $this->dm->getRepository(CmsUser::class)->findBy(array('username' =>'beberlei'));
         $this->assertCount(1, $users1);
         $this->assertEquals($user1->username, $users1['/functional/beberlei']->username);
 
-        $users2 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' =>'active'));
+        $users2 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'));
         $this->assertCount(2, $users2);
 
-        $users3 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' =>'active'), null, 1);
+        $users3 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'), null, 1);
         $this->assertCount(1, $users3);
 
-        $users4 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' =>'active'), array('name' => 'asc'), 2, 0);
+        $users4 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'), array('name' => 'asc'), 2, 0);
         $this->assertEquals('/functional/beberlei', $users4->key());
 
-        $users5 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' =>'active'), array('name' => 'asc'), 2, 1);
+        $users5 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'), array('name' => 'asc'), 2, 1);
         $this->assertEquals('/functional/lsmith', $users5->key());
 
         // test descending order
-        $users6 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' =>'active'), array('name' => 'desc'));
+        $users6 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'), array('name' => 'desc'));
         $this->assertEquals('/functional/lsmith', $users6->key());
     }
 
@@ -153,7 +157,7 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $users = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsTeamUser')->findBy(array('nodename' => 'beberlei'));
+        $users = $this->dm->getRepository(CmsTeamUser::class)->findBy(array('nodename' => 'beberlei'));
         $this->assertCount(1, $users);
         $this->assertEquals($user->username, $users['/functional/lsmith/beberlei']->username);
     }
@@ -199,10 +203,10 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
         $this->dm->persist($user2);
         $this->dm->flush();
 
-        $users1 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findOneBy(array('username' =>'beberlei'));
+        $users1 = $this->dm->getRepository(CmsUser::class)->findOneBy(array('username' =>'beberlei'));
         $this->assertEquals($user1->username, $users1->username);
 
-        $users2 = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findOneBy(array('username' =>'obama'));
+        $users2 = $this->dm->getRepository(CmsUser::class)->findOneBy(array('username' =>'obama'));
         $this->assertNull($users2);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventComputingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventComputingTest.php
@@ -4,10 +4,14 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CMS\CmsUserTranslatable;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
-class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class EventComputingTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var TestEventDocumentChanger
@@ -15,7 +19,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
     private $listener;
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -50,7 +54,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
             );
 
         // Create initial user
-        $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user = new CmsUser();
         $user->name = 'mdekrijger';
         $user->username = 'mdekrijger';
         $user->status = 'active';
@@ -63,10 +67,10 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->clear();
 
         // Post persist data is not saved to document, so check before reloading document
-        $this->assertTrue($user->username=='postpersist');
+        $this->assertEquals('postpersist', $user->username);
 
         // Be sure that document is really saved by refetching it from ODM
-        $user = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', $user->id);
+        $user = $this->dm->find(CmsUser::class, $user->id);
         $this->assertEquals('prepersist', $user->name);
         $this->assertEquals('active', $user->status);
 
@@ -82,7 +86,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->assertEquals('postupdate', $user->username);
 
         // Be sure that document is really saved by refetching it from ODM
-        $user = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', $user->id);
+        $user = $this->dm->find(CmsUser::class, $user->id);
         $this->assertEquals('preupdate', $user->name);
         $this->assertEquals('changed', $user->status);
 
@@ -97,7 +101,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->clear();
 
 
-        $user = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', $targetPath);
+        $user = $this->dm->find(CmsUser::class, $targetPath);
 
         // the document was moved but the only changes applied in preUpdate are persisted,
         // pre/postMove changes are not persisted in that flush
@@ -126,7 +130,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
 
         $this->dm->setLocaleChooserStrategy(new LocaleChooser($this->localePrefs, 'en'));
         // Create initial user
-        $user = new \Doctrine\Tests\Models\CMS\CmsUserTranslatable();
+        $user = new CmsUserTranslatable();
         $user->name = 'mdekrijger';
         $user->username = 'mdekrijger';
         $user->status = 'active';
@@ -135,7 +139,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->findTranslation('Doctrine\Tests\Models\CMS\CmsUserTranslatable', $user->id, 'en');
+        $user = $this->dm->findTranslation(CmsUserTranslatable::class, $user->id, 'en');
 
         // username should be changed after loading the translation
         $this->assertEquals('loadTranslation', $user->username);
@@ -153,7 +157,7 @@ class EventComputingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->findTranslation('Doctrine\Tests\Models\CMS\CmsUserTranslatable', $user->id, 'en');
+        $user = $this->dm->findTranslation(CmsUserTranslatable::class, $user->id, 'en');
 
         $this->dm->removeTranslation($user, 'en');
         $this->assertEquals('preRemoveTranslation', $user->name);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerResetTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerResetTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\Tests\Models\CMS\CmsPage;
 
@@ -21,7 +22,7 @@ class EventManagerResetTest extends PHPCRFunctionalTestCase
     private $listener;
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -38,12 +39,12 @@ class EventManagerResetTest extends PHPCRFunctionalTestCase
     public function testResetEvents()
     {
         $page = new CmsPage();
-        $page->title = "my-page";
+        $page->title = 'my-page';
 
         $pageContent = new CmsPageContent();
         $pageContent->id = 1;
-        $pageContent->content = "long story";
-        $pageContent->formatter = "plaintext";
+        $pageContent->content = 'long story';
+        $pageContent->formatter = 'plaintext';
 
         $page->content = $pageContent;
 
@@ -53,15 +54,15 @@ class EventManagerResetTest extends PHPCRFunctionalTestCase
 
         $this->dm->flush();
 
-        $this->assertInstanceOf('Doctrine\Tests\ODM\PHPCR\Functional\CmsPageContent', $page->content);
+        $this->assertInstanceOf(CmsPageContent::class, $page->content);
 
 
         // This is required as the originalData in the UnitOfWork doesn’t set the node of the Document
         $this->dm->clear();
 
-        $pageLoaded = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsPage')->find($page->id);
+        $pageLoaded = $this->dm->getRepository(CmsPage::class)->find($page->id);
 
-        $pageLoaded->title = "my-page-changed";
+        $pageLoaded->title = 'my-page-changed';
 
         $this->assertEquals('my-page-changed', $pageLoaded->title);
 
@@ -76,7 +77,7 @@ class EventManagerResetTest extends PHPCRFunctionalTestCase
 
         $this->dm->flush();
 
-        $this->assertInstanceOf('Doctrine\Tests\ODM\PHPCR\Functional\CmsPageContent', $page->content);
+        $this->assertInstanceOf(CmsPageContent::class, $page->content);
     }
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Common\Persistence\Event\ManagerEventArgs;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event\PreUpdateEventArgs;
 use Doctrine\ODM\PHPCR\Event\MoveEventArgs;
 use Doctrine\ODM\PHPCR\Event;
@@ -21,7 +22,7 @@ class EventManagerTest extends PHPCRFunctionalTestCase
     private $listener;
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -63,8 +64,8 @@ class EventManagerTest extends PHPCRFunctionalTestCase
             );
 
         $page = new CmsPage();
-        $page->title = "my-page";
-        $page->content = "long story";
+        $page->title = 'my-page';
+        $page->content = 'long story';
 
         $this->dm->persist($page);
 
@@ -107,10 +108,10 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $item = new CmsItem();
-        $item->name = "my-item";
+        $item->name = 'my-item';
         $item->documentTarget = $page;
 
-        $page->content = "short story";
+        $page->content = 'short story';
         $this->dm->persist($item);
         $page->addItem($item);
 
@@ -163,8 +164,8 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $this->dm->setLocaleChooserStrategy(new LocaleChooser($this->localePrefs, 'en'));
 
         $page = new CmsPageTranslatable();
-        $page->title = "my-page";
-        $page->content = "long story";
+        $page->title = 'my-page';
+        $page->content = 'long story';
 
         $this->dm->persist($page);
         $this->assertFalse($this->listener->preCreateTranslation);
@@ -181,7 +182,7 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $page = $this->dm->findTranslation('Doctrine\Tests\Models\CMS\CmsPageTranslatable', $page->id, 'en');
+        $page = $this->dm->findTranslation(CmsPageTranslatable::class, $page->id, 'en');
 
         $this->assertTrue($this->listener->postLoadTranslation);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventObjectUpdateTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventObjectUpdateTest.php
@@ -4,10 +4,12 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
-class EventObjectUpdateTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class EventObjectUpdateTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var TestEventDocumentChanger
@@ -15,7 +17,7 @@ class EventObjectUpdateTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
     private $listener;
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -121,17 +123,17 @@ class TestEventDocumentChanger2
 
     protected function switchToObject(LifecycleEventArgs $args)
     {
-        $entity = $args->getEntity();
+        $object = $args->getObject();
         $status = new \stdClass();
-        $status->value = $entity->status;
-        $entity->status = $status;
+        $status->value = $object->status;
+        $object->status = $status;
     }
 
     protected function switchToId(LifecycleEventArgs $args)
     {
-        $entity = $args->getEntity();
+        $object = $args->getObject();
 
-        $entity->status = $entity->status->value;
+        $object->status = $object->status->value;
     }
 
     public function postLoad(LifecycleEventArgs $args)

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FileTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FileTest.php
@@ -3,15 +3,18 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\Document\File;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 
 /**
  * @group functional
  */
-class FileTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class FileTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -22,13 +25,13 @@ class FileTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\FileTestObj';
+        $this->type = FileTestObj::class;
         $this->dm = $this->createDocumentManager();
         $this->node = $this->resetFunctionalNode($this->dm);
     }
@@ -38,7 +41,7 @@ class FileTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $parent = new FileTestObj();
         $parent->file = new File();
         $parent->id = '/functional/filetest';
-        $parent->file->setFileContentFromFilesystem(dirname(__FILE__) . '/_files/foo.txt');
+        $parent->file->setFileContentFromFilesystem(__DIR__.'/_files/foo.txt');
 
         $this->dm->persist($parent);
         $this->dm->flush();
@@ -80,7 +83,7 @@ class FileTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $file = $this->dm->find('Doctrine\ODM\PHPCR\Document\File', '/functional/filetest/file');
+        $file = $this->dm->find(File::class, '/functional/filetest/file');
 
         $this->assertNotNull($file);
         $this->assertNotNull($file->getCreated());

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
@@ -2,7 +2,9 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
@@ -14,7 +16,7 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 class FindTypeValidationTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -25,13 +27,13 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\TypeUser';
+        $this->type = TypeUser::class;
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->node = $this->resetFunctionalNode($this->dm);
 
@@ -110,7 +112,7 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
      */
     public function testNotInstanceOf()
     {
-        $user = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\TypeTeamUser', '/functional/user');
+        $user = $this->dm->find(TypeTeamUser::class, '/functional/user');
 
         $this->assertTrue(null === $user, is_object($user) ? get_class($user) : $user);
     }
@@ -123,7 +125,7 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
         $user = $this->dm->find($this->type, '/functional/user');
         $this->assertInstanceOf($this->type, $user);
 
-        $user = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\TypeTeamUser', '/functional/user');
+        $user = $this->dm->find(TypeTeamUser::class, '/functional/user');
         $this->assertTrue(null === $user, is_object($user) ? get_class($user) : $user);
     }
 
@@ -132,7 +134,7 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
      */
     public function testManyNotInstanceOf()
     {
-        $users = $this->dm->findMany('Doctrine\Tests\ODM\PHPCR\Functional\TypeTeamUser', array('/functional/user'));
+        $users = $this->dm->findMany(TypeTeamUser::class, array('/functional/user'));
 
         $this->assertCount(0, $users);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FixPHPCR1Test.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FixPHPCR1Test.php
@@ -3,15 +3,18 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\Document\File;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 
 /**
  * @group functional
  */
-class FixPHPCR1Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class FixPHPCR1Test extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -22,13 +25,13 @@ class FixPHPCR1Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\FileTestObj';
+        $this->type = FileTestObj::class;
         $this->dm = $this->createDocumentManager();
         $this->node = $this->resetFunctionalNode($this->dm);
     }
@@ -40,7 +43,7 @@ class FixPHPCR1Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->persist($parent);
 
         $parent->file = new File();
-        $parent->file->setFileContentFromFilesystem(dirname(__FILE__) . '/_files/foo.txt');
+        $parent->file->setFileContentFromFilesystem(__DIR__.'/_files/foo.txt');
 
         $this->dm->flush();
         $this->dm->clear();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
@@ -261,11 +261,10 @@ class FlushTest extends PHPCRFunctionalTestCase
     {
         $uuidObj = new UuidTestTwoUuidFieldsObj;
         $uuidObj->id = '/functional/uuidObj';
-        $this->dm->persist($uuidObj);
 
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('You can only designate a single "Uuid" field in "Doctrine\Tests\Models\References\UuidTestTwoUuidFieldsObj"');
-        $this->dm->flush();
+        $this->dm->persist($uuidObj);
     }
 
     public function testRepeatedFlush()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
@@ -261,6 +261,7 @@ class FlushTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->persist($uuidObj);
 
         $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('You can only designate a single "Uuid" field in "Doctrine\Tests\Models\References\UuidTestTwoUuidFieldsObj"');
         $this->dm->flush();
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\Tests\Models\CMS\CmsGroup;
@@ -11,14 +12,16 @@ use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\References\UuidTestObj;
 use Doctrine\Tests\Models\References\UuidTestTwoUuidFieldsObj;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 
 /**
  * @group functional
  */
-class FlushTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class FlushTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -30,7 +33,7 @@ class FlushTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\Models\CMS\CmsUser';
+        $this->type = CmsUser::class;
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->resetFunctionalNode($this->dm);
     }
@@ -296,7 +299,7 @@ class FlushTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->getPhpcrSession()->removeItem($user2->id);
         $this->dm->getPhpcrSession()->save();
         $this->dm->flush();
-        $this->assertInstanceOf('\PHPCR\NodeInterface', $user1->node);
+        $this->assertInstanceOf(NodeInterface::class, $user1->node);
 
         $this->assertCount(4, $group->getUsers());
         $this->dm->clear();
@@ -304,6 +307,6 @@ class FlushTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $group = $this->dm->find(null, '/functional/group');
         $group->getUsers()->first();
         $this->assertCount(2, $group->getUsers());
-        $this->assertInstanceOf('\PHPCR\NodeInterface', $group->getUsers()->first()->node);
+        $this->assertInstanceOf(NodeInterface::class, $group->getUsers()->first()->node);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
@@ -253,14 +254,13 @@ class FlushTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertNotNull($uuidObj->uuid1);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     */
     public function testUuidFieldOnlySetOnce()
     {
         $uuidObj = new UuidTestTwoUuidFieldsObj;
         $uuidObj->id = '/functional/uuidObj';
         $this->dm->persist($uuidObj);
+
+        $this->expectException(MappingException::class);
         $this->dm->flush();
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
@@ -9,6 +9,7 @@ use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\References\UuidTestObj;
 use Doctrine\Tests\Models\References\UuidTestTwoUuidFieldsObj;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 
 /**
  * @group functional
@@ -167,7 +168,7 @@ class FlushTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $user->username = 'domnikl';
         $user->status = 'developer';
 
-        $this->setExpectedException('\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->dm->flush($user);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FolderFileTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FolderFileTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\Document\File;
 use Doctrine\ODM\PHPCR\Document\Folder;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 
@@ -13,12 +14,12 @@ use PHPCR\NodeInterface;
 class FolderFileTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildTest.php
@@ -2,19 +2,23 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\PHPCRException;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
+use Doctrine\Common\Proxy\Proxy;
 
 /**
  * Test for the Child mapping.
  *
  * @group functional
  */
-class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class ChildTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -22,16 +26,16 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
      * Class name of the document class
      * @var string
      */
-    private $type = 'Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy\ChildTestObj';
+    private $type = ChildTestObj::class;
 
     /**
      * Class name of the child document class
      * @var string
      */
-    private $childType = 'Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy\ChildChildTestObj';
+    private $childType = ChildChildTestObj::class;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
@@ -89,7 +93,7 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         $doc = $this->dm->find(null, '/functional/childtest');
         $this->assertInstanceOf($this->type, $doc);
-        $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $doc->child);
+        $this->assertInstanceOf(Proxy::class, $doc->child);
     }
 
     public function testInsertAddUnnamedChildLater()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildTest.php
@@ -2,7 +2,9 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 
+use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\PHPCRException;
 
 /**
  * Test for the Child mapping.
@@ -113,9 +115,6 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals($this->node->getNode('childtest')->getNode('test')->getProperty('name')->getString(), 'Child');
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
-     */
     public function testCreateConflictingName()
     {
         $parent = new ChildTestObj();
@@ -127,6 +126,8 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $parent->id = '/functional/childtest';
 
         $this->dm->persist($parent);
+
+        $this->expectException(IdException::class);
         $this->dm->flush();
     }
 
@@ -160,9 +161,6 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertNull($parent->child);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testInsertArray()
     {
         $parent = new ChildTestObj();
@@ -173,12 +171,11 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $parent->id = '/functional/childtest';
 
         $this->dm->persist($parent);
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testInsertNoObject()
     {
         $parent = new ChildTestObj();
@@ -189,6 +186,8 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $parent->id = '/functional/childtest';
 
         $this->dm->persist($parent);
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
@@ -325,9 +324,6 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertNull($parent->child);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testMoveByAssignment()
     {
         $original = new ChildTestObj();
@@ -352,6 +348,7 @@ class ChildTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         $other->child = $original->child;
 
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildrenTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildrenTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 
+use Doctrine\ODM\PHPCR\ChildrenCollection;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\DocumentRepository;
@@ -30,7 +31,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
      */
     private $node;
 
-    private $type = 'Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy\ChildrenTestObj';
+    private $type = ChildrenTestObj::class;
 
     /**
      * @var TestResetReorderingListener
@@ -567,7 +568,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $parent = $this->dm->find($this->type, '/functional/parent');
         $this->assertCount(4, $parent->allChildren);
 
-        /** @var $childrenCollection \Doctrine\ODM\PHPCR\ChildrenCollection */
+        /** @var $childrenCollection ChildrenCollection */
         $childrenCollection = $parent->allChildren;
         $children = $childrenCollection->toArray();
 
@@ -726,7 +727,7 @@ class ChildrenTestObj
     public $aChildren;
 
     /**
-    * @var \Doctrine\ODM\PHPCR\ChildrenCollection
+    * @var ChildrenCollection
     * @PHPCR\Children(fetchDepth=2, cascade="persist")
     */
     public $allChildren;
@@ -821,7 +822,7 @@ class TestResetReorderingListener
         $document = $e->getObject();
         if ($document instanceof ChildrenTestObj && $document->allChildren->first()->name === 'Child B') {
 
-            /** @var $childrenCollection \Doctrine\ODM\PHPCR\ChildrenCollection */
+            /** @var $childrenCollection ChildrenCollection */
             $childrenCollection = $document->allChildren;
             $children = $childrenCollection->toArray();
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildrenTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildrenTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\RepositoryInterface;
@@ -347,8 +348,6 @@ class ChildrenTest extends PHPCRFunctionalTestCase
 
     /**
      * A children field must always be a collection/array. It can't be a single document.
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
      */
     public function testInsertNoArray()
     {
@@ -360,18 +359,19 @@ class ChildrenTest extends PHPCRFunctionalTestCase
 
         $parent->allChildren = $child;
         $this->dm->persist($parent);
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testInsertNoObject()
     {
         $parent = $this->dm->find($this->type, '/functional/parent');
 
         $parent->allChildren = array('This is not an object');
         $this->dm->persist($parent);
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
@@ -671,9 +671,6 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $this->assertCount(3, $parent->allChildren);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testMoveByAssignment()
     {
         $this->createChildren();
@@ -691,12 +688,10 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $other = $this->dm->find($this->type, '/functional/other');
         $other->allChildren->add($parent->allChildren['Child A']);
 
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testMoveByUpdateId()
     {
         $this->createChildren();
@@ -705,6 +700,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
 
         $child->id = '/functional/elsewhere';
 
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
@@ -2,12 +2,16 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
+use Doctrine\ODM\PHPCR\Document\Generic;
 
 /**
  * Test for the Parent mapping.
@@ -17,7 +21,7 @@ use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 class ParentTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -28,13 +32,13 @@ class ParentTest extends PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy\NameDoc';
+        $this->type = NameDoc::class;
         $this->dm = $this->createDocumentManager();
         $this->node = $this->resetFunctionalNode($this->dm);
 
@@ -44,7 +48,7 @@ class ParentTest extends PHPCRFunctionalTestCase
         }
 
         $user = $this->node->addNode('thename');
-        $user->setProperty('phpcr:class', $this->type, \PHPCR\PropertyType::STRING);
+        $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
 
         $this->dm->getPhpcrSession()->save();
     }
@@ -229,7 +233,7 @@ class ParentTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $referrer = $this->dm->find(null, '/functional/referrer');
-        $this->assertInstanceOf('\Doctrine\ODM\PHPCR\Document\Generic', $referrer->ref->parent);
+        $this->assertInstanceOf(Generic::class, $referrer->ref->parent);
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
@@ -262,10 +262,10 @@ class ParentTest extends PHPCRFunctionalTestCase
         $child->nodename = 'bad/name';
         $child->parent = $parent;
         $parent->children->add($child);
-        $this->dm->persist($child);
 
         $this->expectException(IdException::class);
-        $this->dm->flush();
+        $this->expectExceptionMessage('Nodename property "nodename" of document "Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy\NameDoc" contains the illegal PHPCR value "bad/name"');
+        $this->dm->persist($child);
     }
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
@@ -3,8 +3,10 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 
 use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Common\Proxy\Proxy;
+use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
 /**
@@ -78,23 +80,21 @@ class ParentTest extends PHPCRFunctionalTestCase
         $this->assertEquals($doc->nodename, $docNew->nodename);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testParentChangeException()
     {
         $doc = $this->dm->find($this->type, '/functional/thename');
         $doc->parent = new NameDoc();
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testIdChangeException()
     {
         $doc = $this->dm->find($this->type, '/functional/thename');
         $doc->id = '/different';
+
+        $this->expectException(PHPCRException::class);
         $this->dm->flush();
     }
 
@@ -235,8 +235,6 @@ class ParentTest extends PHPCRFunctionalTestCase
     /**
      * Create a node with a bad name and allow it to be discovered
      * among its parent node's children without explicity persisting it.
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
      */
     public function testIllegalNameNewChild()
     {
@@ -247,6 +245,7 @@ class ParentTest extends PHPCRFunctionalTestCase
         $child->parent = $parent;
         $parent->children->add($child);
 
+        $this->expectException(IdException::class);
         $this->dm->flush();
     }
 
@@ -254,8 +253,6 @@ class ParentTest extends PHPCRFunctionalTestCase
      * Create a node with a bad name and allow it to be discovered
      * among its parent node's children while also explicitly
      * persisting it.
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
      */
     public function testIllegalNameManagedChild()
     {
@@ -267,6 +264,7 @@ class ParentTest extends PHPCRFunctionalTestCase
         $parent->children->add($child);
         $this->dm->persist($child);
 
+        $this->expectException(IdException::class);
         $this->dm->flush();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Mapping;
 
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
@@ -49,14 +50,13 @@ class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
         $this->dm->persist($second);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     */
     public function testSecondLevelInheritanceWithDuplicate()
     {
         $second = new SecondLevelWithDuplicate();
         $second->id = '/functional/second';
         $second->text = 'text test';
+
+        $this->expectException(MappingException::class);
         $this->dm->persist($second);
     }
 
@@ -140,12 +140,11 @@ class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
     /**
      * @dataProvider invalidIdProvider
      *
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     *
      * @param string $class fqn of a class with invalid mapping
      */
     public function testInvalidId($class)
     {
+        $this->expectException(MappingException::class);
         $this->dm->getClassMetadata($class);
     }
 
@@ -153,9 +152,9 @@ class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
     {
         return array(
             array(
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\ParentIdNoParentStrategy',
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AutoNameIdNoParentStrategy',
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\NoId',
+                ParentIdNoParentStrategy::class,
+                AutoNameIdNoParentStrategy::class,
+                NoId::class,
             )
         );
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
@@ -2,25 +2,28 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Mapping;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 
 /**
  * @group functional
  */
-class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class AnnotationMappingTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
@@ -105,32 +108,32 @@ class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
     {
         return array(
             array(
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\ParentIdStrategy',
+                ParentIdStrategy::class,
                 ClassMetadata::GENERATOR_TYPE_PARENT,
                 'parentId',
             ),
             array(
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\ParentIdStrategyDifferentOrder',
+                ParentIdStrategyDifferentOrder::class,
                 ClassMetadata::GENERATOR_TYPE_PARENT,
                 'parentId2',
             ),
             array(
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AutoNameIdStrategy',
+                AutoNameIdStrategy::class,
                 ClassMetadata::GENERATOR_TYPE_AUTO,
                 'autoname as only has parent but not nodename',
             ),
             array(
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AssignedIdStrategy',
+                AssignedIdStrategy::class,
                 ClassMetadata::GENERATOR_TYPE_ASSIGNED,
                 'assigned',
             ),
             array(
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\RepositoryIdStrategy',
+                RepositoryIdStrategy::class,
                 ClassMetadata::GENERATOR_TYPE_REPOSITORY,
                 'repository'
             ),
             array(
-                '\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\StandardCase',
+                StandardCase::class,
                 ClassMetadata::GENERATOR_TYPE_ASSIGNED,
                 'standardcase',
             ),
@@ -167,7 +170,7 @@ class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
         $this->dm->persist($doc);
         $this->dm->flush();
         $this->dm->clear();
-        $this->assertInstanceOf('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\ParentIdStrategy', $this->dm->find(null, '/functional/parent-strategy'));
+        $this->assertInstanceOf(ParentIdStrategy::class, $this->dm->find(null, '/functional/parent-strategy'));
     }
 
     public function testPersistAutoNameId()
@@ -178,7 +181,7 @@ class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
         $this->dm->flush();
         $id = $this->dm->getUnitOfWork()->getDocumentId($doc);
         $this->dm->clear();
-        $this->assertInstanceOf('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\AutoNameIdStrategy', $this->dm->find(null, $id));
+        $this->assertInstanceOf(AutoNameIdStrategy::class, $this->dm->find(null, $id));
     }
 
     public function testPersistRepository()
@@ -189,7 +192,7 @@ class AnnotationMappingTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
         $this->dm->flush();
         $id = $this->dm->getUnitOfWork()->getDocumentId($doc);
         $this->dm->clear();
-        $this->assertInstanceOf('\Doctrine\Tests\ODM\PHPCR\Functional\Mapping\RepositoryIdStrategy', $this->dm->find(null, $id));
+        $this->assertInstanceOf(RepositoryIdStrategy::class, $this->dm->find(null, $id));
     }
 
     // TODO comprehensive test for all possible mapped fields in an abstract test, trying to persist and check if properly set

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MergeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MergeTest.php
@@ -7,6 +7,7 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 
 class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 {
@@ -78,7 +79,7 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         $this->dm->remove($user);
 
-        $this->setExpectedException('\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException', "Removed document detected during merge at '/functional/beberlei'. Cannot merge with a removed document.");
+        $this->expectException(InvalidArgumentException::class, "Removed document detected during merge at '/functional/beberlei'. Cannot merge with a removed document.");
         $this->dm->merge($user);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MergeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MergeTest.php
@@ -8,13 +8,21 @@ use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use Doctrine\ODM\PHPCR\ReferenceManyCollection;
+use PHPCR\NodeInterface;
 
-class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class MergeTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var DocumentManager
      */
     private $dm;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
 
     public function setUp()
     {
@@ -26,23 +34,23 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testMergeNewDocument()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $mergedUser = $this->dm->merge($user);
 
         $this->assertNotSame($mergedUser, $user);
-        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $mergedUser);
-        $this->assertEquals("beberlei", $mergedUser->username);
-        $this->assertEquals($this->node->getPath().'/'.$mergedUser->username, $mergedUser->id, "Merged new document should have generated path");
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\ReferenceManyCollection', $mergedUser->articles);
+        $this->assertInstanceOf(CmsUser::class, $mergedUser);
+        $this->assertEquals('beberlei', $mergedUser->username);
+        $this->assertEquals($this->node->getPath().'/'.$mergedUser->username, $mergedUser->id, 'Merged new document should have generated path');
+        $this->assertInstanceOf(ReferenceManyCollection::class, $mergedUser->articles);
     }
 
     public function testMergeManagedDocument()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $this->dm->persist($user);
         $this->dm->flush();
@@ -55,8 +63,8 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testMergeKnownDocument()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $this->dm->persist($user);
         $this->dm->flush();
@@ -71,8 +79,8 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testMergeRemovedDocument()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $this->dm->persist($user);
         $this->dm->flush();
@@ -87,36 +95,36 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testMergeWithManagedDocument()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $this->dm->persist($user);
         $this->dm->flush();
 
         $mergableUser = new CmsUser();
         $mergableUser->id = $user->id;
-        $mergableUser->username = "jgalt";
-        $mergableUser->name = "John Galt";
+        $mergableUser->username = 'jgalt';
+        $mergableUser->name = 'John Galt';
 
         $mergedUser = $this->dm->merge($mergableUser);
 
         $this->assertSame($mergedUser, $user);
-        $this->assertEquals("jgalt", $mergedUser->username);
-        $this->assertInstanceOf('PHPCR\NodeInterface', $mergedUser->node);
+        $this->assertEquals('jgalt', $mergedUser->username);
+        $this->assertInstanceOf(NodeInterface::class, $mergedUser->node);
     }
 
     public function testMergeChangeDocumentClass()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $this->dm->persist($user);
         $this->dm->flush();
 
         $otherUser = new CmsUser();
-        $otherUser->username = "lukas";
-        $otherUser->name = "Lukas";
+        $otherUser->username = 'lukas';
+        $otherUser->name = 'Lukas';
 
         $mergableGroup = new CmsGroup();
         $mergableGroup->id = $user->id;
@@ -129,8 +137,8 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testMergeUnknownAssignedId()
     {
         $doc = new CmsArticle();
-        $doc->id = "/foo";
-        $doc->name = "Foo";
+        $doc->id = '/foo';
+        $doc->name = 'Foo';
 
         $mergedDoc = $this->dm->merge($doc);
 
@@ -141,12 +149,12 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testMergeWithChild()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $teamuser = new CmsTeamUser();
-        $teamuser->username = "jwage";
-        $teamuser->name = "Jonathan Wage";
+        $teamuser->username = 'jwage';
+        $teamuser->name = 'Jonathan Wage';
         $teamuser->parent = $user;
         $user->child = $teamuser;
 
@@ -154,15 +162,15 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $mergableUser = new CmsUser();
-        $mergableUser->username = "jgalt";
-        $mergableUser->name = "John Galt";
+        $mergableUser->username = 'jgalt';
+        $mergableUser->name = 'John Galt';
         $mergableUser->id = $user->id;
 
         $mergedUser = $this->dm->merge($mergableUser);
 
         $this->assertSame($mergedUser, $user);
-        $this->assertEquals("jgalt", $mergedUser->username);
-        $this->assertEquals("jwage", $mergedUser->child->username);
+        $this->assertEquals('jgalt', $mergedUser->username);
+        $this->assertEquals('jwage', $mergedUser->child->username);
 
         $this->dm->flush();
         $mergedUser->children->count();
@@ -177,7 +185,7 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertSame($mergedUser, $user);
         $this->assertEquals('dbu', $mergedUser->username);
         $this->assertEquals('David', $mergedUser->name);
-        $this->assertEquals("jwage", $mergedUser->child->username);
+        $this->assertEquals('jwage', $mergedUser->child->username);
 
         $this->dm->flush();
     }
@@ -185,12 +193,12 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testMergeWithChildren()
     {
         $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
 
         $teamuser = new CmsTeamUser();
-        $teamuser->username = "jwage";
-        $teamuser->name = "Jonathan Wage";
+        $teamuser->username = 'jwage';
+        $teamuser->name = 'Jonathan Wage';
         $teamuser->parent = $user;
 
         $this->dm->persist($user);
@@ -202,14 +210,14 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertCount(1, $user->children);
 
         $mergableUser = new CmsUser();
-        $mergableUser->username = "jgalt";
-        $mergableUser->name = "John Galt";
+        $mergableUser->username = 'jgalt';
+        $mergableUser->name = 'John Galt';
         $mergableUser->id = $user->id;
 
         $mergedUser = $this->dm->merge($mergableUser);
 
         $this->assertSame($mergedUser, $user);
-        $this->assertEquals("jgalt", $mergedUser->username);
+        $this->assertEquals('jgalt', $mergedUser->username);
         $this->assertCount(1, $mergedUser->children);
 
         $this->dm->flush();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MergeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MergeTest.php
@@ -79,7 +79,8 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         $this->dm->remove($user);
 
-        $this->expectException(InvalidArgumentException::class, "Removed document detected during merge at '/functional/beberlei'. Cannot merge with a removed document.");
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Removed document detected during merge at '/functional/beberlei'. Cannot merge with a removed document.");
         $this->dm->merge($user);
     }
 
@@ -104,9 +105,6 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertInstanceOf('PHPCR\NodeInterface', $mergedUser->node);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testMergeChangeDocumentClass()
     {
         $user = new CmsUser();
@@ -124,6 +122,7 @@ class MergeTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $mergableGroup->id = $user->id;
         $mergableGroup->name = "doctrine";
 
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->merge($mergableGroup);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MixinTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MixinTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 use Doctrine\Tests\ODM\PHPCR\Mapping\Model\MixinMappingObject;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use PHPCR\NodeType\ConstraintViolationException;
 
 /**
  * @group functional
@@ -84,9 +85,6 @@ class MixinTest extends PHPCRFunctionalTestCase
         $this->assertEquals('changed', $this->node->getNode('protected')->getProperty('change_me')->getString());
     }
 
-    /**
-     * @expectedException \PHPCR\NodeType\ConstraintViolationException
-     */
     public function testChangingProtectedPropertyThrowsException()
     {
         $test = new TestObject();
@@ -101,14 +99,10 @@ class MixinTest extends PHPCRFunctionalTestCase
         $test->changeMe = 'changed';
         $test->created = new \DateTime();
 
+        $this->expectException(ConstraintViolationException::class);
         $this->dm->flush();
-
-        $this->assertEquals('changed', $this->node->getNode('protected')->getProperty('change_me')->getString());
     }
 
-    /**
-     * @expectedException \PHPCR\NodeType\ConstraintViolationException
-     */
     public function testChangingProtectedPropertyToNullThrowsException()
     {
         $test = new TestObject();
@@ -123,9 +117,8 @@ class MixinTest extends PHPCRFunctionalTestCase
         $test->changeMe = 'changed';
         $test->created = null;
 
+        $this->expectException(ConstraintViolationException::class);
         $this->dm->flush();
-
-        $this->assertEquals('changed', $this->node->getNode('protected')->getProperty('change_me')->getString());
     }
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MixinTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MixinTest.php
@@ -2,9 +2,11 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\ODM\PHPCR\Mapping\Model\MixinMappingObject;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use PHPCR\NodeInterface;
 use PHPCR\NodeType\ConstraintViolationException;
 
 /**
@@ -13,7 +15,7 @@ use PHPCR\NodeType\ConstraintViolationException;
 class MixinTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -24,13 +26,13 @@ class MixinTest extends PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\MixinMappingObject';
+        $this->type = MixinMappingObject::class;
         $this->dm = $this->createDocumentManager();
         $this->node = $this->resetFunctionalNode($this->dm);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveByAssignmentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveByAssignmentTest.php
@@ -2,7 +2,10 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
@@ -10,10 +13,10 @@ use Doctrine\Tests\Models\CMS\CmsTeamUser;
 /**
  * @group functional
  */
-class MoveByAssignmentTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class MoveByAssignmentTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -24,13 +27,13 @@ class MoveByAssignmentTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTest
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\Models\CMS\CmsTeamUser';
+        $this->type = CmsTeamUser::class;
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->node = $this->resetFunctionalNode($this->dm);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
@@ -2,17 +2,19 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\PropertyType;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
+use Doctrine\Tests\Models\CMS\CmsUser;
 
 /**
  * @group functional
  */
-class MoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class MoveTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -22,7 +24,7 @@ class MoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\Models\CMS\CmsUser';
+        $this->type = CmsUser::class;
         $this->dm = $this->createDocumentManager(array(__DIR__));
         $this->node = $this->resetFunctionalNode($this->dm);
 
@@ -230,7 +232,7 @@ class MoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $user = $this->dm->find(null, '/functional/lsmith/dbu');
-        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsTeamUser', $user);
+        $this->assertInstanceOf(CmsTeamUser::class, $user);
         $root = $this->dm->find(null, '/');
         $user->setParentDocument($root);
         $this->dm->persist($user);
@@ -238,6 +240,6 @@ class MoveTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $user = $this->dm->find(null, '/dbu');
-        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsTeamUser', $user);
+        $this->assertInstanceOf(CmsTeamUser::class, $user);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/PropertyNameTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/PropertyNameTest.php
@@ -2,15 +2,18 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 
 /**
  * @group functional
  */
-class PropertyNameTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class PropertyNameTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -21,13 +24,13 @@ class PropertyNameTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\TestObj';
+        $this->type = TestObj::class;
         $this->dm = $this->createDocumentManager();
         $this->node = $this->resetFunctionalNode($this->dm);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/PropertyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/PropertyTest.php
@@ -2,16 +2,19 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
 
 /**
  * @group functional
  */
-class PropertyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class PropertyTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -22,13 +25,13 @@ class PropertyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\PropertyTestObj';
+        $this->type = PropertyTestObj::class;
         $this->dm = $this->createDocumentManager();
         $this->node = $this->resetFunctionalNode($this->dm);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProtectedPropertyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProtectedPropertyTest.php
@@ -2,16 +2,21 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use Jackalope\Session;
+use PHPCR\NodeInterface;
+use PHPCR\NodeType\ConstraintViolationException;
 
 /**
  * @see http://www.doctrine-project.org/jira/browse/PHPCR-78
  * @group functional
  */
-class ProtectedPropertyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class ProtectedPropertyTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -22,7 +27,7 @@ class ProtectedPropertyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
@@ -32,7 +37,7 @@ class ProtectedPropertyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $session = $this->dm->getPhpcrSession();
-        if (! $session instanceof \Jackalope\Session) {
+        if (! $session instanceof Session) {
             $this->markTestSkipped('Not a Jackalope session');
         }
 
@@ -68,7 +73,7 @@ CND;
             $this->dm->persist($object);
             $this->dm->flush();
             $this->dm->clear();
-        } catch (\PHPCR\NodeType\ConstraintViolationException $e) {
+        } catch (ConstraintViolationException $e) {
             $this->fail(sprintf('A ConstraintViolationException has been thrown when persisting document ("%s").', $e->getMessage()));
         }
 
@@ -84,7 +89,7 @@ CND;
             $this->dm->persist($object);
             $this->dm->flush();
             $this->dm->clear();
-        } catch (\PHPCR\NodeType\ConstraintViolationException $e) {
+        } catch (ConstraintViolationException $e) {
             $this->fail(sprintf('A ConstraintViolationException has been thrown when persisting document ("%s").', $e->getMessage()));
         }
 
@@ -102,7 +107,7 @@ CND;
             $object->changeme = 'changed';
             $this->dm->flush();
             $this->dm->clear();
-        } catch (\PHPCR\NodeType\ConstraintViolationException $e) {
+        } catch (ConstraintViolationException $e) {
             $this->fail(sprintf('A ConstraintViolationException has been thrown when persisting document ("%s").', $e->getMessage()));
         }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProxyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProxyTest.php
@@ -6,6 +6,7 @@ use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use Doctrine\Common\Proxy\Proxy;
 
 /**
  * @group functional
@@ -98,10 +99,10 @@ class ProxyTest extends PHPCRFunctionalTestCase
 
         $parent = $this->dm->find(null, $parentId);
         $doc = $parent->children->current();
-        $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $doc);
-        $this->assertInstanceOf('Doctrine\Tests\ODM\PHPCR\Functional\DocWithoutId', $doc);
+        $this->assertInstanceOf(Proxy::class, $doc);
+        $this->assertInstanceOf(DocWithoutId::class, $doc);
         $this->assertEquals('foo', $doc->nodename);
-        $this->assertInstanceOf('Doctrine\Tests\ODM\PHPCR\Functional\ParentDoc', $doc->parent);
+        $this->assertInstanceOf(ParentDoc::class, $doc->parent);
     }
 
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderJoinTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderJoinTest.php
@@ -72,9 +72,9 @@ class QueryBuilderJoinTest extends PHPCRFunctionalTestCase
     public function testEquiJoinInnerOnReference()
     {
         $qb = $this->dm->createQueryBuilder();
-        $qb->fromDocument('Doctrine\Tests\Models\CMS\CmsUser', 'u');
+        $qb->fromDocument(CmsUser::class, 'u');
         $qb->addJoinInner()
-            ->right()->document('Doctrine\Tests\Models\CMS\CmsAddress', 'a')->end()
+            ->right()->document(CmsAddress::class, 'a')->end()
             ->condition()->equi('u.address', 'a.uuid');
         $qb->where()->eq()->field('a.city')->literal('Lyon');
         $q = $qb->getQuery();
@@ -215,9 +215,9 @@ class QueryBuilderJoinTest extends PHPCRFunctionalTestCase
     public function testUniqueNodeTypeOuterJoin()
     {
         $qb = $this->dm->createQueryBuilder()
-            ->fromDocument('Doctrine\Tests\Models\CMS\CmsUser', 'u')
+            ->fromDocument(CmsUser::class, 'u')
             ->addJoinLeftOuter()
-                ->right()->document('Doctrine\Tests\Models\CMS\CmsProfile', 'p')->end()
+                ->right()->document(CmsProfile::class, 'p')->end()
                 ->condition()->equi('u.profiles', 'p.uuid')
             ->end()->end()
             ->where()->orX()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
@@ -246,7 +246,6 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
 
     /**
      * @depends testFrom
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
      */
     public function testOrderByNonSimpleField()
     {
@@ -254,7 +253,10 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
         $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
         $qb->orderBy()->asc()->localname('a.username')->end();
 
-        $qb->getQuery()->execute();
+        $query = $qb->getQuery();
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $query->execute();
     }
 
     /**
@@ -396,18 +398,16 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
         $this->assertCount(1, $res);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Alias name "a" is not known
-     */
     public function testConditionWithNonExistingAlias()
     {
         $qb = $this->createQb();
         $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'b');
         $qb->where()->descendant('/functional', 'a')->end();
         $q = $qb->getQuery();
-        $res = $q->execute();
-        $this->assertCount(3, $res);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Alias name "a" is not known');
+        $q->execute();
     }
 
     public function testConditionWithStaticLiteralOfDifferentType()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
@@ -2,14 +2,12 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\ODM\PHPCR\DocumentRepository;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
-use Doctrine\Common\Proxy\Proxy;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\Tests\Models\Blog\User as BlogUser;
 use Doctrine\Tests\Models\Blog\Post;
 use Doctrine\Tests\Models\Blog\Comment;
-use PHPCR\Util\PathHelper;
+use PHPCR\NodeInterface;
 use PHPCR\Util\NodeHelper;
 
 /**
@@ -18,12 +16,12 @@ use PHPCR\Util\NodeHelper;
 class QueryBuilderTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     protected $dm;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     protected $node;
 
@@ -110,7 +108,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testFrom()
     {
         $qb = $this->createQb();
-        $qb->from()->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from()->document(BlogUser::class, 'a');
 
         // add where to stop rouge documents that havn't been stored in /functional/ from appearing.
         $qb->where()->eq()->field('a.status')->literal('query_builder')->end();
@@ -138,7 +136,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testComparison()
     {
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->where()
             ->eq()
                 ->field('a.username')
@@ -149,7 +147,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
         $this->assertCount(0, $res);
 
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->where()
             ->eq()
                 ->field('a.username')
@@ -163,7 +161,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testComposite()
     {
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->where()
             ->orX()
                 ->eq()->field('a.username')->literal('dtl')->end()
@@ -361,7 +359,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testTextSearch($field, $search, $resCount)
     {
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->where()->fullTextSearch('a.'.$field, $search);
         $q = $qb->getQuery();
 
@@ -376,7 +374,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testDescendant()
     {
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->where()->descendant('/functional', 'a')->end();
         $q = $qb->getQuery();
         $res = $q->execute();
@@ -389,7 +387,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testSameNode()
     {
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->where()->same('/functional/user/dtl', 'a');
         $q = $qb->getQuery();
         $res = $q->execute();
@@ -420,7 +418,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->where()->eq()
             ->field('a.age')
             ->literal('99') // we pass the age here as a string type

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
@@ -273,7 +273,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     {
         // select one property
         $qb = $this->createQb();
-        $qb->from('a')->document(User::class, 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->select()->field('a.username');
         $qb->where()
             ->eq()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
@@ -229,7 +229,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testOrderBy()
     {
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->where()->eq()->field('a.status')->literal('query_builder')->end();
         $qb->orderBy()->asc()->field('a.username')->end();
 
@@ -250,13 +250,12 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testOrderByNonSimpleField()
     {
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(BlogUser::class, 'a');
         $qb->orderBy()->asc()->localname('a.username')->end();
 
-        $query = $qb->getQuery();
-
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
-        $query->execute();
+        $this->expectExceptionMessage('Alias name "a.username" is not known. The following aliases are valid: "a"');
+        $qb->getQuery();
     }
 
     /**
@@ -276,7 +275,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     {
         // select one property
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'a');
+        $qb->from('a')->document(User::class, 'a');
         $qb->select()->field('a.username');
         $qb->where()
             ->eq()
@@ -401,13 +400,12 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     public function testConditionWithNonExistingAlias()
     {
         $qb = $this->createQb();
-        $qb->from('a')->document('Doctrine\Tests\Models\Blog\User', 'b');
+        $qb->from('a')->document(BlogUser::class, 'b');
         $qb->where()->descendant('/functional', 'a')->end();
-        $q = $qb->getQuery();
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Alias name "a" is not known');
-        $q->execute();
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Alias name "a" is not known. The following aliases are valid: "b"');
+        $q = $qb->getQuery();
     }
 
     public function testConditionWithStaticLiteralOfDifferentType()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QuerySql2Test.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QuerySql2Test.php
@@ -2,7 +2,12 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use PHPCR\Query\InvalidQueryException;
+use Doctrine\ODM\PHPCR\Query\Query;
+use PHPCR\Query\QueryInterface;
 
 /**
  * @group functional
@@ -89,10 +94,10 @@ class QuerySql2Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     {
         if ($rowCount == -1) {
             // magic to tell this is an invalid query
-            $this->setExpectedException('PHPCR\Query\InvalidQueryException');
+            $this->expectException(InvalidQueryException::class);
         }
-        $query = $this->dm->createQuery($statement, \PHPCR\Query\QueryInterface::JCR_SQL2);
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Query\Query', $query);
+        $query = $this->dm->createQuery($statement, QueryInterface::JCR_SQL2);
+        $this->assertInstanceOf(Query::class, $query);
 
         $result = $query->execute();
         $this->assertCount($rowCount, $result);
@@ -105,12 +110,13 @@ class QuerySql2Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     {
         if ($rowCount == -1) {
             // magic to tell this is an invalid query
-            $this->setExpectedException('PHPCR\Query\InvalidQueryException');
+            $this->expectException(InvalidQueryException::class);
         }
 
+        /** @var DocumentRepository $repository */
         $repository = $this->dm->getRepository($this->type);
-        $query = $repository->createQuery($statement, \PHPCR\Query\QueryInterface::JCR_SQL2);
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Query\Query', $query);
+        $query = $repository->createQuery($statement, QueryInterface::JCR_SQL2);
+        $this->assertInstanceOf(Query::class, $query);
 
         $result = $query->execute();
         $this->assertCount($rowCount, $result);
@@ -119,8 +125,8 @@ class QuerySql2Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testQueryLimit()
     {
         $query = $this->dm->createPhpcrQuery('SELECT * FROM [nt:unstructured] WHERE ISCHILDNODE("/functional") ORDER BY username',
-                                        \PHPCR\Query\QueryInterface::JCR_SQL2);
-        $this->assertInstanceOf('PHPCR\Query\QueryInterface', $query);
+                                        QueryInterface::JCR_SQL2);
+        $this->assertInstanceOf(QueryInterface::class, $query);
         $query->setLimit(2);
         $result = $this->dm->getDocumentsByPhpcrQuery($query, $this->type);
         $this->assertCount(2, $result);
@@ -128,7 +134,7 @@ class QuerySql2Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $vals = array();
         $nums = array();
         foreach ($result as $obj) {
-            $this->assertInstanceOf('Doctrine\Tests\ODM\PHPCR\Functional\QuerySql2TestObj', $obj);
+            $this->assertInstanceOf(QuerySql2TestObj::class, $obj);
             $ids[] = $obj->id;
             $vals[] = $obj->username;
             $nums[] = $obj->numbers;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QuerySql2Test.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QuerySql2Test.php
@@ -3,8 +3,11 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 use PHPCR\Query\InvalidQueryException;
 use Doctrine\ODM\PHPCR\Query\Query;
 use PHPCR\Query\QueryInterface;
@@ -12,10 +15,10 @@ use PHPCR\Query\QueryInterface;
 /**
  * @group functional
  */
-class QuerySql2Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class QuerySql2Test extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -26,7 +29,7 @@ class QuerySql2Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
@@ -56,7 +59,7 @@ class QuerySql2Test extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\Functional\QuerySql2TestObj';
+        $this->type = QuerySql2TestObj::class;
         $this->dm = $this->createDocumentManager();
         $this->node = $this->resetFunctionalNode($this->dm);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -190,7 +190,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $refManyTestObj->references = $refRefTestObj;
 
         $this->expectException(PHPCRException::class);
-        $this->expectExceptionMessage('Referenced document is not stored correctly in a reference-many property.');
+        $this->expectExceptionMessage('Referenced documents are not stored correctly in a reference-many property.');
         $this->dm->persist($refManyTestObj);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\Models\References\RefCascadeManyTestObj;
@@ -21,38 +22,41 @@ use Doctrine\Tests\Models\References\RefManyTestObj;
 use Doctrine\Tests\Models\References\RefManyTestObjForCascade;
 use Doctrine\Tests\Models\References\RefManyWithParentTestObjForCascade;
 use Doctrine\Tests\Models\References\ParentTestObj;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
 use PHPCR\Util\UUIDHelper;
 use PHPCR\ReferentialIntegrityException;
 
 /**
  * @group functional
  */
-class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class ReferenceTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
      * Class name of the document class
-     * @var \PHPCR\SessionInterface
+     * @var SessionInterface
      */
     private $session;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
-    private $referrerType = 'Doctrine\Tests\Models\References\RefTestObj';
-    private $referencedType = 'Doctrine\Tests\Models\References\RefRefTestObj';
-    private $referrerManyType = 'Doctrine\Tests\Models\References\RefManyTestObj';
-    private $referrerManyTypePathStrategy = 'Doctrine\Tests\Models\References\RefManyTestObjPathStrategy';
-    private $referrerManyForCascadeType = 'Doctrine\Tests\Models\References\RefManyTestObjForCascade';
-    private $hardReferrerType = 'Doctrine\Tests\Models\References\HardRefTestObj';
-    private $referrerDifType = 'Doctrine\Tests\Models\References\RefDifTestObj';
-    private $referrerManyWithParentForCascadeType = 'Doctrine\Tests\Models\References\RefManyWithParentTestObjForCascade';
+    private $referrerType = RefTestObj::class;
+    private $referencedType = RefRefTestObj::class;
+    private $referrerManyType = RefManyTestObj::class;
+    private $referrerManyTypePathStrategy = RefManyTestObjPathStrategy::class;
+    private $referrerManyForCascadeType = RefManyTestObjForCascade::class;
+    private $hardReferrerType = HardRefTestObj::class;
+    private $referrerDifType = RefDifTestObj::class;
+    private $referrerManyWithParentForCascadeType = RefManyWithParentTestObjForCascade::class;
 
     public function setUp()
     {
@@ -155,7 +159,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertTrue($refTestNode->hasProperty('reference'));
         $this->assertEquals($refRefTestNode->getIdentifier(), $refTestNode->getProperty('reference')->getString());
 
-        $ref = $this->dm->find('Doctrine\Tests\Models\References\RefTestPrivateObj', '/functional/refTestObj');
+        $ref = $this->dm->find(RefTestPrivateObj::class, '/functional/refTestObj');
         $refref = $ref->getReference();
 
         $this->assertNotNull($refref);
@@ -318,7 +322,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $node = $this->session->getNode('/functional/refTestObj')->getPropertyValue('myReference');
-        $this->assertInstanceOf('PHPCR\\NodeInterface', $node);
+        $this->assertInstanceOf(NodeInterface::class, $node);
         $this->assertEquals('referenced changed', $node->getPropertyValue('name'));
     }
 
@@ -866,7 +870,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referencing = $this->dm->find('Doctrine\Tests\Models\References\RefManyTestObj', '/functional/refManyTestObj');
+        $referencing = $this->dm->find(RefManyTestObj::class, '/functional/refManyTestObj');
         $this->dm->flush();
 
         $this->assertFalse($referencing->references->isInitialized());

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -22,6 +22,7 @@ use Doctrine\Tests\Models\References\RefManyTestObjForCascade;
 use Doctrine\Tests\Models\References\RefManyWithParentTestObjForCascade;
 use Doctrine\Tests\Models\References\ParentTestObj;
 use PHPCR\Util\UUIDHelper;
+use PHPCR\ReferentialIntegrityException;
 
 /**
  * @group functional
@@ -774,7 +775,7 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         $referenced = $this->dm->find($this->referencedType, '/functional/refRefTestObj');
 
-        $this->setExpectedException('PHPCR\ReferentialIntegrityException');
+        $this->expectException(ReferentialIntegrityException::class);
         $this->dm->remove($referenced);
         $this->dm->flush();
         $this->dm->clear();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -184,15 +184,14 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $refManyTestObj = new RefManyTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refManyTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
+        $refManyTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
 
         $refManyTestObj->references = $refRefTestObj;
 
-        $this->dm->persist($refManyTestObj);
         $this->expectException(PHPCRException::class);
         $this->expectExceptionMessage('Referenced document is not stored correctly in a reference-many property.');
-        $this->dm->flush();
+        $this->dm->persist($refManyTestObj);
     }
 
     public function testCreateOneArrayError()
@@ -200,17 +199,15 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $refTestObj = new RefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->reference = array($refRefTestObj);
 
-        $this->dm->persist($refTestObj);
-
         $this->expectException(PHPCRException::class);
         $this->expectExceptionMessage('Referenced document is not stored correctly in a reference-one property.');
-        $this->dm->flush();
+        $this->dm->persist($refTestObj);
     }
 
     public function testCreateWithoutRef()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -162,9 +162,6 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals('/functional/refRefTestObj', $refref->id);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testReferenceNonReferenceable()
     {
         $refTestObj = new RefTestPrivateObj();
@@ -176,17 +173,12 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $refTestObj->setReference($refRefTestObj);
 
         $this->dm->persist($refTestObj);
-        try {
-            $this->dm->flush();
-        } catch (PHPCRException $e) {
-            $this->assertContains('Referenced document Doctrine\Tests\Models\References\NonRefTestObj is not referenceable', $e->getMessage());
-            throw $e;
-        }
+
+        $this->expectException(PHPCRException::class);
+        $this->expectExceptionMessage('Referenced document Doctrine\Tests\Models\References\NonRefTestObj is not referenceable');
+        $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testCreateManyNoArrayError()
     {
         $refManyTestObj = new RefManyTestObj();
@@ -198,17 +190,11 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $refManyTestObj->references = $refRefTestObj;
 
         $this->dm->persist($refManyTestObj);
-        try {
-            $this->dm->flush();
-        } catch (PHPCRException $e) {
-            $this->assertContains('Referenced document is not stored correctly in a reference-many property.', $e->getMessage());
-            throw $e;
-        }
+        $this->expectException(PHPCRException::class);
+        $this->expectExceptionMessage('Referenced document is not stored correctly in a reference-many property.');
+        $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\PHPCRException
-     */
     public function testCreateOneArrayError()
     {
         $refTestObj = new RefTestObj();
@@ -221,12 +207,10 @@ class ReferenceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $refTestObj->reference = array($refRefTestObj);
 
         $this->dm->persist($refTestObj);
-        try {
-            $this->dm->flush();
-        } catch (PHPCRException $e) {
-            $this->assertContains('Referenced document is not stored correctly in a reference-one property.', $e->getMessage());
-            throw $e;
-        }
+
+        $this->expectException(PHPCRException::class);
+        $this->expectExceptionMessage('Referenced document is not stored correctly in a reference-one property.');
+        $this->dm->flush();
     }
 
     public function testCreateWithoutRef()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
@@ -2,7 +2,13 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
+use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
 
 /**
  * These tests test if referrers are correctly read. For cascading
@@ -10,20 +16,20 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
  *
  * @group functional
  */
-class ReferrerTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class ReferrerTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @var \PHPCR\SessionInterface
+     * @var SessionInterface
      */
     private $session;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
@@ -135,7 +141,7 @@ class ReferrerTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         $tmpIds = array();
         foreach ($reference->referrers as $referrer) {
-            $this->assertInstanceOf('\Doctrine\Tests\ODM\PHPCR\Functional\ReferrerTestObj', $referrer);
+            $this->assertInstanceOf(ReferrerTestObj::class, $referrer);
             $tmpIds[] = $referrer->id;
         }
 
@@ -588,8 +594,8 @@ class ReferrerTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
      */
     public function testMultilangReferrers()
     {
-        $this->dm->setLocaleChooserStrategy(new \Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser($this->localePrefs, 'en'));
-        $this->dm->setTranslationStrategy('attribute', new \Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy($this->dm));
+        $this->dm->setLocaleChooserStrategy(new LocaleChooser($this->localePrefs, 'en'));
+        $this->dm->setTranslationStrategy('attribute', new AttributeTranslationStrategy($this->dm));
 
         $referrerTestObj = new ReferrerTestObjMultilang();
         $referrerRefTestObj = new ReferrerRefTestObj();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/RefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/RefreshTest.php
@@ -6,8 +6,10 @@ use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\References\ParentTestObj;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use Doctrine\Common\Proxy\Proxy;
 
-class RefreshTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class RefreshTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var DocumentManager
@@ -45,13 +47,13 @@ class RefreshTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         // Add a group
         $group1 = new CmsGroup;
-        $group1->name = "12345";
+        $group1->name = '12345';
         $group1->id = '/functional/group1';
         $user->addGroup($group1);
 
         // Add a group
         $group2 = new CmsGroup;
-        $group2->name = "54321";
+        $group2->name = '54321';
         $group2->id = '/functional/group2';
 
         $this->dm->persist($user);
@@ -82,7 +84,7 @@ class RefreshTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $child = $this->dm->find(null, '/functional/parent/child');
-        $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $child->parent);
+        $this->assertInstanceOf(Proxy::class, $child->parent);
         $child->parent->name = 'x';
 
         $this->dm->refresh($child->parent);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/RefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/RefreshTest.php
@@ -89,14 +89,13 @@ class RefreshTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertEquals('parent', $child->parent->name);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testRefreshDetached()
     {
         $user = new CmsUser;
         $user->id = '/functional/Guilherme';
         $user->username = 'gblanco';
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->refresh($user);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\Document\Generic;
 use PHPCR\NodeInterface;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 
 /**
  * @group functional
@@ -102,7 +103,7 @@ class ReorderTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     public function testReorderNoObject()
     {
-        $this->setExpectedException('\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->dm->reorder('parent', 'first', 'second', false);
         $this->dm->flush();
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
@@ -2,18 +2,19 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Document\Generic;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 
 /**
  * @group functional
  */
-class ReorderTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class ReorderTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -183,13 +184,11 @@ class ReorderTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertNull($parent);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testReorderAfterRemove()
     {
         $parent = $this->dm->find(null, '/functional/source');
         $this->dm->remove($parent);
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->reorder($parent, 'first', 'second', false);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/TargetDocumentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/TargetDocumentTest.php
@@ -2,22 +2,25 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\Models\References\RefType2TestObj;
 use Doctrine\Tests\Models\References\RefType1TestObj;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 
 /**
  * @group functional
  */
-class TargetDocumentTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class TargetDocumentTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
@@ -46,7 +49,7 @@ class TargetDocumentTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
 
         $this->dm->clear();
-        $referer = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\ReferenceManyObj', '/functional/referer');
+        $referer = $this->dm->find(ReferenceManyObj::class, '/functional/referer');
         $this->assertEquals('Referer', $referer->name);
         $this->assertCount(2, $referer->references);
         $this->assertTrue($referer->references[0] instanceof RefType1TestObj);
@@ -78,9 +81,9 @@ class TargetDocumentTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCa
         $this->dm->flush();
         $this->dm->clear();
 
-        $referer = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\ReferenceOneObj', '/functional/referer1');
+        $referer = $this->dm->find(ReferenceOneObj::class, '/functional/referer1');
         $this->assertTrue($referer->reference instanceof RefType1TestObj);
-        $referer = $this->dm->find('Doctrine\Tests\ODM\PHPCR\Functional\ReferenceOneObj', '/functional/referer2');
+        $referer = $this->dm->find(ReferenceOneObj::class, '/functional/referer2');
         $this->assertTrue($referer->reference instanceof RefType2TestObj);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
@@ -477,6 +477,6 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
 
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('locales must be specified');
-        $this->converter->convert(Comment::class, array(), array(), 'attribute');
+        $this->converter->convert(TranslatedComment::class, array());
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
@@ -12,6 +12,7 @@ use Doctrine\Tests\ODM\PHPCR\Functional\Translation\AttributeTranslationStrategy
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
+use Doctrine\Tests\Models\Blog\Comment;
 
 class TranslationConverterTest extends PHPCRFunctionalTestCase
 {
@@ -451,35 +452,29 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $this->assertFalse($this->session->hasPendingChanges());
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     * @expectedExceptionMessage To untranslate a document, you need to specify the previous translation strategy
-     */
     public function testUntranslateMissingPrevious()
     {
-        $class = 'Doctrine\Tests\Models\Blog\Comment';
-        $this->converter->convert($class, array('en'));
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('To untranslate a document, you need to specify the previous translation strategy');
+        $this->converter->convert(Comment::class, array('en'));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     * @expectedExceptionMessage need to specify the fields that where previously translated
-     */
     public function testUntranslateMissingFields()
     {
-        $class = 'Doctrine\Tests\Models\Blog\Comment';
-        $this->converter->convert($class, array(), array(), 'attribute');
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('need to specify the fields that where previously translated');
+        $this->converter->convert(Comment::class, array(), array(), 'attribute');
     }
 
     /**
      * Converting to translated without specifying locales.
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     * @expectedExceptionMessage locales must be specified
      */
     public function testMissingLocales()
     {
         $this->converter = new TranslationConverter($this->dm, 1);
-        $class = 'Doctrine\Tests\Models\Translation\Comment';
-        $this->converter->convert($class, array());
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('locales must be specified');
+        $this->converter->convert(Comment::class, array());
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
@@ -13,6 +13,8 @@ use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use Doctrine\Tests\Models\Blog\Comment;
+use Doctrine\Tests\Models\Translation\Comment as TranslatedComment;
+use Doctrine\Tests\Models\Translation\ChildTranslationComment;
 
 class TranslationConverterTest extends PHPCRFunctionalTestCase
 {
@@ -58,7 +60,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
     {
         $this->converter = new TranslationConverter($this->dm, 1);
 
-        $class = 'Doctrine\Tests\Models\Translation\Comment';
+        $class = TranslatedComment::class;
         $field = 'text';
         $comment = $this->node->addNode('convert');
         $comment->setProperty($field, 'Lorem ipsum...');
@@ -107,7 +109,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $class = 'Doctrine\Tests\Models\Translation\Article';
+        $class = Article::class;
         $field = 'nullable';
         $comment = $this->node->getNode('convert');
         $comment->setProperty($field, 'Move to translated');
@@ -151,7 +153,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $class = 'Doctrine\Tests\Models\Translation\Article';
+        $class = Article::class;
         $field = 'nullable';
         $comment = $this->node->getNode('convert');
         $comment->setProperty($field, 'Move to translated');
@@ -184,8 +186,8 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
 
     public function testTranslateChild()
     {
-        $class = 'Doctrine\Tests\Models\Translation\ChildTranslationComment';
-        $parentClass = 'Doctrine\Tests\Models\Translation\Comment';
+        $class = ChildTranslationComment::class;
+        $parentClass = TranslatedComment::class;
         $field = 'text';
         $comment = $this->node->addNode('convert');
         $comment->setProperty($field, 'Lorem ipsum...');
@@ -214,8 +216,8 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
 
     public function testTranslateAttributeToChild()
     {
-        $class = 'Doctrine\Tests\Models\Translation\ChildTranslationComment';
-        $parentClass = 'Doctrine\Tests\Models\Translation\Comment';
+        $class = ChildTranslationComment::class;
+        $parentClass = TranslatedComment::class;
         $field = 'text';
         $comment = $this->node->addNode('convert');
         $comment->setProperty(
@@ -252,7 +254,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
 
     public function testUntranslateAttribute()
     {
-        $class = 'Doctrine\Tests\Models\Blog\Comment';
+        $class = Comment::class;
         $field = 'title';
         $comment = $this->node->addNode('convert');
         $comment->setProperty(
@@ -301,7 +303,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $class = 'Doctrine\Tests\Models\Translation\Article';
+        $class = Article::class;
         $field = 'author';
         $comment = $this->node->getNode('convert');
         $comment->setProperty(
@@ -343,7 +345,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
 
     public function testUntranslateChild()
     {
-        $class = 'Doctrine\Tests\Models\Blog\Comment';
+        $class = Comment::class;
         $field = 'title';
         $comment = $this->node->addNode('convert');
         $comment->setProperty('phpcr:class', $class);
@@ -389,7 +391,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $class = 'Doctrine\Tests\Models\Translation\ChildTranslationArticle';
+        $class = ChildTranslationArticle::class;
         $field = 'author';
         $node = $this->node->getNode('convert');
         $node->getNode('phpcr_locale:en')->setProperty($field, 'Move to untranslated');
@@ -435,8 +437,8 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
     {
         $this->converter = new TranslationConverter($this->dm);
 
-        $class = 'Doctrine\Tests\Models\Translation\ChildTranslationComment';
-        $parentClass = 'Doctrine\Tests\Models\Translation\Comment';
+        $class = ChildTranslationComment::class;
+        $parentClass = TranslatedComment::class;
         $field = 'text';
         $comment = $this->node->addNode('convert');
         $comment->setProperty($field, 'Lorem ipsum...');

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
@@ -475,6 +475,6 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
 
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('locales must be specified');
-        $this->converter->convert(Comment::class, array());
+        $this->converter->convert(Comment::class, array(), array(), 'attribute');
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/AttributeTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/AttributeTranslationStrategyTest.php
@@ -2,29 +2,32 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Translation\Translation;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
 
 class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
 {
     protected $testNodeName = '__test-node__';
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @var \PHPCR\SessionInterface
+     * @var SessionInterface
      */
     private $session;
 
     /**
-     * @var \PHPCR\WorkspaceInterface
+     * @var WorkspaceInterface
      */
     private $workspace;
 
@@ -38,7 +41,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->dm = $this->createDocumentManager();
         $this->session = $this->dm->getPhpcrSession();
         $this->workspace = $this->dm->getPhpcrSession()->getWorkspace();
-        $this->metadata = $this->dm->getClassMetadata('Doctrine\Tests\Models\Translation\Article');
+        $this->metadata = $this->dm->getClassMetadata(Article::class);
     }
 
     public function tearDown()
@@ -471,7 +474,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
 
         $node = $this->getTestNode();
         $node->setProperty('author', 'John Doe');
-        $node->setProperty('phpcr:class', 'Doctrine\Tests\Models\Translation\Article');
+        $node->setProperty('phpcr:class', Article::class);
 
         $strategy->saveTranslation($data, $node, $this->metadata, 'en');
 
@@ -487,7 +490,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->dm->getPhpcrSession()->save();
 
         $qb = $this->dm->createQueryBuilder();
-        $qb->from()->document('Doctrine\Tests\Models\Translation\Article', 'a');
+        $qb->from()->document(Article::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')
@@ -498,7 +501,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertCount(0, $res);
 
         $qb = $this->dm->createQueryBuilder();
-        $qb->from()->document('Doctrine\Tests\Models\Translation\Article', 'a');
+        $qb->from()->document(Article::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')
@@ -510,7 +513,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
 
         $qb = $this->dm->createQueryBuilder();
         $qb->setLocale(false);
-        $qb->from()->document('Doctrine\Tests\Models\Translation\Article', 'a');
+        $qb->from()->document(Article::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')
@@ -521,7 +524,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertCount(0, $res);
 
         $qb = $this->dm->createQueryBuilder();
-        $qb->from()->document('Doctrine\Tests\Models\Translation\Article', 'a');
+        $qb->from()->document(Article::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')
@@ -533,7 +536,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
 
         $qb = $this->dm->createQueryBuilder();
         $qb->setLocale('fr');
-        $qb->from()->document('Doctrine\Tests\Models\Translation\Article', 'a');
+        $qb->from()->document(Article::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/ChildTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/ChildTranslationStrategyTest.php
@@ -2,29 +2,33 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\ChildTranslationStrategy;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\ODM\PHPCR\Translation\Translation;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
+use Doctrine\Tests\Models\Translation\ChildTranslationArticle;
 
-class ChildTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
 {
     protected $testNodeName = '__test-node__';
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @var \PHPCR\SessionInterface
+     * @var SessionInterface
      */
     private $session;
 
     /**
-     * @var \PHPCR\WorkspaceInterface
+     * @var WorkspaceInterface
      */
     private $workspace;
 
@@ -38,7 +42,7 @@ class ChildTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFuncti
         $this->dm = $this->createDocumentManager();
         $this->session = $this->dm->getPhpcrSession();
         $this->workspace = $this->dm->getPhpcrSession()->getWorkspace();
-        $this->metadata = $this->dm->getClassMetadata('Doctrine\Tests\Models\Translation\Article');
+        $this->metadata = $this->dm->getClassMetadata(Article::class);
     }
 
     public function tearDown()
@@ -366,7 +370,7 @@ class ChildTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFuncti
 
         $node = $this->getTestNode();
         $node->setProperty('author', 'John Doe');
-        $node->setProperty('phpcr:class', 'Doctrine\Tests\Models\Translation\ChildTranslationArticle');
+        $node->setProperty('phpcr:class', ChildTranslationArticle::class);
 
         $strategy->saveTranslation($data, $node, $this->metadata, 'en');
 
@@ -382,7 +386,7 @@ class ChildTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFuncti
         $this->dm->getPhpcrSession()->save();
 
         $qb = $this->dm->createQueryBuilder();
-        $qb->from()->document('Doctrine\Tests\Models\Translation\ChildTranslationArticle', 'a');
+        $qb->from()->document(ChildTranslationArticle::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')
@@ -392,7 +396,7 @@ class ChildTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFuncti
         $this->assertCount(0, $res);
 
         $qb = $this->dm->createQueryBuilder();
-        $qb->from()->document('Doctrine\Tests\Models\Translation\ChildTranslationArticle', 'a');
+        $qb->from()->document(ChildTranslationArticle::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')
@@ -403,7 +407,7 @@ class ChildTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFuncti
 
         $qb = $this->dm->createQueryBuilder();
         $qb->setLocale(false);
-        $qb->from()->document('Doctrine\Tests\Models\Translation\ChildTranslationArticle', 'a');
+        $qb->from()->document(ChildTranslationArticle::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')
@@ -413,7 +417,7 @@ class ChildTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFuncti
         $this->assertCount(0, $res);
 
         $qb = $this->dm->createQueryBuilder();
-        $qb->from()->document('Doctrine\Tests\Models\Translation\ChildTranslationArticle', 'a');
+        $qb->from()->document(ChildTranslationArticle::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')
@@ -424,7 +428,7 @@ class ChildTranslationStrategyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFuncti
 
         $qb = $this->dm->createQueryBuilder();
         $qb->setLocale('fr');
-        $qb->from()->document('Doctrine\Tests\Models\Translation\ChildTranslationArticle', 'a');
+        $qb->from()->document(ChildTranslationArticle::class, 'a');
         $qb->where()
             ->eq()
             ->field('a.topic')

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
@@ -11,6 +11,7 @@ use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\PHPCRException;
+use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
 
 class DocumentManagerTest extends PHPCRFunctionalTestCase
 {
@@ -476,11 +477,11 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         // if we do not flush, the translation node does not exist
 
         $doc = $this->dm->findTranslation($this->class, $this->doc->id, 'it', true);
-        $this->assertInstanceOf('Doctrine\Tests\Models\Translation\Article', $doc);
+        $this->assertInstanceOf(Article::class, $doc);
         $this->assertEquals('John Doe', $doc->author);
         $this->assertEquals('en', $doc->locale);
 
-        $this->setExpectedException('Doctrine\ODM\PHPCR\Translation\MissingTranslationException');
+        $this->expectException(MissingTranslationException::class);
         $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'it', false);
     }
 
@@ -497,7 +498,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $doc = $this->dm->find(null, $path);
-        $this->assertInstanceOf('Doctrine\Tests\Models\Translation\Comment', $doc);
+        $this->assertInstanceOf(Comment::class, $doc);
         $this->assertNull($doc->getText());
     }
 
@@ -568,7 +569,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
         $this->dm->flush();
 
-        $this->setExpectedException('Doctrine\ODM\PHPCR\PHPCRException');
+        $this->expectException(PHPCRException::class);
 
         $doc->topic = null;
         $this->dm->flush();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\Tests\Models\Translation\Comment;
 use Doctrine\Tests\Models\Translation\InvalidMapping;
@@ -12,47 +13,50 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Doctrine\ODM\PHPCR\Document\Generic;
 
 class DocumentManagerTest extends PHPCRFunctionalTestCase
 {
-    protected $testNodeName = '__my_test_node__';
+    private $testNodeName = '__my_test_node__';
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
-    protected $dm;
+    private $dm;
 
     /**
-     * @var \PHPCR\SessionInterface
+     * @var SessionInterface
      */
-    protected $session;
+    private $session;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
-    protected $node;
+    private $node;
 
     /**
      * @var ClassMetadata
      */
-    protected $metadata;
+    private $metadata;
 
     /**
      * @var Article
      */
-    protected $doc;
+    private $doc;
 
     /**
      * @var string
      */
-    protected $class = 'Doctrine\Tests\Models\Translation\Article';
+    private $class = Article::class;
 
     /**
      * @var string
      */
-    protected $childrenClass = 'Doctrine\Tests\Models\Translation\Comment';
+    private $childrenClass = Comment::class;
 
-    protected $localePrefs = array(
+    private $localePrefs = array(
         'en' => array('de', 'fr'),
         'fr' => array('de', 'en'),
         'de' => array('en'),
@@ -78,12 +82,12 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->doc->assoc = array('key' => 'value');
     }
 
-    protected function getTestNode()
+    private function getTestNode()
     {
         return $this->session->getNode('/functional/'.$this->testNodeName);
     }
 
-    protected function assertDocumentStored()
+    private function assertDocumentStored()
     {
         $node = $this->getTestNode();
         $this->assertNotNull($node);
@@ -366,7 +370,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $children = $this->doc->getChildren();
         $this->assertCount(1, $children);
         foreach ($children as $comment) {
-            $this->assertInstanceOf('Doctrine\ODM\PHPCR\Document\Generic', $comment);
+            $this->assertInstanceOf(Generic::class, $comment);
             $this->assertNull($this->dm->getUnitOfWork()->getCurrentLocale($comment));
         }
 
@@ -376,7 +380,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $children = $this->dm->getChildren($this->doc);
         $this->assertCount(1, $children);
         foreach ($children as $comment) {
-            $this->assertInstanceOf('Doctrine\ODM\PHPCR\Document\Generic', $comment);
+            $this->assertInstanceOf(Generic::class, $comment);
             $this->assertNull($this->dm->getUnitOfWork()->getCurrentLocale($comment));
         }
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationHierarchyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationHierarchyTest.php
@@ -2,20 +2,22 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
-use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
-use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
 use Doctrine\Tests\Models\Translation\Article;
-use Doctrine\Tests\Models\Translation\Comment;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
+use Doctrine\Common\Proxy\Proxy;
+use PHPCR\PropertyType;
 
 /**
  * @group functional
  */
-class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class TranslationHierarchyTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -26,24 +28,24 @@ class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
     private $type;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->type = 'Doctrine\Tests\Models\Translation\Article';
+        $this->type = Article::class;
         $this->dm = $this->createDocumentManager();
         $this->dm->setLocaleChooserStrategy(new LocaleChooser(array('en' => array('fr'), 'fr' => array('en')), 'en'));
         $this->node = $this->resetFunctionalNode($this->dm);
         $user = $this->node->addNode('thename');
-        $user->setProperty('phpcr:class', $this->type, \PHPCR\PropertyType::STRING);
-        $user->setProperty('phpcr_locale:fr-topic', 'french', \PHPCR\PropertyType::STRING);
-        $user->setProperty('phpcr_locale:fr-text', 'french text', \PHPCR\PropertyType::STRING);
-        $user->setProperty('phpcr_locale:frnullfields', array('nullable'), \PHPCR\PropertyType::STRING);
-        $user->setProperty('phpcr_locale:en-topic', 'english', \PHPCR\PropertyType::STRING);
-        $user->setProperty('phpcr_locale:en-text', 'english text', \PHPCR\PropertyType::STRING);
-        $user->setProperty('phpcr_locale:ennullfields', array('nullable'), \PHPCR\PropertyType::STRING);
+        $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
+        $user->setProperty('phpcr_locale:fr-topic', 'french', PropertyType::STRING);
+        $user->setProperty('phpcr_locale:fr-text', 'french text', PropertyType::STRING);
+        $user->setProperty('phpcr_locale:frnullfields', array('nullable'), PropertyType::STRING);
+        $user->setProperty('phpcr_locale:en-topic', 'english', PropertyType::STRING);
+        $user->setProperty('phpcr_locale:en-text', 'english text', PropertyType::STRING);
+        $user->setProperty('phpcr_locale:ennullfields', array('nullable'), PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
     }
 
@@ -117,7 +119,7 @@ class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
         // object must be the same locale
         $doc = $this->dm->findTranslation($this->type, '/functional/thename', 'fr');
 
-        $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $doc->child);
+        $this->assertInstanceOf(Proxy::class, $doc->child);
         $this->assertEquals('fr', $doc->locale);
         $this->assertEquals('fr', $doc->child->locale);
         $this->assertEquals('fr', $doc->child->relatedArticles[0]->locale);
@@ -127,7 +129,7 @@ class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
 
         $doc = $this->dm->findTranslation($this->type, '/functional/thename', 'en');
 
-        $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $doc->child);
+        $this->assertInstanceOf(Proxy::class, $doc->child);
         $this->assertEquals('en', $doc->locale);
         $this->assertEquals('en', $doc->child->locale);
         $this->assertEquals('Interesting Topic', $doc->child->topic);
@@ -142,7 +144,7 @@ class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
         // should give the doc and the related in french
         $child = $this->dm->findTranslation($this->type, '/functional/thename/child', 'en');
 
-        $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $child->parent);
+        $this->assertInstanceOf(Proxy::class, $child->parent);
         $this->assertEquals('en', $child->locale);
 
         $this->assertEquals('fr', $child->parent->locale);
@@ -167,7 +169,7 @@ class TranslationHierarchyTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctional
 
         $doc = $this->dm->findTranslation($this->type, '/functional/thename', 'fr');
 
-        $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $doc->child);
+        $this->assertInstanceOf(Proxy::class, $doc->child);
         $this->assertEquals('fr', $doc->locale);
         $this->assertEquals('fr', $doc->child->locale);
         $this->assertEquals('Sujet interessant', $doc->child->topic);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
@@ -2,21 +2,25 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\ODM\PHPCR\Translation\Translation;
 use Doctrine\Tests\Models\Translation\NoLocalePropertyArticle;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\WorkspaceInterface;
+use Doctrine\Tests\Models\Translation\Article;
 
-class TranslationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class TranslationTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @var \PHPCR\WorkspaceInterface
+     * @var WorkspaceInterface
      */
     private $workspace;
 
@@ -40,7 +44,7 @@ class TranslationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     public function testLoadAnnotations()
     {
         $factory = new ClassMetadataFactory($this->dm);
-        $metadata = $factory->getMetadataFor('Doctrine\Tests\Models\Translation\Article');
+        $metadata = $factory->getMetadataFor(Article::class);
 
         $this->assertFieldMetadataEquals(false, $metadata, 'author', 'translated');
         $this->assertFieldMetadataEquals(false, $metadata, 'publishDate', 'translated');
@@ -69,12 +73,13 @@ class TranslationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     /**
      * Assertion shortcut:
      * Check the given $metadata contain a field mapping for $field that contains the $key and having the value $expectedValue.
+     *
      * @param string $expectedValue The expected value
-     * @param \Doctrine\ODM\PHPCR\Mapping\ClassMetadata $metadata The class metadata to test
+     * @param ClassMetadata $metadata The class metadata to test
      * @param string $field The name of the field's mapping to test
      * @param string $key The key expected to be in the field mapping
      */
-    protected function assertFieldMetadataEquals($expectedValue, ClassMetadata $metadata, $field, $key)
+    private function assertFieldMetadataEquals($expectedValue, ClassMetadata $metadata, $field, $key)
     {
         $mapping = $metadata->mappings[$field];
         $this->assertInternalType('array', $mapping);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
@@ -4,7 +4,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\ODM\PHPCR\Translation\Translation;
+use Doctrine\Tests\Models\Translation\NoLocalePropertyArticle;
 
 class TranslationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 {
@@ -54,13 +56,14 @@ class TranslationTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
     }
 
     /**
-     * Test loading of a translatable document missing the @Locale annotation.
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
+     * Test loading of a translatable document missing the Locale annotation.
      */
     public function testLoadMissingLocaleAnnotation()
     {
         $factory = new ClassMetadataFactory($this->dm);
-        $factory->getMetadataFor('Doctrine\Tests\Models\Translation\NoLocalePropertyArticle');
+
+        $this->expectException(MappingException::class);
+        $factory->getMetadataFor(NoLocalePropertyArticle::class);
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
@@ -17,11 +17,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsBlogPost;
 use Doctrine\Tests\Models\CMS\CmsBlogInvalidChild;
 use Doctrine\Tests\Models\CMS\CmsBlogFolder;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
 /**
  * @group functional
  */
-class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class UnitOfWorkTest extends PHPCRFunctionalTestCase
 {
     /**
      * @var DocumentManager
@@ -45,9 +46,9 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $user1 = new CmsUser();
         $user1->username = 'dantleech';
         $address = new CmsAddress();
-        $address->city = "Springfield";
-        $address->zip = "12354";
-        $address->country = "Germany";
+        $address->city = 'Springfield';
+        $address->zip = '12354';
+        $address->country = 'Germany';
         $user1->address = $address;
 
         // getScheduledInserts
@@ -93,18 +94,18 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $root = $this->dm->find(null, 'functional');
 
         $parent1 = new ParentTestObj();
-        $parent1->nodename = "root1";
-        $parent1->name = "root1";
+        $parent1->nodename = 'root1';
+        $parent1->name = 'root1';
         $parent1->setParentDocument($root);
 
         $parent2 = new ParentTestObj();
-        $parent2->name = "/root2";
-        $parent2->nodename = "root2";
+        $parent2->name = '/root2';
+        $parent2->nodename = 'root2';
         $parent2->setParentDocument($root);
 
         $child = new ParentNoNodenameTestObj();
         $child->setParentDocument($parent1);
-        $child->name = "child";
+        $child->name = 'child';
 
         $this->dm->persist($parent1);
         $this->dm->persist($parent2);
@@ -178,10 +179,7 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->clear();
 
         // this forces the objects to be loaded in an order where the $parent will become a proxy
-        $documents = $this->dm->findMany(
-            'Doctrine\Tests\Models\References\ParentTestObj',
-            array($childId, $parentId)
-        );
+        $documents = $this->dm->findMany(ParentTestObj::class, array($childId, $parentId));
 
         $this->assertCount(2, $documents);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
 use Doctrine\ODM\PHPCR\UnitOfWork;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -193,10 +194,6 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->assertSame('parent', $parent->nodename);
     }
 
-    /**
-     * @expectedException Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
-     * @expectedExceptionMessage Document "Doctrine\Tests\Models\CMS\CmsArticleFolder" does not allow children of type "Doctrine\Tests\Models\CMS\CmsGroup". Allowed child classes "Doctrine\Tests\Models\CMS\CmsArticle"
-     */
     public function testRequiredClassesInvalidChildren()
     {
         $articleFolder = new CmsArticleFolder();
@@ -208,6 +205,9 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
         $this->dm->persist($articleFolder);
         $this->dm->persist($article);
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Document "Doctrine\Tests\Models\CMS\CmsArticleFolder" does not allow children of type "Doctrine\Tests\Models\CMS\CmsGroup". Allowed child classes "Doctrine\Tests\Models\CMS\CmsArticle"');
         $this->dm->flush();
     }
 
@@ -226,10 +226,6 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
-     * @expectedExceptionMessage Document "Doctrine\Tests\Models\CMS\CmsArticleFolder" does not allow children of type "Doctrine\Tests\Models\CMS\CmsGroup". Allowed child classes "Doctrine\Tests\Models\CMS\CmsArticle"
-     */
     public function testRequiredClassesInvalidUpdate()
     {
         $articleFolder = new CmsArticleFolder();
@@ -244,6 +240,9 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $this->dm->move($article, '/functional/articles/address');
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Document "Doctrine\Tests\Models\CMS\CmsArticleFolder" does not allow children of type "Doctrine\Tests\Models\CMS\CmsGroup". Allowed child classes "Doctrine\Tests\Models\CMS\CmsArticle"');
         $this->dm->flush();
     }
 
@@ -262,10 +261,6 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
-     * @expectedExceptionMessage Document "Doctrine\Tests\Models\CMS\CmsBlogFolder" does not allow children of type "Doctrine\Tests\Models\CMS\CmsBlogInvalidChild". Allowed child classes "Doctrine\Tests\Models\CMS\CmsBlogPost"
-     */
     public function testRequiredClassesAddToChildrenInvalid()
     {
         $post = new CmsBlogInvalidChild();
@@ -278,13 +273,12 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         ));
 
         $this->dm->persist($postFolder);
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Document "Doctrine\Tests\Models\CMS\CmsBlogFolder" does not allow children of type "Doctrine\Tests\Models\CMS\CmsBlogInvalidChild". Allowed child classes "Doctrine\Tests\Models\CMS\CmsBlogPost"');
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
-     * @expectedExceptionMessage Document "Doctrine\Tests\Models\CMS\CmsBlogFolder" does not allow children of type "Doctrine\Tests\Models\CMS\CmsBlogInvalidChild". Allowed child classes "Doctrine\Tests\Models\CMS\CmsBlogPost"
-     */
     public function testRequiredClassesAddToChildrenInvalidOnUpdate()
     {
         $post = new CmsBlogPost();
@@ -307,7 +301,8 @@ class UnitOfWorkTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $postFolder->posts->add($post);
 
         $this->dm->persist($postFolder);
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Document "Doctrine\Tests\Models\CMS\CmsBlogFolder" does not allow children of type "Doctrine\Tests\Models\CMS\CmsBlogInvalidChild". Allowed child classes "Doctrine\Tests\Models\CMS\CmsBlogPost"');
         $this->dm->flush();
-        $this->dm->clear();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/AnnotationsTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/AnnotationsTest.php
@@ -4,6 +4,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Versioning;
 
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
+use Doctrine\Tests\Models\Versioning\InvalidVersionableArticle;
+use Doctrine\Tests\Models\Versioning\InconsistentVersionableArticle;
 
 class AnnotationsTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 {
@@ -43,22 +46,24 @@ class AnnotationsTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
 
     /**
      * Test that using an invalid versionable annotation will not work
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
      */
     public function testLoadInvalidAnnotation()
     {
         $factory = new ClassMetadataFactory($this->dm);
-        $metadata = $factory->getMetadataFor('Doctrine\Tests\Models\Versioning\InvalidVersionableArticle');
+
+        $this->expectException(MappingException::class);
+        $factory->getMetadataFor(InvalidVersionableArticle::class);
     }
 
     /**
      * Test that using the Version annotation on non-versionable documents will not work
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
      */
     public function testLoadInconsistentAnnotations()
     {
         $factory = new ClassMetadataFactory($this->dm);
-        $factory->getMetadataFor('Doctrine\Tests\Models\Versioning\InconsistentVersionableArticle');
+
+        $this->expectException(MappingException::class);
+        $factory->getMetadataFor(InconsistentVersionableArticle::class);
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/AnnotationsTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/AnnotationsTest.php
@@ -2,21 +2,29 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Versioning;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\Tests\Models\Versioning\InvalidVersionableArticle;
 use Doctrine\Tests\Models\Versioning\InconsistentVersionableArticle;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Doctrine\Tests\Models\Versioning\VersionableArticle;
+use Doctrine\Tests\Models\Versioning\NonVersionableArticle;
+use Doctrine\Tests\Models\Versioning\FullVersionableArticle;
+use Doctrine\Tests\Models\Versioning\ExtendedVersionableArticle;
 
-class AnnotationsTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+class AnnotationsTest extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @var \PHPCR\SessionInterface
+     * @var SessionInterface
      */
     private $session;
 
@@ -34,12 +42,12 @@ class AnnotationsTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
         $factory = new ClassMetadataFactory($this->dm);
 
         // Check the annotation is correctly read if it is present
-        $metadata = $factory->getMetadataFor('Doctrine\Tests\Models\Versioning\VersionableArticle');
+        $metadata = $factory->getMetadataFor(VersionableArticle::class);
         $this->assertTrue(isset($metadata->versionable));
         $this->assertEquals('simple', $metadata->versionable);
 
         // Check the annotation is not set if it is not present
-        $metadata = $factory->getMetadataFor('Doctrine\Tests\Models\Versioning\NonVersionableArticle');
+        $metadata = $factory->getMetadataFor(NonVersionableArticle::class);
         $this->assertTrue(isset($metadata->versionable));
         $this->assertFalse($metadata->versionable);
     }
@@ -76,20 +84,20 @@ class AnnotationsTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
             $this->markTestSkipped('PHPCR repository doesn\'t support versioning');
         }
 
-        $node = $this->createTestDocument('versionable-article-test', 'Doctrine\\Tests\\Models\\Versioning\\VersionableArticle');
+        $node = $this->createTestDocument('versionable-article-test', VersionableArticle::class);
         $this->assertTrue($node->isNodeType('mix:simpleVersionable'));
         $this->assertFalse($node->isNodeType('mix:versionable'));
 
         // mix:versionable derives from mix:simpleVersionable, so a full versionable node will be both types
-        $node = $this->createTestDocument('versionable-article-test', 'Doctrine\\Tests\\Models\\Versioning\\FullVersionableArticle');
+        $node = $this->createTestDocument('versionable-article-test', FullVersionableArticle::class);
         $this->assertTrue($node->isNodeType('mix:versionable'));
         $this->assertTrue($node->isNodeType('mix:simpleVersionable'));
 
-        $node = $this->createTestDocument('versionable-article-test', 'Doctrine\\Tests\\Models\\Versioning\\NonVersionableArticle');
+        $node = $this->createTestDocument('versionable-article-test', NonVersionableArticle::class);
         $this->assertFalse($node->isNodeType('mix:simpleVersionable'));
         $this->assertFalse($node->isNodeType('mix:versionable'));
 
-        $node = $this->createTestDocument('versionable-article-test', 'Doctrine\\Tests\\Models\\Versioning\\ExtendedVersionableArticle');
+        $node = $this->createTestDocument('versionable-article-test', ExtendedVersionableArticle::class);
         $this->assertTrue($node->isNodeType('mix:simpleVersionable'));
         $this->assertTrue($node->isNodeType('mix:versionable'));
     }
@@ -100,16 +108,15 @@ class AnnotationsTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
      * @param string $name The name of the new node (will be created under root)
      * @param string $class The class name of the document
      *
-     * @return \PHPCR\NodeInterface
+     * @return NodeInterface
      */
-    protected function createTestDocument($name, $class)
+    private function createTestDocument($name, $class)
     {
         $this->removeTestNode($name);
 
         $article = new $class();
         $article->id = '/' . $name;
         $article->author = 'John Doe';
-        $article->topic = 'Some topic';
         $article->topic = 'Some subject';
         $article->setText('Lorem ipsum...');
 
@@ -128,7 +135,7 @@ class AnnotationsTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
      *
      * @return void
      */
-    protected function removeTestNode($name)
+    private function removeTestNode($name)
     {
         $root = $this->session->getNode('/');
         if ($root->hasNode($name)) {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/FullVersioningTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/FullVersioningTest.php
@@ -32,7 +32,7 @@ class FullVersioningTest extends VersioningTestAbstract
 {
     public function setUp()
     {
-        $this->typeVersion = 'Doctrine\Tests\ODM\PHPCR\Functional\Versioning\FullVersionTestObj';
+        $this->typeVersion = FullVersionTestObj::class;
         parent::setUp();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/SimpleVersioningTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/SimpleVersioningTest.php
@@ -32,7 +32,7 @@ class SimpleVersioningTest extends VersioningTestAbstract
 {
     public function setUp()
     {
-        $this->typeVersion = 'Doctrine\Tests\ODM\PHPCR\Functional\Versioning\SimpleVersionTestObj';
+        $this->typeVersion = SimpleVersionTestObj::class;
         parent::setUp();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/VersioningTestAbstract.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/VersioningTestAbstract.php
@@ -2,22 +2,24 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Versioning;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
 use PHPCR\ReferentialIntegrityException;
 use PHPCR\Util\PathHelper;
 use Doctrine\Tests\Models\Versioning\FullVersionableArticle;
 use Doctrine\Tests\Models\Versioning\FullVersionableArticleWithChildren;
 use Doctrine\Tests\Models\Versioning\NonVersionableArticle;
-use Doctrine\ODM\PHPCR\UnitOfWork;
 use PHPCR\Version\VersionException;
 
 /**
  * @group functional
  */
-abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
@@ -36,13 +38,13 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
     private $typeReference;
 
     /**
-     * @var \PHPCR\NodeInterface
+     * @var NodeInterface
      */
     private $node;
 
     public function setUp()
     {
-        $this->typeReference = 'Doctrine\Tests\ODM\PHPCR\Functional\Versioning\ReferenceTestObj';
+        $this->typeReference = ReferenceTestObj::class;
         $this->dm = $this->createDocumentManager();
 
         // Check that the repository supports versioning
@@ -111,7 +113,7 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
         $user = $this->dm->find($this->typeVersion, '/functional/versionTestObj');
         $this->dm->checkin($user);
 
-        $this->assertInstanceOf('PHPCR\NodeInterface', $user->node);
+        $this->assertInstanceOf(NodeInterface::class, $user->node);
         $this->assertTrue($user->node->isNodeType('mix:simpleVersionable'));
 
         // TODO: understand why jcr:isCheckedOut is true for a checked in node
@@ -375,13 +377,13 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
         $this->dm->checkpoint($versionableArticle);
 
         $firstVersion = $this->dm->findVersionByName(
-                'Doctrine\Tests\Models\Versioning\FullVersionableArticleWithChildren',
+                FullVersionableArticleWithChildren::class,
                 $versionableArticle->id,
                 '1.0'
         );
 
         $secondVersion = $this->dm->findVersionByName(
-                'Doctrine\Tests\Models\Versioning\FullVersionableArticleWithChildren',
+                FullVersionableArticleWithChildren::class,
                 $versionableArticle->id,
                 '1.1'
         );

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/VersioningTestAbstract.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/VersioningTestAbstract.php
@@ -3,11 +3,13 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Versioning;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use PHPCR\ReferentialIntegrityException;
 use PHPCR\Util\PathHelper;
 use Doctrine\Tests\Models\Versioning\FullVersionableArticle;
 use Doctrine\Tests\Models\Versioning\FullVersionableArticleWithChildren;
 use Doctrine\Tests\Models\Versioning\NonVersionableArticle;
 use Doctrine\ODM\PHPCR\UnitOfWork;
+use PHPCR\Version\VersionException;
 
 /**
  * @group functional
@@ -74,16 +76,15 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
         $this->dm = $this->createDocumentManager();
     }
 
-    /**
-     * @expectedException Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     * @expectedMessage The document at path '/functional/referenceTestObj' is not versionable
-     */
     public function testCheckinOnNonVersionableNode()
     {
         $contentNode = $this->dm->find(
             $this->typeReference,
             '/functional/referenceTestObj'
         );
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The document at path \'/functional/referenceTestObj\' is not versionable');
         $this->dm->checkin($contentNode);
     }
 
@@ -174,7 +175,6 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
 
     /**
      * Test it's not possible to get a version of a non-versionable document
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
      */
     public function testFindVersionByNameNotVersionable()
     {
@@ -182,15 +182,17 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
         $node = $session->getNode('/functional')->addNode('noVersionTestObj');
         $session->save();
         $id = $node->getPath();
+
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->findVersionByName($this->typeVersion, $id, 'whatever');
     }
 
     /**
      * Test that trying to read a non existing version fails
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
      */
     public function testFindVersionByNameVersionDoesNotExist()
     {
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->findVersionByName($this->typeVersion, '/functional/versionTestObj', 'whatever');
     }
 
@@ -234,9 +236,6 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
         $this->assertNull($frozenDocument->reference);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testPersistVersionError()
     {
         $doc = $this->dm->find($this->typeVersion, '/functional/versionTestObj');
@@ -248,6 +247,7 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
 
         $frozenDocument = $this->dm->findVersionByName($this->typeVersion, '/functional/versionTestObj', $lastVersionName);
 
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->persist($frozenDocument);
     }
 
@@ -275,7 +275,6 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
 
     /**
      * Check we cannot remove the last version of a document (since it's the current version)
-     * @expectedException \PHPCR\ReferentialIntegrityException
      */
     public function testRemoveLastVersion()
     {
@@ -288,12 +287,13 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
 
         $version = $this->dm->findVersionByName($this->typeVersion, '/functional/versionTestObj', $lastVersionName);
         $this->assertNotNull($version);
+
+        $this->expectException(ReferentialIntegrityException::class);
         $this->dm->removeVersion($version);
     }
 
     /**
      * Check we cannot remove the root version of a document
-     * @expectedException \PHPCR\Version\VersionException
      */
     public function testRemoveRootVersion()
     {
@@ -306,6 +306,8 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
 
         $version = $this->dm->findVersionByName($this->typeVersion, '/functional/versionTestObj', $firstVersionName);
         $this->assertNotNull($version);
+
+        $this->expectException(VersionException::class);
         $this->dm->removeVersion($version);
     }
 
@@ -336,10 +338,10 @@ abstract class VersioningTestAbstract extends \Doctrine\Tests\ODM\PHPCR\PHPCRFun
     /**
      * Check the version we removed in testRemoveVersion does not exist anymore
      * @depends testRemoveVersion
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
      */
     public function testDeletedVersionDoesNotExistAnymore($lastVersionName)
     {
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->findVersionByName($this->typeVersion, '/functional/versionTestObj', $lastVersionName);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/AssignedIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/AssignedIdGeneratorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Id\AssignedIdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
@@ -15,7 +16,7 @@ class AssignedIdGeneratorTest extends TestCase
 
         $generator = new AssignedIdGenerator;
         $cm = new ClassMetadataProxy($id);
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
 
         $this->assertEquals($id, $generator->generate(null, $cm, $dm));
     }
@@ -29,7 +30,7 @@ class AssignedIdGeneratorTest extends TestCase
 
         $generator = new AssignedIdGenerator;
         $cm = new ClassMetadataProxy($id);
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
 
         try {
             $generator->generate(null, $cm, $dm);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/IdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/IdGeneratorTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Doctrine\ODM\PHPCR\Id\ParentIdGenerator;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdGenerator;
+use Doctrine\ODM\PHPCR\Id\AssignedIdGenerator;
 use Doctrine\ODM\PHPCR\Id\AutoIdGenerator;
 use Doctrine\ODM\PHPCR\Id\IdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
@@ -8,34 +11,34 @@ use PHPUnit\Framework\TestCase;
 class IdGeneratorTest extends TestCase
 {
     /**
-     * @covers Doctrine\ODM\PHPCR\Id\IdGenerator::create
+     * @covers \Doctrine\ODM\PHPCR\Id\IdGenerator::create
      */
     public function testCreateGeneratorTypeAssigned()
     {
         $generator = IdGenerator::create(ClassMetadata::GENERATOR_TYPE_ASSIGNED);
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Id\AssignedIdGenerator', $generator);
+        $this->assertInstanceOf(AssignedIdGenerator::class, $generator);
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\Id\IdGenerator::create
+     * @covers \Doctrine\ODM\PHPCR\Id\IdGenerator::create
      */
     public function testCreateGeneratorTypeRepository()
     {
         $generator = IdGenerator::create(ClassMetadata::GENERATOR_TYPE_REPOSITORY);
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Id\RepositoryIdGenerator', $generator);
+        $this->assertInstanceOf(RepositoryIdGenerator::class, $generator);
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\Id\IdGenerator::create
+     * @covers \Doctrine\ODM\PHPCR\Id\IdGenerator::create
      */
     public function testCreateGeneratorTypeParent()
     {
         $generator = IdGenerator::create(ClassMetadata::GENERATOR_TYPE_PARENT);
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Id\ParentIdGenerator', $generator);
+        $this->assertInstanceOf(ParentIdGenerator::class, $generator);
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\Id\IdGenerator::create
+     * @covers \Doctrine\ODM\PHPCR\Id\IdGenerator::create
      */
     public function testCreateGeneratorTypeAuto()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/IdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/IdGeneratorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\ODM\PHPCR\Id\AutoIdGenerator;
 use Doctrine\ODM\PHPCR\Id\IdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
@@ -39,15 +40,12 @@ class IdGeneratorTest extends TestCase
     public function testCreateGeneratorTypeAuto()
     {
         $generator = IdGenerator::create(ClassMetadata::GENERATOR_TYPE_AUTO);
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Id\AutoIdGenerator', $generator);
+        $this->assertInstanceOf(AutoIdGenerator::class, $generator);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     * @covers Doctrine\ODM\PHPCR\Id\IdGenerator::create
-     */
     public function testCreateException()
     {
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         IdGenerator::create(null);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/ParentIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/ParentIdGeneratorTest.php
@@ -2,9 +2,12 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Id;
 
+use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Id\ParentIdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\UnitOfWork;
 
 class ParentIdGeneratorTest extends TestCase
 {
@@ -18,14 +21,14 @@ class ParentIdGeneratorTest extends TestCase
         $generator = new ParentIdGenerator;
         $parent = new ParentDummy;
         $cm = new ParentClassMetadataProxy($parent, 'name', $id, new MockField($parent, '/miau'));
-        $uow = $this->getMockBuilder('Doctrine\ODM\PHPCR\UnitOfWork')->disableOriginalConstructor()->getMock();
+        $uow = $this->createMock(UnitOfWork::class);
         $uow
             ->expects($this->once())
             ->method('getDocumentId')
             ->with($this->equalTo($parent))
             ->will($this->returnValue('/miau'))
         ;
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
         $dm
             ->expects($this->once())
             ->method('getUnitOfWork')
@@ -43,7 +46,7 @@ class ParentIdGeneratorTest extends TestCase
 
         $generator = new ParentIdGenerator;
         $cm = new ParentClassMetadataProxy(null, 'name', $id);
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
 
         $this->assertEquals($id, $generator->generate(null, $cm, $dm));
     }
@@ -57,67 +60,61 @@ class ParentIdGeneratorTest extends TestCase
 
         $generator = new ParentIdGenerator;
         $cm = new ParentClassMetadataProxy(new ParentDummy, '', $id);
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
 
         $this->assertEquals($id, $generator->generate(null, $cm, $dm));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
-     */
     public function testGenerateNoIdNoParentNoName()
     {
         $generator = new ParentIdGenerator;
         $cm = new ParentClassMetadataProxy(null, '', '');
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
 
+        $this->expectException(IdException::class);
         $generator->generate(null, $cm, $dm);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
-     */
     public function testGenerateNoIdNoParent()
     {
         $generator = new ParentIdGenerator;
         $cm = new ParentClassMetadataProxy(null, 'name', '');
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
 
+        $this->expectException(IdException::class);
         $generator->generate(null, $cm, $dm);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
-     */
     public function testGenerateNoIdNoName()
     {
         $generator = new ParentIdGenerator;
         $cm = new ParentClassMetadataProxy(new ParentDummy, '', '');
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
 
+        $this->expectException(IdException::class);
         $generator->generate(null, $cm, $dm);
     }
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Id\IdException
-     */
+
     public function testGenerateNoParentId()
     {
         $generator = new ParentIdGenerator;
         $parent = new ParentDummy;
         $cm = new ParentClassMetadataProxy($parent, 'name', '', new MockField($parent, '/miau'));
-        $uow = $this->getMockBuilder('Doctrine\ODM\PHPCR\UnitOfWork')->disableOriginalConstructor()->getMock();
+        $uow = $this->createMock(UnitOfWork::class);
         $uow
             ->expects($this->once())
             ->method('getDocumentId')
             ->with($this->equalTo($parent))
             ->will($this->returnValue(''))
         ;
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
         $dm
             ->expects($this->once())
             ->method('getUnitOfWork')
             ->will($this->returnValue($uow))
         ;
+
+        $this->expectException(IdException::class);
         $generator->generate(null, $cm, $dm);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/RepositoryIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/RepositoryIdGeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
@@ -13,14 +15,14 @@ class RepositoryIdGeneratorTest extends TestCase
     {
         $id = 'moo';
         $cm = new RepositoryClassMetadataProxy($id);
-        $repository = $this->getMockBuilder('Doctrine\ODM\PHPCR\Id\RepositoryIdInterface')->getMock();
+        $repository = $this->createMock(RepositoryIdInterface::class);
         $repository
             ->expects($this->once())
             ->method('generateId')
             ->with($this->equalTo(null))
             ->will($this->returnValue('generatedid'))
         ;
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
         $dm
             ->expects($this->once())
             ->method('getRepository')
@@ -40,14 +42,14 @@ class RepositoryIdGeneratorTest extends TestCase
         $id = 'moo';
         $generator = new RepositoryIdGenerator;
         $cm = new ClassMetadataProxy($id);
-        $repository = $this->getMockBuilder('Doctrine\ODM\PHPCR\Id\RepositoryIdInterface')->getMock();
+        $repository = $this->createMock(RepositoryIdInterface::class);
         $repository
             ->expects($this->once())
             ->method('generateId')
             ->with($this->equalTo(null))
             ->will($this->throwException(new \Exception))
         ;
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $dm = $this->createMock(DocumentManager::class);
         $dm
             ->expects($this->once())
             ->method('getRepository')

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -2,20 +2,24 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use PHPUnit\Framework\TestCase;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
+use Doctrine\Tests\Models\ECommerce\ECommerceCart;
+use PHPCR\SessionInterface;
 
 abstract class AbstractMappingDriverTest extends TestCase
 {
     /**
-     * @return \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver
+     * @return MappingDriver
      */
     abstract protected function loadDriver();
     /**
-     * @return \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver
+     * @return MappingDriver
      */
     abstract protected function loadDriverForTestMappingDocuments();
 
@@ -29,7 +33,8 @@ abstract class AbstractMappingDriverTest extends TestCase
      * of this class.
      *
      * @param string $className
-     * @return \Doctrine\ODM\PHPCR\Mapping\ClassMetadata
+     *
+     * @return ClassMetadata
      */
     protected function loadMetadataForClassname($className)
     {
@@ -66,7 +71,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testGetAllClassNamesReturnsAlreadyLoadedClassesIfAppropriate()
     {
-        $rightClassName = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\FieldMappingObject';
+        $rightClassName = Model\FieldMappingObject::class;
         $this->ensureIsLoaded($rightClassName);
 
         $driver = $this->loadDriverForTestMappingDocuments();
@@ -77,7 +82,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testGetAllClassNamesReturnsOnlyTheAppropriateClasses()
     {
-        $extraneousClassName = 'Doctrine\Tests\Models\ECommerce\ECommerceCart';
+        $extraneousClassName = ECommerceCart::class;
         $this->ensureIsLoaded($extraneousClassName);
 
         $driver = $this->loadDriverForTestMappingDocuments();
@@ -87,19 +92,21 @@ abstract class AbstractMappingDriverTest extends TestCase
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver::loadMetadataForClass
-     * @covers Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver::loadMetadataForClass
-     * @covers Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver::loadMetadataForClass
+     * @covers \Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver::loadMetadataForClass
+     * @covers \Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver::loadMetadataForClass
+     * @covers \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver::loadMetadataForClass
      */
     public function testLoadFieldMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\FieldMappingObject';
+        $className = Model\FieldMappingObject::class;
         return $this->loadMetadataForClassName($className);
     }
 
     /**
      * @depends testLoadFieldMapping
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testFieldMappings($class)
     {
@@ -135,6 +142,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testIdentifier($class)
     {
@@ -146,6 +155,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testStringFieldMappings($class)
     {
@@ -158,6 +169,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testBinaryFieldMappings($class)
     {
@@ -170,6 +183,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testLongFieldMappings($class)
     {
@@ -182,6 +197,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testIntFieldMappings($class)
     {
@@ -194,6 +211,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testDecimalFieldMappings($class)
     {
@@ -206,6 +225,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testDoubleFieldMappings($class)
     {
@@ -218,6 +239,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testFloatFieldMappings($class)
     {
@@ -230,6 +253,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testDateFieldMappings($class)
     {
@@ -242,6 +267,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testBooleanFieldMappings($class)
     {
@@ -266,6 +293,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testPathFieldMappings($class)
     {
@@ -278,6 +307,8 @@ abstract class AbstractMappingDriverTest extends TestCase
     /**
      * @depends testFieldMappings
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
     public function testUriFieldMappings($class)
     {
@@ -289,7 +320,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadNodenameMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\NodenameMappingObject';
+        $className = Model\NodenameMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -306,7 +337,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadParentDocumentMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ParentDocumentMappingObject';
+        $className = Model\ParentDocumentMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -323,7 +354,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadDepthMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\DepthMappingObject';
+        $className = Model\DepthMappingObject::class;
         return $this->loadMetadataForClassname($className);
     }
 
@@ -339,19 +370,20 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testParentWithPrivatePropertyMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ParentWithPrivatePropertyObject';
+        $className = Model\ParentWithPrivatePropertyObject::class;
         $class = $this->loadMetadataForClassname($className);
         $this->assertEquals('foo', $class->mappings['foo']['property']);
         $this->assertEquals('string', $class->mappings['foo']['type']);
 
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ParentPrivatePropertyMappingObject';
+        $className = Model\ParentPrivatePropertyMappingObject::class;
         $class = $this->loadMetadataForClassname($className);
 
         $this->assertTrue(isset($class->identifier));
         $this->assertEmpty($class->fieldMappings);
 
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
-        $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session);
+        /** @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject $session */
+        $session = $this->createMock(SessionInterface::class);
+        $dm = DocumentManager::create($session);
         $dm->getConfiguration()->setMetadataDriverImpl($this->loadDriver());
         $cmf = new ClassMetadataFactory($dm);
         $class = $cmf->getMetadataFor($className);
@@ -360,9 +392,12 @@ abstract class AbstractMappingDriverTest extends TestCase
         $this->assertEquals('string', $class->mappings['foo']['type']);
     }
 
+    /**
+     * @return ClassMetadata
+     */
     public function testLoadChildMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildMappingObject';
+        $className = Model\ChildMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -383,7 +418,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadChildrenMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildrenMappingObject';
+        $className = Model\ChildrenMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -406,7 +441,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadRepositoryMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\RepositoryMappingObject';
+        $className = Model\RepositoryMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -417,13 +452,13 @@ abstract class AbstractMappingDriverTest extends TestCase
      */
     public function testRepositoryMapping($class)
     {
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\DocumentRepository', $class->customRepositoryClassName);
+        $this->assertEquals(Model\DocumentRepository::class, $class->customRepositoryClassName);
         $this->assertTrue($class->isIdGeneratorRepository());
     }
 
     public function testLoadVersionableMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\VersionableMappingObject';
+        $className = Model\VersionableMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -441,7 +476,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadReferenceableMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceableMappingObject';
+        $className = Model\ReferenceableMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -457,7 +492,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadUniqueNodeTypeMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\UniqueNodeTypeMappingObject';
+        $className = Model\UniqueNodeTypeMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -473,7 +508,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadNodeTypeMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\NodeTypeMappingObject';
+        $className = Model\NodeTypeMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -489,7 +524,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadMappedSuperclassTypeMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\MappedSuperclassMappingObject';
+        $className = Model\MappedSuperclassMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -502,7 +537,7 @@ abstract class AbstractMappingDriverTest extends TestCase
     {
         $this->assertTrue($class->isMappedSuperclass);
         $this->assertEquals("phpcr:test", $class->nodeType);
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\DocumentRepository', $class->customRepositoryClassName);
+        $this->assertEquals(Model\DocumentRepository::class, $class->customRepositoryClassName);
         $this->assertEquals("children", $class->translator);
         $this->assertEquals(array('mix:one', 'mix:two'), $class->mixins);
         $this->assertEquals("simple", $class->versionable);
@@ -520,12 +555,12 @@ abstract class AbstractMappingDriverTest extends TestCase
     public function testLoadMappedSuperclassChildTypeMapping()
     {
         $parentClass = $this->loadMetadataForClassname(
-            'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceParentMappingObject'
+            Model\ClassInheritanceParentMappingObject::class
         );
 
         $mappingDriver = $this->loadDriver();
         $subClass = new ClassMetadata(
-            $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceChildMappingObject'
+            $className = Model\ClassInheritanceChildMappingObject::class
         );
         $subClass->initializeReflection(new RuntimeReflectionService());
         $subClass->mapId($parentClass->mappings[$parentClass->identifier], $parentClass);
@@ -551,7 +586,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadNodeMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\NodeMappingObject';
+        $className = Model\NodeMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -567,7 +602,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadReferenceOneMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceOneMappingObject';
+        $className = Model\ReferenceOneMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -588,20 +623,20 @@ abstract class AbstractMappingDriverTest extends TestCase
         $this->assertEquals('referenceOneWeak', $referenceOneWeak['fieldName']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $referenceOneWeak['targetDocument']);
         $this->assertEquals('weak', $referenceOneWeak['strategy']);
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceOneMappingObject', $referenceOneWeak['sourceDocument']);
+        $this->assertEquals(Model\ReferenceOneMappingObject::class, $referenceOneWeak['sourceDocument']);
         $this->assertEquals(ClassMetadata::MANY_TO_ONE, $referenceOneWeak['type']);
 
         $referenceOneHard = $class->mappings['referenceOneHard'];
         $this->assertEquals('referenceOneHard', $referenceOneHard['fieldName']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $referenceOneHard['targetDocument']);
         $this->assertEquals('hard', $referenceOneHard['strategy']);
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceOneMappingObject', $referenceOneHard['sourceDocument']);
+        $this->assertEquals(Model\ReferenceOneMappingObject::class, $referenceOneHard['sourceDocument']);
         $this->assertEquals(ClassMetadata::MANY_TO_ONE, $referenceOneHard['type']);
     }
 
     public function testLoadReferenceManyMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceManyMappingObject';
+        $className = Model\ReferenceManyMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -623,20 +658,20 @@ abstract class AbstractMappingDriverTest extends TestCase
         $this->assertEquals('referenceManyWeak', $referenceManyWeak['fieldName']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $referenceManyWeak['targetDocument']);
         $this->assertEquals('weak', $referenceManyWeak['strategy']);
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceManyMappingObject', $referenceManyWeak['sourceDocument']);
+        $this->assertEquals(Model\ReferenceManyMappingObject::class, $referenceManyWeak['sourceDocument']);
         $this->assertEquals(ClassMetadata::MANY_TO_MANY, $referenceManyWeak['type']);
 
         $referenceManyHard = $class->mappings['referenceManyHard'];
         $this->assertEquals('referenceManyHard', $referenceManyHard['fieldName']);
         $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\myDocument', $referenceManyHard['targetDocument']);
         $this->assertEquals('hard', $referenceManyHard['strategy']);
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceManyMappingObject', $referenceManyHard['sourceDocument']);
+        $this->assertEquals(Model\ReferenceManyMappingObject::class, $referenceManyHard['sourceDocument']);
         $this->assertEquals(ClassMetadata::MANY_TO_MANY, $referenceManyHard['type']);
     }
 
     public function testLoadReferrersMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferrersMappingObject';
+        $className = Model\ReferrersMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -677,7 +712,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadTranslatorMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObject';
+        $className = Model\TranslatorMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -697,7 +732,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadMixinMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\MixinMappingObject';
+        $className = Model\MixinMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -714,7 +749,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadReplaceMixinMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReplaceMixinMappingObject';
+        $className = Model\ReplaceMixinMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -731,7 +766,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadLifecycleCallbackMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\LifecycleCallbackMappingObject';
+        $className = Model\LifecycleCallbackMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -754,11 +789,12 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testStringExtendedMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\StringMappingObject';
+        $className = Model\StringMappingObject::class;
         $this->loadMetadataForClassname($className);
 
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\StringExtendedMappingObject';
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        $className = Model\StringExtendedMappingObject::class;
+        /** @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject $session */
+        $session = $this->createMock(SessionInterface::class);
         $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session);
         $dm->getConfiguration()->setMetadataDriverImpl($this->loadDriver());
         $cmf = new ClassMetadataFactory($dm);
@@ -786,7 +822,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadUuidMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\UuidMappingObject';
+        $className = Model\UuidMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -796,14 +832,14 @@ abstract class AbstractMappingDriverTest extends TestCase
      */
     public function testUuidMappingNonReferenceable()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\UuidMappingObject';
+        $className = Model\UuidMappingObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
 
     public function testLoadChildClassesMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesObject';
+        $className = Model\ChildClassesObject::class;
 
         return $this->loadMetadataForClassname($className);
     }
@@ -819,7 +855,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     public function testLoadIsLeafMapping()
     {
-        $className = 'Doctrine\Tests\ODM\PHPCR\Mapping\Model\IsLeafObject';
+        $className = Model\IsLeafObject::class;
 
         return $this->loadMetadataForClassname($className);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -6,6 +6,7 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use PHPUnit\Framework\TestCase;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
 
 abstract class AbstractMappingDriverTest extends TestCase
 {
@@ -48,7 +49,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
         $driver = $this->loadDriver();
 
-        $this->setExpectedException('Doctrine\ODM\PHPCR\Mapping\MappingException');
+        $this->expectException(MappingException::class);
         $driver->loadMetadataForClass('stdClass', $cm);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -795,7 +795,7 @@ abstract class AbstractMappingDriverTest extends TestCase
         $className = Model\StringExtendedMappingObject::class;
         /** @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject $session */
         $session = $this->createMock(SessionInterface::class);
-        $dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session);
+        $dm = DocumentManager::create($session);
         $dm->getConfiguration()->setMetadataDriverImpl($this->loadDriver());
         $cmf = new ClassMetadataFactory($dm);
         $class = $cmf->getMetadataFor($className);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
@@ -1,6 +1,6 @@
 <?php
-
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
+
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 
@@ -28,6 +28,5 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
      */
     public function testParentWithPrivatePropertyMapping()
     {
-        return;
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 
 /**
  * @group mapping
@@ -9,8 +11,9 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
 {
     protected function loadDriver()
     {
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-        return new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver($reader);
+        $reader = new AnnotationReader();
+
+        return new AnnotationDriver($reader);
     }
 
     protected function loadDriverForTestMappingDocuments()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -2,11 +2,14 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Event;
+use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use PHPUnit\Framework\TestCase;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use PHPCR\SessionInterface;
@@ -14,33 +17,32 @@ use PHPCR\SessionInterface;
 class ClassMetadataFactoryTest extends TestCase
 {
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
+     * @var DocumentManager
      */
     private $dm;
 
     /**
-     * @param $fqn
+     * @param string $fqn
      *
      * @return ClassMetadata
      */
     protected function getMetadataFor($fqn)
     {
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-        $annotationDriver = new \Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver($reader);
+        $reader = new AnnotationReader();
+        $annotationDriver = new AnnotationDriver($reader);
         $annotationDriver->addPaths(array(__DIR__ . '/Model'));
         $this->dm->getConfiguration()->setMetadataDriverImpl($annotationDriver);
 
         $cmf = new ClassMetadataFactory($this->dm);
-        $meta = $cmf->getMetadataFor($fqn);
 
-        return $meta;
+        return $cmf->getMetadataFor($fqn);
     }
 
     public function setUp()
     {
         /** @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject $session */
         $session = $this->createMock(SessionInterface::class);
-        $this->dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session);
+        $this->dm = DocumentManager::create($session);
     }
 
     public function testNotMappedThrowsException()
@@ -83,17 +85,15 @@ class ClassMetadataFactoryTest extends TestCase
         $this->markTestIncomplete('Test cache driver setting and handling.');
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     */
     public function testLoadMetadataReferenceableChildOverriddenAsFalse()
     {
-        $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ReferenceableChildReferenceableFalseMappingObject');
+        $this->expectException(MappingException::class);
+        $this->getMetadataFor(Model\ReferenceableChildReferenceableFalseMappingObject::class);
     }
 
     public function testLoadMetadataDefaults()
     {
-        $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\DefaultMappingObject');
+        $meta = $this->getMetadataFor(Model\DefaultMappingObject::class);
         $this->assertFalse($meta->referenceable);
         $this->assertNull($meta->translator);
         $this->assertEquals('nt:unstructured', $meta->nodeType);
@@ -103,18 +103,18 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testLoadMetadataClassInheritanceChild()
     {
-        $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceChildMappingObject');
+        $meta = $this->getMetadataFor(Model\ClassInheritanceChildMappingObject::class);
         $this->assertTrue($meta->referenceable);
         $this->assertEquals('foo', $meta->translator);
         $this->assertEquals('nt:test', $meta->nodeType);
         $this->assertEquals(array('mix:foo', 'mix:bar'), $meta->mixins);
         $this->assertEquals('simple', $meta->versionable);
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\DocumentRepository', $meta->customRepositoryClassName);
+        $this->assertEquals(Model\DocumentRepository::class, $meta->customRepositoryClassName);
     }
 
     public function testLoadInheritedMixins()
     {
-        $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\InheritedMixinMappingObject');
+        $meta = $this->getMetadataFor(Model\InheritedMixinMappingObject::class);
         $this->assertCount(2, $meta->mixins);
         $this->assertContains('mix:lastModified', $meta->mixins);
         $this->assertContains('mix:title', $meta->mixins);
@@ -122,44 +122,39 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testLoadMetadataClassInheritanceChildCanOverride()
     {
-        $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ClassInheritanceChildOverridesMappingObject');
+        $meta = $this->getMetadataFor(Model\ClassInheritanceChildOverridesMappingObject::class);
         $this->assertTrue($meta->referenceable);
         $this->assertEquals('bar', $meta->translator);
         $this->assertEquals('nt:test-override', $meta->nodeType);
         $this->assertEquals(array('mix:baz'), $meta->mixins);
         $this->assertEquals('full', $meta->versionable);
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Model\BarfooRepository', $meta->customRepositoryClassName);
+        $this->assertEquals(Model\BarfooRepository::class, $meta->customRepositoryClassName);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     * @expectedExceptionMessage is not referenceable
-     */
     public function testValidateUuidNotReferenceable()
     {
-        $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\UuidMappingObjectNotReferenceable');
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('is not referenceable');
+
+        $this->getMetadataFor(Model\UuidMappingObjectNotReferenceable::class);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     */
     public function testValidateTranslatableNoStrategy()
     {
-        $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObjectNoStrategy');
+        $this->expectException(MappingException::class);
+        $this->getMetadataFor(Model\TranslatorMappingObjectNoStrategy::class);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     * @expectedExceptionMessage Cannot map a document as a leaf and define child classes for "Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesAndLeafObject"
-     */
     public function testValidateChildClassesIfLeafConflict()
     {
-        $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesAndLeafObject');
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Cannot map a document as a leaf and define child classes for "Doctrine\Tests\ODM\PHPCR\Mapping\Model\ChildClassesAndLeafObject"');
+        $this->getMetadataFor(Model\ChildClassesAndLeafObject::class);
     }
 
     public function testValidateTranslatable()
     {
-        $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\TranslatorMappingObject');
+        $this->getMetadataFor(Model\TranslatorMappingObject::class);
     }
 
     public function testLoadClassMetadataEvent()
@@ -168,7 +163,7 @@ class ClassMetadataFactoryTest extends TestCase
         $evm = $this->dm->getEventManager();
         $evm->addEventListener(array(Event::loadClassMetadata), $listener);
 
-        $meta = $this->getMetadataFor('Doctrine\Tests\ODM\PHPCR\Mapping\Model\DefaultMappingObject');
+        $meta = $this->getMetadataFor(Model\DefaultMappingObject::class);
         $this->assertTrue($listener->called);
         $this->assertSame($this->dm, $listener->dm);
         $this->assertSame($meta, $listener->meta);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -3,10 +3,13 @@
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Event;
 use PHPUnit\Framework\TestCase;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
+use PHPCR\SessionInterface;
 
 class ClassMetadataFactoryTest extends TestCase
 {
@@ -35,7 +38,8 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function setUp()
     {
-        $session = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
+        /** @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject $session */
+        $session = $this->createMock(SessionInterface::class);
         $this->dm = \Doctrine\ODM\PHPCR\DocumentManager::create($session);
     }
 
@@ -43,7 +47,7 @@ class ClassMetadataFactoryTest extends TestCase
     {
         $cmf = new ClassMetadataFactory($this->dm);
 
-        $this->setExpectedException('Doctrine\ODM\PHPCR\Mapping\MappingException');
+        $this->expectException(MappingException::class);
         $cmf->getMetadataFor('unknown');
     }
 
@@ -51,7 +55,7 @@ class ClassMetadataFactoryTest extends TestCase
     {
         $cmf = new ClassMetadataFactory($this->dm);
 
-        $cm = new \Doctrine\ODM\PHPCR\Mapping\ClassMetadata('stdClass');
+        $cm = new ClassMetadata('stdClass');
 
         $cmf->setMetadataFor('stdClass', $cm);
 
@@ -61,12 +65,12 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testGetAllMetadata()
     {
-        $driver = new \Doctrine\Common\Persistence\Mapping\Driver\PHPDriver(array(__DIR__ . '/Model/php'));
+        $driver = new PHPDriver(array(__DIR__ . '/Model/php'));
         $this->dm->getConfiguration()->setMetadataDriverImpl($driver);
 
         $cmf = new ClassMetadataFactory($this->dm);
 
-        $cm = new \Doctrine\ODM\PHPCR\Mapping\ClassMetadata('stdClass');
+        $cm = new ClassMetadata('stdClass');
         $cmf->setMetadataFor('stdClass', $cm);
 
         $metadata = $cmf->getAllMetadata();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
@@ -2,12 +2,14 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
+use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use PHPUnit\Framework\TestCase;
 
 class ClassMetadataTest extends TestCase
@@ -83,21 +85,19 @@ class ClassMetadataTest extends TestCase
 
     /**
      * @depends testClassName
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
      */
     public function testGetAssociationNonexisting(ClassMetadata $cm)
     {
+        $this->expectException(MappingException::class);
         $cm->getAssociation('nonexisting');
     }
 
     /**
      * @depends testMapFieldWithId
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
      */
     public function testGetFieldNonexisting(ClassMetadata $cm)
     {
+        $this->expectException(MappingException::class);
         $cm->getFieldMapping('nonexisting');
     }
 
@@ -163,39 +163,37 @@ class ClassMetadataTest extends TestCase
 
     /**
      * @depends testMapField
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
      */
     public function testMapFieldWithoutNameThrowsException(ClassMetadata $cm)
     {
+        $this->expectException(MappingException::class);
         $cm->mapField(array());
     }
 
     /**
      * @depends testMapField
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
      */
     public function testMapNonExistingField(ClassMetadata $cm)
     {
+        $this->expectException(MappingException::class);
         $cm->mapField(array('fieldName' => 'notexisting'));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     */
     public function testMapChildInvalidName()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Address');
+        $cm = new ClassMetadata(Address::class);
         $cm->initializeReflection(new RuntimeReflectionService());
+
+        $this->expectException(MappingException::class);
         $cm->mapChild(array('fieldName' => 'child', 'nodeName' => 'in/valid'));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Mapping\MappingException
-     */
     public function testMapChildrenInvalidFetchDepth()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cm = new ClassMetadata(Person::class);
         $cm->initializeReflection(new RuntimeReflectionService());
+
+        $this->expectException(MappingException::class);
         $cm->mapChildren(array('fieldName' => 'address', 'fetchDepth' => 'invalid'));
     }
 
@@ -329,15 +327,15 @@ class ClassMetadataTest extends TestCase
     /**
      * It should throw an exception if given a child class FQN when the
      * metadata is for a leaf.
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
-     * @expectedExceptionMessage has been mapped as a leaf
      */
     public function testAssertValidChildClassesIsLeaf()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cm = new ClassMetadata(Person::class);
         $childCm = new ClassMetadata('stdClass');
         $cm->setIsLeaf(true);
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('has been mapped as a leaf');
         $cm->assertValidChildClass($childCm);
     }
 
@@ -394,17 +392,17 @@ class ClassMetadataTest extends TestCase
 
     /**
      * It should throw an exception if the given class is not allowed.
-     *
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
-     * @expectedExceptionMessage does not allow children of type "stdClass"
      */
     public function testAssertValidChildClassesNotAllowed()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cm = new ClassMetadata(Person::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $childCm = new ClassMetadata('stdClass');
         $childCm->initializeReflection(new RuntimeReflectionService());
-        $cm->setChildClasses(array('Doctrine\Tests\ODM\PHPCR\Mapping\Person'));
+        $cm->setChildClasses(array(Person::class));
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('does not allow children of type "stdClass"');
         $cm->assertValidChildClass($childCm);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
@@ -11,12 +11,16 @@ use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use PHPUnit\Framework\TestCase;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CMS\CmsUserRepository;
+use Doctrine\Tests\Models\CMS\CmsAddress;
+use PHPCR\RepositoryException;
 
 class ClassMetadataTest extends TestCase
 {
     public function testGetTypeOfField()
     {
-        $cmi = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cmi = new ClassMetadata(Person::class);
         $cmi->initializeReflection(new RuntimeReflectionService());
         $this->assertNull($cmi->getTypeOfField('some_field'));
         $cmi->mappings['some_field'] = array('type' => 'some_type');
@@ -25,9 +29,9 @@ class ClassMetadataTest extends TestCase
 
     public function testClassName()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cm = new ClassMetadata(Person::class);
         $cm->initializeReflection(new RuntimeReflectionService());
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\Person', $cm->name);
+        $this->assertEquals(Person::class, $cm->name);
         $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
 
         return $cm;
@@ -38,12 +42,12 @@ class ClassMetadataTest extends TestCase
      */
     public function testIsValidNodename(ClassMetadata $cm)
     {
-        $this->assertInstanceOf('PHPCR\RepositoryException', $cm->isValidNodename(''));
-        $this->assertInstanceOf('PHPCR\RepositoryException', $cm->isValidNodename('a:b:c'));
-        $this->assertInstanceOf('PHPCR\RepositoryException', $cm->isValidNodename('a:'));
-        $this->assertInstanceOf('PHPCR\RepositoryException', $cm->isValidNodename(':a'));
-        $this->assertInstanceOf('PHPCR\RepositoryException', $cm->isValidNodename(':'));
-        $this->assertInstanceOf('PHPCR\RepositoryException', $cm->isValidNodename('x/y'));
+        $this->assertInstanceOf(RepositoryException::class, $cm->isValidNodename(''));
+        $this->assertInstanceOf(RepositoryException::class, $cm->isValidNodename('a:b:c'));
+        $this->assertInstanceOf(RepositoryException::class, $cm->isValidNodename('a:'));
+        $this->assertInstanceOf(RepositoryException::class, $cm->isValidNodename(':a'));
+        $this->assertInstanceOf(RepositoryException::class, $cm->isValidNodename(':'));
+        $this->assertInstanceOf(RepositoryException::class, $cm->isValidNodename('x/y'));
 
         $cm->isValidNodename('a:b');
         $cm->isValidNodename('b');
@@ -148,7 +152,7 @@ class ClassMetadataTest extends TestCase
         $ad->loadMetadataForClass($cmp->getName(), $cmp);
 
         // Initialize subclass metadata.
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Customer');
+        $cm = new ClassMetadata(Customer::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
         // Test that the translated field is being inherited.
@@ -214,7 +218,7 @@ class ClassMetadataTest extends TestCase
         $instance1 = $cm->newInstance();
         $instance2 = $cm->newInstance();
 
-        $this->assertInstanceOf('Doctrine\Tests\ODM\PHPCR\Mapping\Person', $instance1);
+        $this->assertInstanceOf(Person::class, $instance1);
         $this->assertNotSame($instance1, $instance2);
     }
 
@@ -237,14 +241,14 @@ class ClassMetadataTest extends TestCase
     {
         $cm = unserialize('O:40:"Doctrine\ODM\PHPCR\Mapping\ClassMetadata":16:{s:8:"nodeType";s:15:"nt:unstructured";s:10:"identifier";s:2:"id";s:4:"name";s:39:"Doctrine\Tests\ODM\PHPCR\Mapping\Person";s:11:"idGenerator";i:1;s:8:"mappings";a:5:{s:2:"id";a:7:{s:9:"fieldName";s:2:"id";s:2:"id";b:1;s:8:"strategy";s:10:"repository";s:4:"type";s:6:"string";s:10:"multivalue";b:0;s:8:"nullable";b:0;s:8:"property";s:2:"id";}s:8:"username";a:5:{s:9:"fieldName";s:8:"username";s:8:"property";s:8:"username";s:4:"type";s:6:"string";s:10:"multivalue";b:0;s:8:"nullable";b:0;}s:7:"created";a:5:{s:9:"fieldName";s:7:"created";s:8:"property";s:7:"created";s:4:"type";s:8:"datetime";s:10:"multivalue";b:0;s:8:"nullable";b:0;}s:6:"locale";a:3:{s:9:"fieldName";s:6:"locale";s:4:"type";s:6:"locale";s:8:"property";s:6:"locale";}s:15:"translatedField";a:7:{s:9:"fieldName";s:15:"translatedField";s:4:"type";s:6:"string";s:10:"translated";b:1;s:8:"property";s:15:"translatedField";s:10:"multivalue";b:0;s:5:"assoc";N;s:8:"nullable";b:0;}}s:13:"fieldMappings";a:4:{i:0;s:2:"id";i:1;s:8:"username";i:2;s:7:"created";i:3;s:15:"translatedField";}s:17:"referenceMappings";a:0:{}s:17:"referrersMappings";a:0:{}s:22:"mixedReferrersMappings";a:0:{}s:16:"childrenMappings";a:0:{}s:13:"childMappings";a:0:{}s:25:"customRepositoryClassName";s:51:"Doctrine\Tests\ODM\PHPCR\Mapping\DocumentRepository";s:18:"isMappedSuperclass";b:1;s:11:"versionable";b:1;s:14:"uniqueNodeType";b:1;s:18:"lifecycleCallbacks";a:1:{s:8:"postLoad";a:1:{i:0;s:8:"callback";}}}');
 
-        $this->assertInstanceOf('Doctrine\ODM\PHPCR\Mapping\ClassMetadata', $cm);
+        $this->assertInstanceOf(ClassMetadata::class, $cm);
 
         $this->assertEquals(array('callback'), $cm->getLifecycleCallbacks('postLoad'));
         $this->assertTrue($cm->isMappedSuperclass);
         $this->assertTrue($cm->versionable);
         $this->assertTrue($cm->uniqueNodeType);
         $this->assertTrue($cm->inheritMixins);
-        $this->assertEquals('Doctrine\Tests\ODM\PHPCR\Mapping\DocumentRepository', $cm->customRepositoryClassName);
+        $this->assertEquals(DocumentRepository::class, $cm->customRepositoryClassName);
     }
 
     /**
@@ -253,13 +257,13 @@ class ClassMetadataTest extends TestCase
      */
     public function testMapAssociationManyToOne(ClassMetadata $cm)
     {
-        $cm->mapManyToOne(array('fieldName' => 'address', 'targetDocument' => 'Doctrine\Tests\ODM\PHPCR\Mapping\Address'));
+        $cm->mapManyToOne(array('fieldName' => 'address', 'targetDocument' => Address::class));
 
         $this->assertTrue(isset($cm->mappings['address']), "No 'address' in associations map.");
         $this->assertEquals(array(
             'fieldName' => 'address',
-            'targetDocument' => 'Doctrine\Tests\ODM\PHPCR\Mapping\Address',
-            'sourceDocument' => 'Doctrine\Tests\ODM\PHPCR\Mapping\Person',
+            'targetDocument' => Address::class,
+            'sourceDocument' => Person::class,
             'type' => ClassMetadata::MANY_TO_ONE,
             'strategy' => 'weak',
             'cascade' => null,
@@ -271,19 +275,19 @@ class ClassMetadataTest extends TestCase
 
     public function testClassMetadataInstanceSerialization()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService);
 
         // Test initial state
         $this->assertTrue(count($cm->getReflectionProperties()) == 0);
         $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
-        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->name);
+        $this->assertEquals(CmsUser::class, $cm->name);
         $this->assertEquals(array(), $cm->parentClasses);
         $this->assertEquals(0, count($cm->referenceMappings));
 
         // Customize state
-        $cm->setParentClasses(array("UserParent"));
-        $cm->setCustomRepositoryClassName("CmsUserRepository");
+        $cm->setParentClasses(array('UserParent'));
+        $cm->setCustomRepositoryClassName('CmsUserRepository');
         $cm->setNodeType('foo:bar');
         $cm->mapManyToOne(array('fieldName' => 'address', 'targetDocument' => 'CmsAddress', 'mappedBy' => 'foo'));
         $this->assertEquals(1, count($cm->referenceMappings));
@@ -291,20 +295,20 @@ class ClassMetadataTest extends TestCase
         $serialized = serialize($cm);
         /** @var ClassMetadata $cm */
         $cm = unserialize($serialized);
-        $cm->wakeupReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->wakeupReflection(new RuntimeReflectionService);
 
         // Check state
         $this->assertTrue(count($cm->getReflectionProperties()) > 0);
         $this->assertEquals('Doctrine\Tests\Models\CMS', $cm->namespace);
-        $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
-        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->name);
+        $this->assertInstanceOf(\ReflectionClass::class, $cm->reflClass);
+        $this->assertEquals(CmsUser::class, $cm->name);
         $this->assertEquals(array('UserParent'), $cm->parentClasses);
-        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUserRepository', $cm->customRepositoryClassName);
+        $this->assertEquals(CmsUserRepository::class, $cm->customRepositoryClassName);
         $this->assertEquals('foo:bar', $cm->getNodeType());
         $this->assertEquals(ClassMetadata::MANY_TO_ONE, $cm->getTypeOfField('address'));
         $this->assertEquals(1, count($cm->referenceMappings));
         $this->assertTrue($cm->hasAssociation('address'));
-        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsAddress', $cm->getAssociationTargetClass('address'));
+        $this->assertEquals(CmsAddress::class, $cm->getAssociationTargetClass('address'));
     }
 
     /**
@@ -316,7 +320,7 @@ class ClassMetadataTest extends TestCase
         $serialized = serialize($cm);
         /** @var ClassMetadata $cm */
         $cm = unserialize($serialized);
-        $cm->wakeupReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->wakeupReflection(new RuntimeReflectionService);
 
         // Check properties needed for translations
         $this->assertEquals('attribute', $cm->translator);
@@ -344,7 +348,7 @@ class ClassMetadataTest extends TestCase
      */
     public function testAssertValidChildClassesEmpty()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cm = new ClassMetadata(Person::class);
         $childCm = new ClassMetadata('stdClass');
         $cm->setChildClasses(array());
         $cm->assertValidChildClass($childCm);
@@ -355,7 +359,7 @@ class ClassMetadataTest extends TestCase
      */
     public function testAssertValidChildClassesAllowed()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cm = new ClassMetadata(Person::class);
         $cm->setChildClasses(array('stdClass'));
         $childCm = new ClassMetadata('stdClass');
         $childCm->initializeReflection(new RuntimeReflectionService());
@@ -367,11 +371,11 @@ class ClassMetadataTest extends TestCase
      */
     public function testAssertValidChildClassInstance()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cm = new ClassMetadata(Person::class);
         $cm->initializeReflection(new RuntimeReflectionService());
-        $childCm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Customer');
+        $childCm = new ClassMetadata(Customer::class);
         $childCm->initializeReflection(new RuntimeReflectionService());
-        $cm->setChildClasses(array('Doctrine\Tests\ODM\PHPCR\Mapping\Person'));
+        $cm->setChildClasses(array(Person::class));
         $result = $cm->assertValidChildClass($childCm);
         $this->assertNull($result);
     }
@@ -381,7 +385,7 @@ class ClassMetadataTest extends TestCase
      */
     public function testAssertValidChildClassInterface()
     {
-        $cm = new ClassMetadata('Doctrine\Tests\ODM\PHPCR\Mapping\Person');
+        $cm = new ClassMetadata(Person::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $childCm = new ClassMetadata('ArrayAccess');
         $childCm->initializeReflection(new RuntimeReflectionService());

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/XmlDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/XmlDriverTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver;
 
 /**
  * @group mapping
@@ -11,15 +12,15 @@ use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 class XmlDriverTest extends AbstractMappingDriverTest
 {
     /**
-     * @return \Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver
+     * @return XmlDriver
      */
     protected function loadDriver()
     {
         $location = __DIR__ . '/Model/xml';
-        
-        return new \Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver($location);
+
+        return new XmlDriver($location);
     }
-    
+
     protected function loadDriverForTestMappingDocuments()
     {
         return $this->loadDriver();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/YamlDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/YamlDriverTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver;
 
 /**
  * @group mapping
@@ -11,15 +12,15 @@ use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 class YamlDriverTest extends AbstractMappingDriverTest
 {
     /**
-     * @return \Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver
+     * @return YamlDriver
      */
     protected function loadDriver()
     {
         $location = __DIR__ . '/Model/yml';
-        
-        return new \Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver($location);
+
+        return new YamlDriver($location);
     }
-    
+
     protected function loadDriverForTestMappingDocuments()
     {
         return $this->loadDriver();

--- a/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
@@ -35,7 +35,7 @@ abstract class PHPCRFunctionalTestCase extends TestCase
         $factoryclass = $GLOBALS['DOCTRINE_PHPCR_FACTORY']
             ?? RepositoryFactoryJackrabbit::class;
 
-        if ($factoryclass === RepositoryFactoryDoctrineDBAL::class) {
+        if (ltrim($factoryclass, '\\') === RepositoryFactoryDoctrineDBAL::class) {
             $params = array();
             foreach ($GLOBALS as $key => $value) {
                 if (0 === strpos($key, 'jackalope.doctrine.dbal.')) {

--- a/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
@@ -2,10 +2,16 @@
 
 namespace Doctrine\Tests\ODM\PHPCR;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Jackalope\RepositoryFactoryDoctrineDBAL;
+use Jackalope\RepositoryFactoryJackrabbit;
 use PHPCR\RepositoryFactoryInterface;
 use PHPCR\SessionInterface;
+use PHPCR\SimpleCredentials;
 use PHPUnit\Framework\TestCase;
 
 abstract class PHPCRFunctionalTestCase extends TestCase
@@ -17,8 +23,8 @@ abstract class PHPCRFunctionalTestCase extends TestCase
 
     public function createDocumentManager(array $paths = null)
     {
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-        $reader->addGlobalIgnoredName('group');
+        $reader = new AnnotationReader();
+        AnnotationReader::addGlobalIgnoredName('group');
 
         if (empty($paths)) {
             $paths = array(__DIR__ . "/../../Models");
@@ -27,9 +33,9 @@ abstract class PHPCRFunctionalTestCase extends TestCase
         $metaDriver = new AnnotationDriver($reader, $paths);
 
         $factoryclass = $GLOBALS['DOCTRINE_PHPCR_FACTORY']
-            ?? '\Jackalope\RepositoryFactoryJackrabbit';
+            ?? RepositoryFactoryJackrabbit::class;
 
-        if ($factoryclass === '\Jackalope\RepositoryFactoryDoctrineDBAL') {
+        if ($factoryclass === RepositoryFactoryDoctrineDBAL::class) {
             $params = array();
             foreach ($GLOBALS as $key => $value) {
                 if (0 === strpos($key, 'jackalope.doctrine.dbal.')) {
@@ -39,7 +45,7 @@ abstract class PHPCRFunctionalTestCase extends TestCase
             if (isset($params['username'])) {
                 $params['user'] = $params['username'];
             }
-            $GLOBALS['jackalope.doctrine_dbal_connection'] = \Doctrine\DBAL\DriverManager::getConnection($params);
+            $GLOBALS['jackalope.doctrine_dbal_connection'] = DriverManager::getConnection($params);
         }
 
         /** @var $factory RepositoryFactoryInterface */
@@ -55,11 +61,11 @@ abstract class PHPCRFunctionalTestCase extends TestCase
         $user = $GLOBALS['DOCTRINE_PHPCR_USER'] ?? '';
         $pass = $GLOBALS['DOCTRINE_PHPCR_PASS'] ?? '';
 
-        $credentials = new \PHPCR\SimpleCredentials($user, $pass);
+        $credentials = new SimpleCredentials($user, $pass);
         $session = $repository->login($credentials, $workspace);
         $this->sessions[] = $session;
 
-        $config = new \Doctrine\ODM\PHPCR\Configuration();
+        $config = new Configuration();
         $config->setMetadataDriverImpl($metaDriver);
 
         return DocumentManager::create($session, $config);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Performance/InsertPerformanceTest.php
@@ -2,9 +2,27 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Performance;
 
-class InsertPerformanceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\NodeInterface;
+
+class InsertPerformanceTest extends PHPCRFunctionalTestCase
 {
-    protected $count = 100;
+    /**
+     * @var DocumentManager
+     */
+    private $dm;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var int
+     */
+    private $count = 100;
 
     public function setup()
     {
@@ -22,7 +40,7 @@ class InsertPerformanceTest extends \Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTes
         $s = microtime(true);
 
         for ($i = 0; $i < $this->count; $i++) {
-            $user = new \Doctrine\Tests\Models\CMS\CmsUser();
+            $user = new CmsUser();
             $user->name = "Benjamin";
             $user->username = "beberlei";
             $user->status = "active";

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractLeafNodeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractLeafNodeTest.php
@@ -2,15 +2,25 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
 use PHPUnit\Framework\TestCase;
+use Doctrine\ODM\PHPCR\Exception\RuntimeException;
 
 class AbstractLeafNodeTest extends TestCase
 {
+    /**
+     * @var AbstractLeafNode|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $leafNode;
+
+    /**
+     * @var \ReflectionClass
+     */
+    private $refl;
+
     public function setUp()
     {
-        $this->leafNode = $this->getMockBuilder(
-            'Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode'
-        )->getMockForAbstractClass();
+        $this->leafNode = $this->createMock(AbstractLeafNode::class);
 
         $this->refl = new \ReflectionClass($this->leafNode);
     }
@@ -30,7 +40,8 @@ class AbstractLeafNodeTest extends TestCase
     public function testExplodeField($fieldSpec, $xpctdExceptionMessage, $xpctdRes = array())
     {
         if ($xpctdExceptionMessage) {
-            $this->setExpectedException('Doctrine\ODM\PHPCR\Exception\RuntimeException', $xpctdExceptionMessage);
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage($xpctdExceptionMessage);
         }
 
         $method = $this->refl->getMethod('explodeField');

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractNodeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractNodeTest.php
@@ -138,11 +138,13 @@ class AbstractNodeTest extends TestCase
             ->will($this->returnValue($cardinalityMap));
 
         if ($options['exceeds_max']) {
-            $this->setExpectedException('OutOfBoundsException', 'cannot exceed');
+            $this->expectException(\OutOfBoundsException::class);
+            $this->expectExceptionMessage('cannot exceed');
         }
 
         if ($options['invalid_child']) {
-            $this->setExpectedException('OutOfBoundsException', 'cannot be appended');
+            $this->expectException(\OutOfBoundsException::class);
+            $this->expectExceptionMessage('cannot be appended');
         }
 
         $this->addChildrenToNode1($data);
@@ -214,7 +216,8 @@ class AbstractNodeTest extends TestCase
 
         if ($options['expected_exception']) {
             list($exceptionType, $exceptionMessage) = $options['expected_exception'];
-            $this->setExpectedException($exceptionType, $exceptionMessage);
+            $this->expectException($exceptionType);
+            $this->expectExceptionMessage($exceptionMessage);
         }
 
         $this->node1->expects($this->any())

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractNodeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractNodeTest.php
@@ -3,21 +3,38 @@
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
 
 class AbstractNodeTest extends TestCase
 {
+    /**
+     * @var AbstractNode|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $parent;
+
+    /**
+     * @var AbstractNode|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $node1;
+
+    /**
+     * @var AbstractLeafNode|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $leafNode;
+
     public function setUp()
     {
-        $this->parent = $this->getMockBuilder(
-            'Doctrine\ODM\PHPCR\Query\Builder\AbstractNode'
-        )->setMockClassName('ParentNode')->getMockForAbstractClass();
+        $this->parent = $this->getMockBuilder(AbstractNode::class)
+            ->setMockClassName('ParentNode')
+            ->getMockForAbstractClass();
 
-        $this->node1 = $this->getMockBuilder('Doctrine\ODM\PHPCR\Query\Builder\AbstractNode')
+        $this->node1 = $this->getMockBuilder(AbstractNode::class)
             ->setMockClassName('TestNode')
             ->setConstructorArgs(array($this->parent))
             ->getMockForAbstractClass();
 
-        $this->leafNode = $this->getMockBuilder('Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode')
+        $this->leafNode = $this->getMockBuilder(AbstractLeafNode::class)
             ->setMockClassName('LeafNode')
             ->setConstructorArgs(array($this->node1))
             ->getMockForAbstractClass();
@@ -29,11 +46,8 @@ class AbstractNodeTest extends TestCase
     protected function addChildrenToNode1($data)
     {
         foreach ($data as $className) {
-            $childNode = $this->getMockForAbstractClass(
-                'Doctrine\ODM\PHPCR\Query\Builder\AbstractNode',
-                array(),
-                $className
-            );
+            /** @var AbstractNode|\PHPUnit_Framework_MockObject_MockObject $childNode */
+            $childNode = $this->getMockForAbstractClass(AbstractNode::class, array(), $className);
             $childNode->expects($this->once())
                 ->method('getNodeType')
                 ->will($this->returnValue($className));

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConverterPhpcrTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConverterPhpcrTest.php
@@ -162,7 +162,7 @@ class ConverterPhpcrTest extends TestCase
 
         $res = $this->converter->dispatch($from);
 
-        $this->assertInstanceOf('PHPCR\Query\QOM\SelectorInterface', $res);
+        $this->assertInstanceOf(SelectorInterface::class, $res);
         $this->assertEquals('nt:unstructured', $res->getNodeTypeName());
         $this->assertEquals('alias', $res->getSelectorName());
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/LeafNodeTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/LeafNodeTestCase.php
@@ -14,9 +14,9 @@ abstract class LeafNodeTestCase extends TestCase
 
     public function setUp()
     {
-        $this->parent = $this->getMockBuilder(
-            'Doctrine\ODM\PHPCR\Query\Builder\AbstractNode'
-        )->setMockClassName('ParentNode')->getMockForAbstractClass();
+        $this->parent = $this->getMockBuilder(AbstractNode::class)
+            ->setMockClassName('ParentNode')
+            ->getMockForAbstractClass();
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/NodeTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/NodeTestCase.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 use Doctrine\ODM\PHPCR\Query\Builder\Builder;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
 use PHPUnit\Framework\TestCase;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
 
 abstract class NodeTestCase extends TestCase
 {
@@ -12,9 +13,9 @@ abstract class NodeTestCase extends TestCase
 
     public function setUp()
     {
-        $this->parent = $this->getMockBuilder(
-            'Doctrine\ODM\PHPCR\Query\Builder\AbstractNode'
-        )->setMockClassName('ParentNode')->getMockForAbstractClass();
+        $this->parent = $this->getMockBuilder(AbstractNode::class)
+            ->setMockClassName('ParentNode')
+            ->getMockForAbstractClass();
         $this->node = $this->getNode();
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/NodeTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/NodeTestCase.php
@@ -45,9 +45,7 @@ abstract class NodeTestCase extends TestCase
         $res = call_user_func_array(array($this->node, $method), $args);
         $refl = new \ReflectionClass($expectedClass);
 
-        if ($refl->isSubclassOf(
-            'Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode'
-        )) {
+        if ($refl->isSubclassOf(AbstractLeafNode::class)) {
             $this->assertSame($this->node, $res, 'Leaf node method "'.$method.'" returns parent');
         } else {
             $this->assertInstanceOf($expectedClass, $res);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\ODM\PHPCR\Query\Builder\ConverterInterface;
 
 class QueryBuilderTest extends NodeTestCase
 {
@@ -20,9 +21,8 @@ class QueryBuilderTest extends NodeTestCase
 
     public function testNonExistantMethod()
     {
-        $this->setExpectedException('BadMethodCallException',
-            'Unknown method "foobar" called on node'
-        );
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Unknown method "foobar" called on node');
         $this->node->foobar();
     }
 
@@ -107,7 +107,7 @@ class QueryBuilderTest extends NodeTestCase
         $property = $reflection->getProperty('converter');
         $property->setAccessible(true);
 
-        $this->node->setConverter($this->getMockBuilder('Doctrine\ODM\PHPCR\Query\Builder\ConverterInterface')->getMock());
+        $this->node->setConverter($this->createMock(ConverterInterface::class));
 
         $clone = clone $this->node;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceDocumentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceDocumentTest.php
@@ -16,11 +16,9 @@ class SourceDocumentTest extends LeafNodeTestCase
         );
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Exception\InvalidArgumentException
-     */
     public function testEmptyAlias()
     {
+        $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         new SourceDocument($this->parent, 'My\Fqn', '');
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
@@ -2,8 +2,13 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query;
 
+use Doctrine\ODM\PHPCR\Query\NoResultException;
 use Doctrine\ODM\PHPCR\Query\Query;
+use Doctrine\ODM\PHPCR\Query\QueryException;
 use PHPUnit\Framework\TestCase;
+use PHPCR\Query\QueryInterface;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @group unit
@@ -12,11 +17,9 @@ class QueryTest extends Testcase
 {
     public function setUp()
     {
-        $this->phpcrQuery = $this->getMockBuilder('PHPCR\Query\QueryInterface')->getMock();
-        $this->dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->arrayCollection = $this->getMockBuilder('Doctrine\Common\Collections\ArrayCollection')->getMock();
+        $this->phpcrQuery = $this->createMock(QueryInterface::class);
+        $this->dm = $this->createMock(DocumentManager::class);
+        $this->arrayCollection = $this->createMock(ArrayCollection::class);
         $this->query = new Query($this->phpcrQuery, $this->dm);
         $this->aliasQuery = new Query($this->phpcrQuery, $this->dm, 'a');
     }
@@ -87,11 +90,9 @@ class QueryTest extends Testcase
         $this->assertEquals('ok', $res->first());
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Query\QueryException
-     */
     public function testExecute_hydrateUnknown()
     {
+        $this->expectException(QueryException::class);
         $this->query->execute(null, 'unknown_hydration_mode');
     }
 
@@ -154,25 +155,23 @@ class QueryTest extends Testcase
         $this->assertEquals('ok1', $res);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Query\QueryException
-     */
     public function testGetOneOrNullResult_withTwoResults()
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
             ->will($this->returnValue(array('ok1', 'ok2')));
+
+        $this->expectException(QueryException::class);
         $this->query->getOneOrNullResult(Query::HYDRATE_PHPCR);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Query\NoResultException
-     */
     public function testGetSingleResult_noResult()
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
             ->will($this->returnValue(array()));
+
+        $this->expectException(NoResultException::class);
         $this->query->getSingleResult(Query::HYDRATE_PHPCR);
     }
 
@@ -185,22 +184,19 @@ class QueryTest extends Testcase
         $this->assertEquals('ok1', $res);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Query\QueryException
-     */
     public function testGetSingleResult_withTwoResults()
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
             ->will($this->returnValue(array('ok1', 'ok2')));
+
+        $this->expectException(QueryException::class);
         $this->query->getSingleResult(Query::HYDRATE_PHPCR);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Query\QueryException
-     */
     public function testIterate()
     {
+        $this->expectException(QueryException::class);
         $this->query->iterate();
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
@@ -58,7 +58,7 @@ class QueryTest extends Testcase
             ->method('execute')
             ->will($this->returnValue(array('ok')));
         $res = $this->query->execute(null, Query::HYDRATE_PHPCR);
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $res);
+        $this->assertInstanceOf(ArrayCollection::class, $res);
         $this->assertEquals('ok', $res->first());
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DocumentConvertTranslationCommandTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DocumentConvertTranslationCommandTest.php
@@ -8,6 +8,7 @@ use PHPCR\SessionInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 use PHPUnit\Framework\TestCase;
+use PHPCR\Util\Console\Helper\PhpcrHelper;
 
 class DocumentConvertTranslationCommandTest extends TestCase
 {
@@ -33,19 +34,14 @@ class DocumentConvertTranslationCommandTest extends TestCase
 
     public function setUp()
     {
-        $this->mockSession = $this->getMockBuilder('PHPCR\SessionInterface')->getMock();
-        $mockHelper = $this->getMockBuilder('PHPCR\Util\Console\Helper\PhpcrHelper')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->mockSession = $this->createMock(SessionInterface::class);
+        $mockHelper = $this->createMock(PhpcrHelper::class);
         $mockHelper
             ->expects($this->once())
             ->method('getSession')
             ->will($this->returnValue($this->mockSession))
         ;
-        $this->converter = $this->getMockBuilder('Doctrine\ODM\PHPCR\Tools\Helper\TranslationConverter')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
+        $this->converter = $this->createMock(TranslationConverter::class);
         $this->command = new DocumentConvertTranslationCommand(null, $this->converter);
         $this->command->setHelperSet(new HelperSet(
             array('phpcr' => $mockHelper)

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Helper/UniqueNodeTypeHelperTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Helper/UniqueNodeTypeHelperTest.php
@@ -2,9 +2,12 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Tools\Helper;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\ODM\PHPCR\Tools\Helper\UniqueNodeTypeHelper;
 use PHPUnit\Framework\TestCase;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 
 /**
  * Verify the behavior of the UniqueNodeTypeHelper class that is used
@@ -23,7 +26,7 @@ class UniqueNodeTypeHelperTest extends TestCase
      */
     public function configureDocumentManager(array $metadata)
     {
-        $classMetadataFactory = $this->getMockBuilder('Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory')
+        $classMetadataFactory = $this->getMockBuilder(ClassMetadataFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(array('getAllMetadata'))
             ->getMock();
@@ -31,7 +34,7 @@ class UniqueNodeTypeHelperTest extends TestCase
             ->method('getAllMetadata')
             ->will($this->returnValue($metadata));
 
-        $documentManager = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
+        $documentManager = $this->getMockBuilder(DocumentManager::class)
             ->disableOriginalConstructor()
             ->setMethods(array('getMetadataFactory'))
             ->getMock();
@@ -45,10 +48,6 @@ class UniqueNodeTypeHelperTest extends TestCase
     /**
      * Verify that a MappingException is correctly thrown when more than
      * one document uses the same node type, but one is marked as unique.
-     *
-     * @expectedException Doctrine\ODM\PHPCR\Mapping\MappingException
-     * @expectedExceptionMessage The class "Doctrine\PHPCR\Models\ClassC" is mapped with uniqueNodeType set to true, but the
-     *     node type "nt:unstructured" is used by "Doctrine\PHPCR\Models\ClassA" as well.
      */
     public function testCheckNodeTypeMappingsWithDuplicate()
     {
@@ -70,6 +69,9 @@ class UniqueNodeTypeHelperTest extends TestCase
         ));
 
         $uniqueNodeTypeHelper = new UniqueNodeTypeHelper();
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The class "Doctrine\PHPCR\Models\ClassC" is mapped with uniqueNodeType set to true, but the node type "nt:unstructured" is used by "Doctrine\PHPCR\Models\ClassA" as well.');
         $uniqueNodeTypeHelper->checkNodeTypeMappings($documentManager);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Test/QueryBuilderTesterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Test/QueryBuilderTesterTest.php
@@ -5,6 +5,8 @@ namespace Doctrine\Tests\ODM\PHPCR\Tools\Test;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Tools\Test\QueryBuilderTester;
 use PHPUnit\Framework\TestCase;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandStaticLiteral;
 
 class QueryBuilderTesterTest extends TestCase
 {
@@ -41,7 +43,7 @@ HERE
             'where[0].constraint[0].constraint[1].operand_dynamic'
 );
         $this->assertInstanceOf(
-            'Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField', $node
+            OperandDynamicField::class, $node
         );
         $this->assertEquals('a', $node->getAlias());
         $this->assertEquals('foo', $node->getField());
@@ -51,7 +53,7 @@ HERE
             'where[0].constraint[0].constraint[1].operand_static'
         );
         $this->assertInstanceOf(
-            'Doctrine\ODM\PHPCR\Query\Builder\OperandStaticLiteral', $node
+            OperandStaticLiteral::class, $node
         );
         $this->assertEquals('Bar', $node->getValue());
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Translation;
 
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
 use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
+use Doctrine\ODM\PHPCR\DocumentManager;
 
 class AttributeTranslationStrategyTest extends PHPCRTestCase
 {
@@ -13,14 +14,12 @@ class AttributeTranslationStrategyTest extends PHPCRTestCase
 
     public function setUp()
     {
-        $this->dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->dm = $this->createMock(DocumentManager::class);
 
         $this->strategy = new AttributeTranslationStrategy($this->dm);
         $this->strategy->setPrefix('test');
 
-        $class = new \ReflectionClass('Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy');
+        $class = new \ReflectionClass(AttributeTranslationStrategy::class);
         $this->method = $class->getMethod('getTranslatedPropertyName');
         $this->method->setAccessible(true);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
@@ -5,6 +5,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Translation;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
 use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
 
 class AttributeTranslationStrategyTest extends PHPCRTestCase
 {
@@ -42,7 +45,7 @@ class AttributeTranslationStrategyTest extends PHPCRTestCase
             $this->markTestSkipped('Prophesize does not work on PHP 5.3.3');
         }
 
-        $classMetadata = $this->prophesize('Doctrine\ODM\PHPCR\Mapping\ClassMetadata');
+        $classMetadata = $this->prophesize(ClassMetadata::class);
         $document = new \stdClass;
         $localizedPropNames = array(
             'test:de-prop1' => 'de',
@@ -53,11 +56,11 @@ class AttributeTranslationStrategyTest extends PHPCRTestCase
             'de_asdf' => false, // no property name
         );
 
-        $node = $this->prophesize('PHPCR\NodeInterface');
+        $node = $this->prophesize(NodeInterface::class);
         $properties = array();
 
         foreach (array_keys($localizedPropNames) as $localizedPropName) {
-            $property = $this->prophesize('PHPCR\PropertyInterface');
+            $property = $this->prophesize(PropertyInterface::class);
             $property->getName()->willReturn($localizedPropName);
             $properties[] = $property->reveal();
         }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/LocaleChooserTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/LocaleChooserTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Translation;
 
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 
 class LocaleChooserTest extends PHPCRTestCase
@@ -21,7 +22,7 @@ class LocaleChooserTest extends PHPCRTestCase
 
     public function setUp()
     {
-        $this->mockMetadata = $this->getMockBuilder('\Doctrine\ODM\PHPCR\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
+        $this->mockMetadata = $this->createMock(ClassMetadata::class);
         $this->localeChooser = new LocaleChooser(array('en' => $this->orderEn, 'de' => $this->orderDe), 'en');
     }
 
@@ -48,11 +49,9 @@ class LocaleChooserTest extends PHPCRTestCase
         $this->assertEquals(array('fr'), $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'de'));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Translation\MissingTranslationException
-     */
     public function testGetFallbackLocalesNonexisting()
     {
+        $this->expectException(MissingTranslationException::class);
         $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'notexisting');
     }
 
@@ -72,11 +71,9 @@ class LocaleChooserTest extends PHPCRTestCase
         $this->assertEquals('de', $locale);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\PHPCR\Translation\MissingTranslationException
-     */
     public function testSetLocaleNonexisting()
     {
+        $this->expectException(MissingTranslationException::class);
         $this->localeChooser->setLocale('nonexisting');
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -8,6 +8,12 @@ use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Jackalope\Factory;
 use Jackalope\Node;
+use Jackalope\Session;
+use Jackalope\ObjectManager;
+use Jackalope\Repository;
+use Jackalope\NodeType\NodeType;
+use Jackalope\NodeType\NodeTypeManager;
+use Jackalope\Workspace;
 
 /**
  * TODO: remove Jackalope dependency
@@ -53,15 +59,11 @@ class UnitOfWorkTest extends PHPCRTestCase
         }
 
         $this->factory = new Factory;
-        $this->session = $this->getMockBuilder('Jackalope\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
-        
-        $this->objectManager = $this->getMockBuilder('Jackalope\ObjectManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->session = $this->createMock(Session::class);
 
-        $this->type = 'Doctrine\Tests\ODM\PHPCR\UoWUser';
+        $this->objectManager = $this->createMock(ObjectManager::class);
+
+        $this->type = UoWUser::class;
         $this->dm = DocumentManager::create($this->session);
         $this->uow = new UnitOfWork($this->dm);
 
@@ -76,52 +78,52 @@ class UnitOfWorkTest extends PHPCRTestCase
 
     protected function createNode($id, $username, $primaryType = 'rep:root')
     {
-        $repository = $this->getMockBuilder('Jackalope\Repository')->disableOriginalConstructor()->getMock();
+        $repository = $this->createMock(Repository::class);
         $this->session->expects($this->any())
             ->method('getRepository')
             ->with()
             ->will($this->returnValue($repository));
-        
-        $type = $this->getMockBuilder('Jackalope\NodeType\NodeType')->disableOriginalConstructor()->getMock();
+
+        $type = $this->createMock(NodeType::class);
         $type->expects($this->any())
             ->method('getName')
             ->with()
             ->will($this->returnValue($primaryType));
-        
-        $ntm = $this->getMockBuilder('Jackalope\NodeType\NodeTypeManager')->disableOriginalConstructor()->getMock();
+
+        $ntm = $this->createMock(NodeTypeManager::class);
         $ntm->expects($this->any())
             ->method('getNodeType')
             ->with()
             ->will($this->returnValue($type));
-        
-        $workspace = $this->getMockBuilder('Jackalope\Workspace')->disableOriginalConstructor()->getMock();
+
+        $workspace = $this->createMock(Workspace::class);
         $workspace->expects($this->any())
             ->method('getNodeTypeManager')
             ->with()
             ->will($this->returnValue($ntm));
-        
+
         $this->session->expects($this->any())
             ->method('getWorkspace')
             ->with()
             ->will($this->returnValue($workspace));
-        
+
         $this->session->expects($this->any())
                ->method('nodeExists')
             ->with($id)
             ->will($this->returnValue(true));
-        
+
         $nodeData = array(
             "jcr:primaryType" => $primaryType,
             "jcr:system" => array(),
             'username' => $username,
         );
         $node = new Node($this->factory, $nodeData, $id, $this->session, $this->objectManager);
-        
+
         $this->session->expects($this->any())
             ->method('getNode')
             ->with($id)
             ->will($this->returnValue($node));
-        
+
         return $node;
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -14,6 +14,7 @@ use Jackalope\Repository;
 use Jackalope\NodeType\NodeType;
 use Jackalope\NodeType\NodeTypeManager;
 use Jackalope\Workspace;
+use PHPCR\SessionInterface;
 
 /**
  * TODO: remove Jackalope dependency
@@ -38,12 +39,12 @@ class UnitOfWorkTest extends PHPCRTestCase
     private $factory;
 
     /**
-     * @var \PHPCR\SessionInterface
+     * @var SessionInterface
      */
     private $session;
 
     /**
-     * @var \Jackalope\ObjectManager
+     * @var ObjectManager
      */
     private $objectManager;
 
@@ -54,7 +55,7 @@ class UnitOfWorkTest extends PHPCRTestCase
 
     public function setUp()
     {
-        if (!class_exists('Jackalope\Factory', true)) {
+        if (!class_exists(Factory::class, true)) {
             $this->markTestSkipped('The Node needs to be properly mocked/stubbed. Remove dependency to Jackalope');
         }
 
@@ -160,8 +161,8 @@ class UnitOfWorkTest extends PHPCRTestCase
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\UnitOfWork::scheduleInsert
-     * @covers Doctrine\ODM\PHPCR\UnitOfWork::doScheduleInsert
+     * @covers \Doctrine\ODM\PHPCR\UnitOfWork::scheduleInsert
+     * @covers \Doctrine\ODM\PHPCR\UnitOfWork::doScheduleInsert
      */
     public function testScheduleInsertion()
     {
@@ -173,9 +174,9 @@ class UnitOfWorkTest extends PHPCRTestCase
     }
 
     /**
-     * @covers Doctrine\ODM\PHPCR\UnitOfWork::scheduleRemove
-     * @covers Doctrine\ODM\PHPCR\UnitOfWork::scheduleInsert
-     * @covers Doctrine\ODM\PHPCR\UnitOfWork::doScheduleInsert
+     * @covers \Doctrine\ODM\PHPCR\UnitOfWork::scheduleRemove
+     * @covers \Doctrine\ODM\PHPCR\UnitOfWork::scheduleInsert
+     * @covers \Doctrine\ODM\PHPCR\UnitOfWork::doScheduleInsert
      */
     public function testScheduleInsertCancelsScheduleRemove()
     {
@@ -205,7 +206,7 @@ class UnitOfWorkTest extends PHPCRTestCase
 
     public function testUuid()
     {
-        $class = new \ReflectionClass('Doctrine\ODM\PHPCR\UnitOfWork');
+        $class = new \ReflectionClass(UnitOfWork::class);
         $method = $class->getMethod('generateUuid');
         $method->setAccessible(true);
 

--- a/tests/phpunit_doctrine_dbal.xml.dist
+++ b/tests/phpunit_doctrine_dbal.xml.dist
@@ -4,7 +4,7 @@
         <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
         <ini name="error_reporting" value="-16385"/>
 
-        <var name="DOCTRINE_PHPCR_FACTORY" value="\Jackalope\RepositoryFactoryDoctrineDBAL" />
+        <var name="DOCTRINE_PHPCR_FACTORY" value="Jackalope\RepositoryFactoryDoctrineDBAL" />
         <var name="jackalope.doctrine.dbal.driver" value="pdo_mysql" />
         <var name="jackalope.doctrine.dbal.host" value="localhost" />
         <var name="jackalope.doctrine.dbal.user" value="root" />


### PR DESCRIPTION
Adjust to phpunit 6
* [x] Rewrite getMock to createMock where possible
* [x] expectException instead of setExpectedException

Other cleanup
* [x] Use ::class pseudo-constants