### PR TITLE
improve styleci config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,12 +1,1 @@
-preset: psr2
-
-enabled:
-  - long_array_syntax
-  - duplicate_semicolon
-
-finder:
-  not-name:
-    # exclude PHP7 illegal annotation classes to avoid false alert. those must not be attempted to be used in PHP 7
-    - Float.php
-    - String.php
-    - Int.php
+preset: recommended

--- a/benchmarks/PersistBench.php
+++ b/benchmarks/PersistBench.php
@@ -2,13 +2,12 @@
 
 namespace Doctrine\Benchmarks\ODM\PHPCR;
 
-use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\References\ParentNoNodenameTestObj;
 use Doctrine\Tests\Models\References\ParentTestObj;
 use Doctrine\Tests\Models\Translation\Comment;
-use Doctrine\Tests\ODM\PHPCR\Functional\TestUser;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
 /**
  * @BeforeMethods({"setUp"})
@@ -31,9 +30,9 @@ class PersistBench extends PHPCRFunctionalTestCase
         $user1 = new CmsUser();
         $user1->username = 'dantleech';
         $address = new CmsAddress();
-        $address->city = "Springfield";
-        $address->zip = "12354";
-        $address->country = "Germany";
+        $address->city = 'Springfield';
+        $address->zip = '12354';
+        $address->country = 'Germany';
         $user1->address = $address;
 
         $this->documentManager->persist($user1);
@@ -44,18 +43,18 @@ class PersistBench extends PHPCRFunctionalTestCase
     public function benchPersistMany()
     {
         $parent1 = new ParentTestObj();
-        $parent1->nodename = "root1";
-        $parent1->name = "root1";
+        $parent1->nodename = 'root1';
+        $parent1->name = 'root1';
         $parent1->setParentDocument($this->root);
 
         $parent2 = new ParentTestObj();
-        $parent2->name = "/root2";
-        $parent2->nodename = "root2";
+        $parent2->name = '/root2';
+        $parent2->nodename = 'root2';
         $parent2->setParentDocument($this->root);
 
         $child = new ParentNoNodenameTestObj();
         $child->setParentDocument($parent1);
-        $child->name = "child";
+        $child->name = 'child';
 
         $c1 = new Comment();
         $c1->name = 'c1';
@@ -63,16 +62,16 @@ class PersistBench extends PHPCRFunctionalTestCase
         $c1->setText('deutsch');
 
         $group1 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group1->name = "Test!";
+        $group1->name = 'Test!';
         $group1->id = '/functional/group1';
 
         $group2 = new \Doctrine\Tests\Models\CMS\CmsGroup();
-        $group2->name = "Test!";
+        $group2->name = 'Test!';
         $group2->id = '/functional/group2';
 
         $user = new \Doctrine\Tests\Models\CMS\CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->name = 'Benjamin';
         $user->addGroup($group1);
         $user->addGroup($group2);
 

--- a/benchmarks/bootstrap.php
+++ b/benchmarks/bootstrap.php
@@ -8,7 +8,7 @@
 $transport = getenv('TRANSPORT') ?: null;
 
 $phpunitFile = $transport ? sprintf('phpunit_%s.xml.dist', $transport) : 'phpunit.xml';
-$phpunitPath = __DIR__ . '/../tests/' . $phpunitFile;
+$phpunitPath = __DIR__.'/../tests/'.$phpunitFile;
 
 if (!file_exists($phpunitPath)) {
     throw new \InvalidArgumentException(sprintf(
@@ -25,4 +25,4 @@ foreach ($xpath->query('//php/var') as $varEl) {
     $GLOBALS[$varEl->getAttribute('name')] = $varEl->getAttribute('value');
 }
 
-require(__DIR__ . '/../tests/bootstrap.php');
+require __DIR__.'/../tests/bootstrap.php';

--- a/bin/phpcrodm.php
+++ b/bin/phpcrodm.php
@@ -1,12 +1,12 @@
 <?php
 
-$up = DIRECTORY_SEPARATOR . '..';
-$file = DIRECTORY_SEPARATOR . 'autoload.php';
-$candiates = array(
-    __DIR__ . $up . $file,
-    __DIR__ . $up . DIRECTORY_SEPARATOR . 'vendor' . $file,
-    __DIR__ . $up . $up . $up . $file,
-);
+$up = DIRECTORY_SEPARATOR.'..';
+$file = DIRECTORY_SEPARATOR.'autoload.php';
+$candiates = [
+    __DIR__.$up.$file,
+    __DIR__.$up.DIRECTORY_SEPARATOR.'vendor'.$file,
+    __DIR__.$up.$up.$up.$file,
+];
 
 foreach ($candiates as $path) {
     $autoload = @include_once $path;
@@ -21,15 +21,15 @@ if (!$autoload) {
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-AnnotationRegistry::registerLoader(array($autoload, 'loadClass'));
+AnnotationRegistry::registerLoader([$autoload, 'loadClass']);
 
-$configFile = getcwd() . DIRECTORY_SEPARATOR . 'cli-config.php';
+$configFile = getcwd().DIRECTORY_SEPARATOR.'cli-config.php';
 
 $helperSet = null;
 if (file_exists($configFile)) {
     if (!is_readable($configFile)) {
         trigger_error(
-            'Configuration file [' . $configFile . '] does not have read permission.', E_USER_ERROR
+            'Configuration file ['.$configFile.'] does not have read permission.', E_USER_ERROR
         );
     }
 
@@ -43,7 +43,7 @@ if (file_exists($configFile)) {
     }
 } else {
     trigger_error(
-        'Configuration file [' . $configFile . '] does not exist. See https://github.com/doctrine/phpcr-odm/wiki/Command-line-tool-configuration', E_USER_ERROR
+        'Configuration file ['.$configFile.'] does not exist. See https://github.com/doctrine/phpcr-odm/wiki/Command-line-tool-configuration', E_USER_ERROR
     );
 }
 
@@ -52,7 +52,7 @@ $helperSet = ($helperSet) ?: new \Symfony\Component\Console\Helper\HelperSet();
 $cli = new \Symfony\Component\Console\Application('Doctrine ODM PHPCR Command Line Interface', Doctrine\ODM\PHPCR\Version::VERSION);
 $cli->setCatchExceptions(true);
 $cli->setHelperSet($helperSet);
-$cli->addCommands(array(
+$cli->addCommands([
     new \PHPCR\Util\Console\Command\NodeDumpCommand(),
     new \PHPCR\Util\Console\Command\NodeMoveCommand(),
     new \PHPCR\Util\Console\Command\NodeRemoveCommand(),
@@ -74,8 +74,8 @@ $cli->addCommands(array(
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\InfoDoctrineCommand(),
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\VerifyUniqueNodeTypesMappingCommand(),
     new \Doctrine\ODM\PHPCR\Tools\Console\Command\RegisterSystemNodeTypesCommand(),
-));
-if (isset($extraCommands) && ! empty($extraCommands)) {
+]);
+if (isset($extraCommands) && !empty($extraCommands)) {
     $cli->addCommands($extraCommands);
 }
 $cli->run();

--- a/lib/Doctrine/ODM/PHPCR/ChildrenCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ChildrenCollection.php
@@ -19,17 +19,16 @@
 
 namespace Doctrine\ODM\PHPCR;
 
-use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
-use PHPCR\Util\PathHelper;
+use Doctrine\Common\Collections\Collection;
 use PHPCR\NodeInterface;
+use PHPCR\Util\PathHelper;
 
 /**
- * Children collection class
+ * Children collection class.
  *
  * This class represents a collection of children of a document which phpcr
  * names match a optional filter
- *
  */
 class ChildrenCollection extends PersistentCollection
 {
@@ -42,11 +41,11 @@ class ChildrenCollection extends PersistentCollection
     /**
      * Creates a new persistent collection.
      *
-     * @param DocumentManagerInterface $dm  The DocumentManager the collection will be associated with.
-     * @param object          $document     The parent document instance
-     * @param string|array    $filter       Filter string or array of filter string
-     * @param int             $fetchDepth   Optional fetch depth, -1 to not override.
-     * @param string          $locale       The locale to use during the loading of this collection
+     * @param DocumentManagerInterface $dm         The DocumentManager the collection will be associated with.
+     * @param object                   $document   The parent document instance
+     * @param string|array             $filter     Filter string or array of filter string
+     * @param int                      $fetchDepth Optional fetch depth, -1 to not override.
+     * @param string                   $locale     The locale to use during the loading of this collection
      */
     public function __construct(DocumentManagerInterface $dm, $document, $filter = null, $fetchDepth = -1, $locale = null)
     {
@@ -58,12 +57,12 @@ class ChildrenCollection extends PersistentCollection
     }
 
     /**
-     * @param DocumentManagerInterface  $dm    The DocumentManager the collection will be associated with.
-     * @param object           $document       The parent document instance
-     * @param array|Collection $collection     The collection to initialize with
-     * @param string|array     $filter         Filter string or array of filter string
-     * @param int              $fetchDepth     Optional fetch depth, -1 to not override.
-     * @param bool             $forceOverwrite If to force overwrite the state in the database to the state of the collection
+     * @param DocumentManagerInterface $dm             The DocumentManager the collection will be associated with.
+     * @param object                   $document       The parent document instance
+     * @param array|Collection         $collection     The collection to initialize with
+     * @param string|array             $filter         Filter string or array of filter string
+     * @param int                      $fetchDepth     Optional fetch depth, -1 to not override.
+     * @param bool                     $forceOverwrite If to force overwrite the state in the database to the state of the collection
      *
      * @return ChildrenCollection
      */
@@ -101,7 +100,7 @@ class ChildrenCollection extends PersistentCollection
         $locale = $this->locale ?: $uow->getCurrentLocale($this->document);
         $uow->getPrefetchHelper()->prefetch($this->dm, $childNodes, $locale);
 
-        $childDocuments = array();
+        $childDocuments = [];
         foreach ($childNodes as $childNode) {
             $childDocuments[$childNode->getName()] = $uow->getOrCreateProxyFromNode($childNode, $locale);
         }
@@ -124,7 +123,7 @@ class ChildrenCollection extends PersistentCollection
         }
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function contains($element)
     {
         if (!$this->isInitialized()) {
@@ -148,13 +147,14 @@ class ChildrenCollection extends PersistentCollection
             }
 
             $nodeName = PathHelper::getNodeName($documentId);
+
             return in_array($nodeName, $this->getOriginalNodeNames());
         }
 
         return parent::contains($element);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function containsKey($key)
     {
         if (!$this->isInitialized()) {
@@ -164,7 +164,7 @@ class ChildrenCollection extends PersistentCollection
         return parent::containsKey($key);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function count()
     {
         if (!$this->isInitialized()) {
@@ -174,7 +174,7 @@ class ChildrenCollection extends PersistentCollection
         return parent::count();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function isEmpty()
     {
         if (!$this->isInitialized()) {
@@ -184,7 +184,7 @@ class ChildrenCollection extends PersistentCollection
         return parent::isEmpty();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function slice($offset, $length = null)
     {
         if (!$this->isInitialized()) {
@@ -203,6 +203,7 @@ class ChildrenCollection extends PersistentCollection
             });
 
             $childNodes = $this->dm->getPhpcrSession()->getNodes($nodeNames);
+
             return $this->getChildren($childNodes);
         }
 
@@ -218,7 +219,7 @@ class ChildrenCollection extends PersistentCollection
     }
 
     /**
-     * Return the ordered list of node names of children that existed when the collection was initialized
+     * Return the ordered list of node names of children that existed when the collection was initialized.
      *
      * @return array
      */
@@ -236,7 +237,7 @@ class ChildrenCollection extends PersistentCollection
     }
 
     /**
-     * Reset originalNodeNames and mark the collection as non dirty
+     * Reset originalNodeNames and mark the collection as non dirty.
      */
     public function takeSnapshot()
     {

--- a/lib/Doctrine/ODM/PHPCR/Configuration.php
+++ b/lib/Doctrine/ODM/PHPCR/Configuration.php
@@ -21,19 +21,20 @@ namespace Doctrine\ODM\PHPCR;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\ODM\PHPCR\DocumentClassMapperInterface;
+use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ODM\PHPCR\Mapping\Driver\BuiltinDocumentsDriver;
 use Doctrine\ODM\PHPCR\Repository\DefaultRepositoryFactory;
 use Doctrine\ODM\PHPCR\Repository\RepositoryFactory;
 use PHPCR\Util\UUIDHelper;
-use Doctrine\Common\Persistence\ObjectRepository;
 
 /**
- * Configuration class
+ * Configuration class.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Jordi Boggiano <j.boggiano@seld.be>
  * @author      Pascal Helfenstein <nicam@nicam.ch>
  */
@@ -42,22 +43,22 @@ class Configuration
     /**
      * Array of attributes for this configuration instance.
      *
-     * @var array $attributes
+     * @var array
      */
-    private $attributes = array(
-        'writeDoctrineMetadata' => true,
+    private $attributes = [
+        'writeDoctrineMetadata'    => true,
         'validateDoctrineMetadata' => true,
-        'metadataDriverImpl' => null,
-        'metadataCacheImpl' => null,
-        'documentClassMapper' => null,
-        'proxyNamespace' => 'MyPHPCRProxyNS',
+        'metadataDriverImpl'       => null,
+        'metadataCacheImpl'        => null,
+        'documentClassMapper'      => null,
+        'proxyNamespace'           => 'MyPHPCRProxyNS',
         'autoGenerateProxyClasses' => true,
-    );
+    ];
 
     /**
-     * Sets if all PHPCR document metadata should be validated on read
+     * Sets if all PHPCR document metadata should be validated on read.
      *
-     * @param boolean $validateDoctrineMetadata
+     * @param bool $validateDoctrineMetadata
      */
     public function setValidateDoctrineMetadata($validateDoctrineMetadata)
     {
@@ -65,9 +66,9 @@ class Configuration
     }
 
     /**
-     * Gets if all PHPCR document metadata should be validated on read
+     * Gets if all PHPCR document metadata should be validated on read.
      *
-     * @return boolean
+     * @return bool
      */
     public function getValidateDoctrineMetadata()
     {
@@ -75,9 +76,9 @@ class Configuration
     }
 
     /**
-     * Sets if all PHPCR documents should automatically get doctrine metadata added on write
+     * Sets if all PHPCR documents should automatically get doctrine metadata added on write.
      *
-     * @param boolean $writeDoctrineMetadata
+     * @param bool $writeDoctrineMetadata
      */
     public function setWriteDoctrineMetadata($writeDoctrineMetadata)
     {
@@ -85,9 +86,9 @@ class Configuration
     }
 
     /**
-     * Gets if all PHPCR documents should automatically get doctrine metadata added on write
+     * Gets if all PHPCR documents should automatically get doctrine metadata added on write.
      *
-     * @return boolean
+     * @return bool
      */
     public function getWriteDoctrineMetadata()
     {
@@ -110,9 +111,9 @@ class Configuration
      *
      * @param string $documentNamespaceAlias
      *
-     * @return string the namespace URI
-     *
      * @throws PHPCRException
+     *
+     * @return string the namespace URI
      */
     public function getDocumentNamespace($documentNamespaceAlias)
     {
@@ -124,7 +125,7 @@ class Configuration
     }
 
     /**
-     * Set the document alias map
+     * Set the document alias map.
      *
      * @param array $documentNamespaces
      */
@@ -137,6 +138,7 @@ class Configuration
      * Sets the driver implementation that is used to retrieve mapping metadata.
      *
      * @param MappingDriver $driverImpl
+     *
      * @todo Force parameter to be a Closure to ensure lazy evaluation
      *       (as soon as a metadata cache is in effect, the driver never needs to initialize).
      */
@@ -250,7 +252,7 @@ class Configuration
      * Sets a boolean flag that indicates whether proxy classes should always be regenerated
      * during each script execution.
      *
-     * @param boolean $bool
+     * @param bool $bool
      */
     public function setAutoGenerateProxyClasses($bool)
     {
@@ -261,7 +263,7 @@ class Configuration
      * Gets a boolean flag that indicates whether proxy classes should always be regenerated
      * during each script execution.
      *
-     * @return boolean
+     * @return bool
      */
     public function getAutoGenerateProxyClasses()
     {
@@ -289,7 +291,7 @@ class Configuration
      */
     public function getClassMetadataFactoryName()
     {
-        if (! isset($this->attributes['classMetadataFactoryName'])) {
+        if (!isset($this->attributes['classMetadataFactoryName'])) {
             $this->attributes['classMetadataFactoryName'] = Mapping\ClassMetadataFactory::class;
         }
 
@@ -303,15 +305,15 @@ class Configuration
      *
      * @param string $className
      *
-     * @return void
-     *
      * @throws PHPCRException If not is a ObjectRepository
+     *
+     * @return void
      */
     public function setDefaultRepositoryClassName($className)
     {
         $reflectionClass = new \ReflectionClass($className);
 
-        if (! $reflectionClass->implementsInterface(ObjectRepository::class)) {
+        if (!$reflectionClass->implementsInterface(ObjectRepository::class)) {
             throw PHPCRException::invalidDocumentRepository($className);
         }
 
@@ -335,6 +337,7 @@ class Configuration
      * Set the document repository factory.
      *
      * @since 1.1
+     *
      * @param RepositoryFactory $repositoryFactory
      */
     public function setRepositoryFactory(RepositoryFactory $repositoryFactory)
@@ -346,6 +349,7 @@ class Configuration
      * Get the document repository factory.
      *
      * @since 1.1
+     *
      * @return RepositoryFactory
      */
     public function getRepositoryFactory()
@@ -358,6 +362,7 @@ class Configuration
      * Set the closure for the UUID generation.
      *
      * @since 1.1
+     *
      * @param callable $generator
      */
     public function setUuidGenerator(\Closure $generator)
@@ -369,6 +374,7 @@ class Configuration
      * Get the closure for the UUID generation.
      *
      * @since 1.1
+     *
      * @return callable a UUID generator
      */
     public function getUuidGenerator()
@@ -376,7 +382,6 @@ class Configuration
         return $this->attributes['uuidGenerator']
             ?? function () {
                 return UUIDHelper::generateUUID();
-            }
-        ;
+            };
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/PHPCR/Decorator/DocumentManagerDecorator.php
@@ -27,7 +27,7 @@ use PHPCR\PropertyType;
 use PHPCR\Query\QueryInterface;
 
 /**
- * Base class for DocumentManager decorators
+ * Base class for DocumentManager decorators.
  *
  * @since 1.3
  */
@@ -47,7 +47,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function setTranslationStrategy($key, TranslationStrategyInterface $strategy)
     {
@@ -55,7 +55,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTranslationStrategy($key)
     {
@@ -63,7 +63,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function hasLocaleChooserStrategy()
     {
@@ -71,7 +71,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getLocaleChooserStrategy()
     {
@@ -79,7 +79,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function setLocaleChooserStrategy(LocaleChooserInterface $strategy)
     {
@@ -87,7 +87,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getProxyFactory()
     {
@@ -95,7 +95,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getEventManager()
     {
@@ -103,7 +103,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getPhpcrSession()
     {
@@ -111,7 +111,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getMetadataFactory()
     {
@@ -119,7 +119,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getConfiguration()
     {
@@ -127,7 +127,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isOpen()
     {
@@ -135,7 +135,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getClassMetadata($className)
     {
@@ -143,7 +143,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function find($className, $id)
     {
@@ -151,7 +151,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function findMany($className, array $ids)
     {
@@ -159,7 +159,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function findTranslation($className, $id, $locale, $fallback = true)
     {
@@ -167,7 +167,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getRepository($className)
     {
@@ -175,7 +175,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function quote($val, $type = PropertyType::STRING)
     {
@@ -183,7 +183,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function escapeFullText($string)
     {
@@ -191,7 +191,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function createPhpcrQuery($statement, $language)
     {
@@ -199,7 +199,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function createQuery($statement, $language)
     {
@@ -207,7 +207,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function createQueryBuilder()
     {
@@ -215,7 +215,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function createPhpcrQueryBuilder()
     {
@@ -223,7 +223,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDocumentsByPhpcrQuery(QueryInterface $query, $className = null, $primarySelector = null)
     {
@@ -231,7 +231,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function persist($document)
     {
@@ -239,7 +239,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function bindTranslation($document, $locale)
     {
@@ -247,7 +247,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function removeTranslation($document, $locale)
     {
@@ -255,7 +255,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getLocalesFor($document, $includeFallbacks = false)
     {
@@ -263,7 +263,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isDocumentTranslatable($document)
     {
@@ -271,7 +271,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function move($document, $targetPath)
     {
@@ -279,7 +279,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function reorder($document, $srcName, $targetName, $before)
     {
@@ -287,7 +287,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function remove($document)
     {
@@ -295,7 +295,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function merge($document)
     {
@@ -303,7 +303,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function detach($document)
     {
@@ -311,7 +311,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function refresh($document)
     {
@@ -319,7 +319,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getChildren($document, $filter = null, $fetchDepth = null, $locale = null)
     {
@@ -327,7 +327,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getReferrers($document, $type = null, $name = null, $locale = null, $refClass = null)
     {
@@ -335,7 +335,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function flush($document = null)
     {
@@ -343,7 +343,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getReference($documentName, $id)
     {
@@ -351,7 +351,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function checkin($document)
     {
@@ -359,7 +359,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function checkout($document)
     {
@@ -367,7 +367,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function checkpoint($document)
     {
@@ -375,7 +375,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function restoreVersion($documentVersion, $removeExisting = true)
     {
@@ -383,7 +383,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function removeVersion($documentVersion)
     {
@@ -391,7 +391,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAllLinearVersions($document, $limit = -1)
     {
@@ -399,7 +399,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function findVersionByName($className, $id, $versionName)
     {
@@ -407,7 +407,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function contains($document)
     {
@@ -415,7 +415,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUnitOfWork()
     {
@@ -423,22 +423,20 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function clear($className = null)
     {
         $this->wrapped->clear($className);
     }
 
-    /**
-     */
     public function close()
     {
         return $this->wrapped->close();
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function initializeObject($document)
     {
@@ -446,7 +444,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getNodeForDocument($document)
     {
@@ -454,7 +452,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDocumentId($document)
     {

--- a/lib/Doctrine/ODM/PHPCR/Document/AbstractFile.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/AbstractFile.php
@@ -23,7 +23,7 @@ use Doctrine\ODM\PHPCR\HierarchyInterface;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * This class represents an abstract "file"
+ * This class represents an abstract "file".
  *
  * @PHPCRODM\MappedSuperclass(mixins="mix:created")
  */
@@ -82,7 +82,7 @@ abstract class AbstractFile implements HierarchyInterface
     }
 
     /**
-     * Set the node name of the file. (only mutable on new document before the persist)
+     * Set the node name of the file. (only mutable on new document before the persist).
      *
      * @param string $name the name of the file
      *
@@ -122,7 +122,7 @@ abstract class AbstractFile implements HierarchyInterface
 
     /**
      * getter for created
-     * The created date is assigned by the content repository
+     * The created date is assigned by the content repository.
      *
      * @return \DateTime created date of the file
      */
@@ -134,7 +134,7 @@ abstract class AbstractFile implements HierarchyInterface
     /**
      * getter for createdBy
      * The createdBy is assigned by the content repository
-     * This is the name of the (jcr) user that created the node
+     * This is the name of the (jcr) user that created the node.
      *
      * @return string name of the (jcr) user who created the file
      */
@@ -144,7 +144,7 @@ abstract class AbstractFile implements HierarchyInterface
     }
 
     /**
-     * String representation
+     * String representation.
      *
      * @return string
      */

--- a/lib/Doctrine/ODM/PHPCR/Document/File.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/File.php
@@ -24,6 +24,7 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * This class represents a JCR file, aka nt:file.
+ *
  * @see http://wiki.apache.org/jackrabbit/nt:file
  *
  * @PHPCRODM\Document(nodeType="nt:file", mixins={}, referenceable=true)
@@ -31,20 +32,20 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 class File extends AbstractFile
 {
     /**
-     * @var Resource
+     * @var resource
      * @PHPCRODM\Child(nodeName="jcr:content", cascade="all")
      */
     protected $content;
 
     /**
      * Set the content for this file from the given filename.
-     * Calls file_get_contents with the given filename
+     * Calls file_get_contents with the given filename.
      *
      * @param string $filename name of the file which contents should be used
      *
-     * @return $this
-     *
      * @throws RuntimeException If the filename does not point to a file that can be read.
+     *
+     * @return $this
      */
     public function setFileContentFromFilesystem($filename)
     {
@@ -56,7 +57,7 @@ class File extends AbstractFile
         }
         $this->getContent();
         $stream = fopen($filename, 'rb');
-        if (! $stream) {
+        if (!$stream) {
             throw new RuntimeException(sprintf('Failed to open file "%s"', $filename));
         }
 
@@ -73,7 +74,7 @@ class File extends AbstractFile
     /**
      * Set the content for this file from the given Resource.
      *
-     * @param Resource $content
+     * @param resource $content
      *
      * @return $this
      */

--- a/lib/Doctrine/ODM/PHPCR/Document/Folder.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/Folder.php
@@ -25,7 +25,8 @@ use Doctrine\ODM\PHPCR\HierarchyInterface;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * This class represents a Folder in the repository, aka nt:folder
+ * This class represents a Folder in the repository, aka nt:folder.
+ *
  * @see http://wiki.apache.org/jackrabbit/nt:folder
  *
  * To add files or folders to a folder, create the new File/Folder and set
@@ -48,7 +49,7 @@ class Folder extends AbstractFile
     protected $child;
 
     /**
-     * The children File documents of this Folder document
+     * The children File documents of this Folder document.
      *
      * @return Collection list of File documents
      */
@@ -58,7 +59,7 @@ class Folder extends AbstractFile
     }
 
     /**
-     * Sets the children of this Folder document
+     * Sets the children of this Folder document.
      *
      * @param $children ArrayCollection
      *
@@ -73,7 +74,7 @@ class Folder extends AbstractFile
 
     /**
      * Add a child document that resolves to nt:hierarchyNode (like the File)
-     * to this document that resolves to nt:folder (like the Folder)
+     * to this document that resolves to nt:folder (like the Folder).
      *
      * @param $child HierarchyInterface
      *

--- a/lib/Doctrine/ODM/PHPCR/Document/Generic.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/Generic.php
@@ -21,12 +21,11 @@ namespace Doctrine\ODM\PHPCR\Document;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use PHPCR\NodeInterface;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
-
 /**
- * This class represents an arbitrary node
+ * This class represents an arbitrary node.
  *
  * It is used as a default document, for example with the ParentDocument annotation.
  * You can not use this to create nodes as it has no type annotation.
@@ -60,7 +59,7 @@ class Generic
     protected $referrers;
 
     /**
-     * Id (path) of this document
+     * Id (path) of this document.
      *
      * @return string the id
      */
@@ -90,7 +89,7 @@ class Generic
     }
 
     /**
-     * Set the node name of the document. (only mutable on new document before the persist)
+     * Set the node name of the document. (only mutable on new document before the persist).
      *
      * @param string $name the name of the document
      *
@@ -128,7 +127,7 @@ class Generic
     }
 
     /**
-     * The children documents of this document
+     * The children documents of this document.
      *
      * If there is information on the document type, the documents are of the
      * specified type, otherwise they will be Generic documents
@@ -141,7 +140,7 @@ class Generic
     }
 
     /**
-     * Sets the children
+     * Sets the children.
      *
      * @param $children ArrayCollection
      *
@@ -155,7 +154,7 @@ class Generic
     }
 
     /**
-     * Add a child to this document
+     * Add a child to this document.
      *
      * @param $child
      *
@@ -173,7 +172,7 @@ class Generic
     }
 
     /**
-     * The documents having a reference to this document
+     * The documents having a reference to this document.
      *
      * If there is information on the document type, the documents are of the
      * specified type, otherwise they will be Generic documents
@@ -186,7 +185,7 @@ class Generic
     }
 
     /**
-     * Sets the referrers
+     * Sets the referrers.
      *
      * @param $referrers ArrayCollection
      *
@@ -200,7 +199,7 @@ class Generic
     }
 
     /**
-     * Add a referrer to this document
+     * Add a referrer to this document.
      *
      * @param $referrer
      *
@@ -218,7 +217,7 @@ class Generic
     }
 
     /**
-     * String representation
+     * String representation.
      *
      * @return string
      */

--- a/lib/Doctrine/ODM/PHPCR/Document/Resource.php
+++ b/lib/Doctrine/ODM/PHPCR/Document/Resource.php
@@ -20,11 +20,11 @@
 namespace Doctrine\ODM\PHPCR\Document;
 
 use Doctrine\ODM\PHPCR\Exception\BadMethodCallException;
-use PHPCR\NodeInterface;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use PHPCR\NodeInterface;
 
 /**
- * This class represents a jcr nt:resource and is used by the File document
+ * This class represents a jcr nt:resource and is used by the File document.
  *
  * @see http://wiki.apache.org/jackrabbit/nt:resource
  *
@@ -279,17 +279,17 @@ class Resource
     }
 
     /**
-     * Get mime type and encoding (RFC2045)
+     * Get mime type and encoding (RFC2045).
      *
      * @return string
      */
     public function getMime()
     {
-        return $this->getMimeType() . ($this->getEncoding() ? '; charset=' . $this->getEncoding() : '');
+        return $this->getMimeType().($this->getEncoding() ? '; charset='.$this->getEncoding() : '');
     }
 
     /**
-     * String representation
+     * String representation.
      *
      * @return string
      */

--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapper.php
@@ -33,7 +33,7 @@ class DocumentClassMapper implements DocumentClassMapperInterface
     private function expandClassName(DocumentManagerInterface $dm, $className = null)
     {
         if (null === $className) {
-            return null;
+            return;
         }
 
         if (false !== strstr($className, ':')) {
@@ -44,7 +44,7 @@ class DocumentClassMapper implements DocumentClassMapperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getClassName(DocumentManagerInterface $dm, NodeInterface $node, $className = null)
     {
@@ -71,7 +71,7 @@ class DocumentClassMapper implements DocumentClassMapperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function writeMetadata(DocumentManagerInterface $dm, NodeInterface $node, $className)
     {
@@ -89,7 +89,7 @@ class DocumentClassMapper implements DocumentClassMapperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function validateClassName(DocumentManagerInterface $dm, $document, $className)
     {

--- a/lib/Doctrine/ODM/PHPCR/DocumentClassMapperInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentClassMapperInterface.php
@@ -25,25 +25,25 @@ use PHPCR\NodeInterface;
 interface DocumentClassMapperInterface
 {
     /**
-     * Determine the class name from a given node
+     * Determine the class name from a given node.
      *
      * @param DocumentManagerInterface $dm
-     * @param NodeInterface   $node
-     * @param string          $className explicit class to use. If set, this
-     *      class or a subclass of it has to be used. If this is not possible,
-     *      an InvalidArgumentException has to be thrown.
-     *
-     * @return string $className if not null, the class configured for this
-     *      node if defined and the Generic document if no better class can be
-     *      found
+     * @param NodeInterface            $node
+     * @param string                   $className explicit class to use. If set, this
+     *                                            class or a subclass of it has to be used. If this is not possible,
+     *                                            an InvalidArgumentException has to be thrown.
      *
      * @throws ClassMismatchException if $node represents a class that is not
-     *      a descendant of $className.
+     *                                a descendant of $className.
+     *
+     * @return string $className if not null, the class configured for this
+     *                node if defined and the Generic document if no better class can be
+     *                found
      */
     public function getClassName(DocumentManagerInterface $dm, NodeInterface $node, $className = null);
 
     /**
-     * Write any relevant meta data into the node to be able to map back to a class name later
+     * Write any relevant meta data into the node to be able to map back to a class name later.
      *
      * @param DocumentManagerInterface $dm
      * @param NodeInterface            $node

--- a/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
@@ -19,30 +19,30 @@
 
 namespace Doctrine\ODM\PHPCR;
 
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
+use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\ODM\PHPCR\Proxy\ProxyFactory;
-use Doctrine\Common\EventManager;
-use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\TranslationStrategyInterface;
-use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooserInterface;
-use Doctrine\ODM\PHPCR\Query\Query;
-use PHPCR\NodeInterface;
-use PHPCR\Query\QueryInterface;
-use PHPCR\PropertyType;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\ODM\PHPCR\Query\Query;
+use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooserInterface;
+use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
+use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\TranslationStrategyInterface;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
+use PHPCR\Query\QueryInterface;
 use PHPCR\RepositoryException;
 use PHPCR\SessionInterface;
 use PHPCR\UnsupportedRepositoryOperationException;
 
 /**
- * DocumentManager interface
+ * DocumentManager interface.
  */
 interface DocumentManagerInterface extends ObjectManager
 {
     /**
-     * Add or replace a translation strategy
+     * Add or replace a translation strategy.
      *
      * Note that you do not need to set the default strategies attribute and
      * child unless you want to replace them.
@@ -57,21 +57,21 @@ interface DocumentManagerInterface extends ObjectManager
      *
      * @param string $key The name of the translation strategy
      *
-     * @return TranslationStrategyInterface
-     *
      * @throws InvalidArgumentException if there is no strategy registered with the given key
+     *
+     * @return TranslationStrategyInterface
      */
     public function getTranslationStrategy($key);
 
     /**
-     * Check if a language chooser strategy is set
+     * Check if a language chooser strategy is set.
      *
      * @return bool
      */
     public function hasLocaleChooserStrategy();
 
     /**
-     * Get the assigned language chooser strategy previously set with setLocaleChooserStrategy
+     * Get the assigned language chooser strategy previously set with setLocaleChooserStrategy.
      *
      * @return LocaleChooserInterface
      */
@@ -114,7 +114,7 @@ interface DocumentManagerInterface extends ObjectManager
     /**
      * Check if the Document manager is open or closed.
      *
-     * @return boolean true if open, false if closed
+     * @return bool true if open, false if closed
      */
     public function isOpen();
 
@@ -122,12 +122,12 @@ interface DocumentManagerInterface extends ObjectManager
      * Finds many documents by id.
      *
      * @param null|string $className Only return documents that match the
-     *      specified class. All others are treated as not found.
+     *                               specified class. All others are treated as not found.
      * @param array       $ids       List of repository paths and/or uuids to
-     *      find documents. Non-existing ids are ignored.
+     *                               find documents. Non-existing ids are ignored.
      *
      * @return Collection list of documents that where found with the $ids and
-     *      if specified the $className.
+     *                    if specified the $className.
      */
     public function findMany($className, array $ids);
 
@@ -148,19 +148,19 @@ interface DocumentManagerInterface extends ObjectManager
      * @param null|string $className The class name to find the translation for
      * @param string      $id        The identifier of the class (path or uuid)
      * @param string      $locale    The language to try to load.
-     * @param boolean     $fallback  Set to true if the language fallback mechanism should be used.
+     * @param bool        $fallback  Set to true if the language fallback mechanism should be used.
+     *
+     * @throws PHPCRException              if $className is specified and does not match
+     *                                     the class of the document that was found at $id.
+     * @throws MissingTranslationException if $fallback is false and the
+     *                                     translation was not found
      *
      * @return object the translated document.
-     *
-     * @throws PHPCRException if $className is specified and does not match
-     *      the class of the document that was found at $id.
-     * @throws MissingTranslationException if $fallback is false and the
-     *      translation was not found
      */
     public function findTranslation($className, $id, $locale, $fallback = true);
 
     /**
-     * Quote a string for inclusion in an SQL2 query
+     * Quote a string for inclusion in an SQL2 query.
      *
      * @param string $val
      * @param int    $type
@@ -184,7 +184,7 @@ interface DocumentManagerInterface extends ObjectManager
 
     /**
      * Create a PHPCR Query from a query string in the specified query language to be
-     * used with getDocumentsByPhpcrQuery()
+     * used with getDocumentsByPhpcrQuery().
      *
      * Note that it is better to use {@link createQuery}, which returns a native ODM
      * query object, when working with the ODM.
@@ -202,7 +202,7 @@ interface DocumentManagerInterface extends ObjectManager
 
     /**
      * Create a ODM Query from a query string in the specified query language to be
-     * used with getDocumentsByPhpcrQuery()
+     * used with getDocumentsByPhpcrQuery().
      *
      * See \PHPCR\Query\QueryInterface for list of generally supported types
      * and check your implementation documentation if you want to use a
@@ -235,7 +235,7 @@ interface DocumentManagerInterface extends ObjectManager
     public function createPhpcrQueryBuilder();
 
     /**
-     * Get document results from a PHPCR query instance
+     * Get document results from a PHPCR query instance.
      *
      * @param QueryInterface $query           The query instance as acquired through createPhpcrQuery().
      * @param string|null    $className       Document class.
@@ -254,12 +254,12 @@ interface DocumentManagerInterface extends ObjectManager
      * @param string $locale   The locale this document currently has.
      *
      * @throws InvalidArgumentException if $document is not an object or not managed.
-     * @throws PHPCRException if the document is not translatable
+     * @throws PHPCRException           if the document is not translatable
      */
     public function bindTranslation($document, $locale);
 
     /**
-     * Remove the translatable fields of the document in the specified locale
+     * Remove the translatable fields of the document in the specified locale.
      *
      * @param object $document the document to persist a translation of
      * @param string $locale   the locale this document currently has
@@ -272,13 +272,13 @@ interface DocumentManagerInterface extends ObjectManager
      * Get the list of locales that exist for the specified document,
      * including those not yet flushed, but bound.
      *
-     * @param object  $document         The document to get the locales for.
-     * @param boolean $includeFallbacks Whether to include the available language fallbacks.
+     * @param object $document         The document to get the locales for.
+     * @param bool   $includeFallbacks Whether to include the available language fallbacks.
+     *
+     * @throws InvalidArgumentException    if $document is not an object.
+     * @throws MissingTranslationException if the document is not translatable
      *
      * @return array of strings with all locales existing for this particular document
-     *
-     * @throws InvalidArgumentException if $document is not an object.
-     * @throws MissingTranslationException if the document is not translatable
      */
     public function getLocalesFor($document, $includeFallbacks = false);
 
@@ -295,7 +295,7 @@ interface DocumentManagerInterface extends ObjectManager
     public function isDocumentTranslatable($document);
 
     /**
-     * Move the previously persisted document and all its children in the tree
+     * Move the previously persisted document and all its children in the tree.
      *
      * Note that this does not update the Id fields of child documents and
      * neither fields with Child/Children mappings. If you want to continue
@@ -310,16 +310,16 @@ interface DocumentManagerInterface extends ObjectManager
     public function move($document, $targetPath);
 
     /**
-     * Reorder a child of the given document
+     * Reorder a child of the given document.
      *
      * Note that this does not update the fields with Child/Children mappings.
      * If you want to continue working with the manager after a reorder, you are probably
      * safest calling DocumentManager::clear and re-loading the documents you need to use.
      *
-     * @param object  $document   The parent document which must be persisted already.
-     * @param string  $srcName    The nodename of the child to be reordered.
-     * @param string  $targetName The nodename of the target of the reordering.
-     * @param boolean $before     Whether to move before or after the target.
+     * @param object $document   The parent document which must be persisted already.
+     * @param string $srcName    The nodename of the child to be reordered.
+     * @param string $targetName The nodename of the target of the reordering.
+     * @param bool   $before     Whether to move before or after the target.
      *
      * @throws InvalidArgumentException if $document is not an object.
      */
@@ -335,12 +335,12 @@ interface DocumentManagerInterface extends ObjectManager
      *
      * @param object       $document   Document instance which children should be loaded.
      * @param string|array $filter     Optional filter to filter on children names.
-     * @param integer      $fetchDepth Optional fetch depth.
+     * @param int          $fetchDepth Optional fetch depth.
      * @param string       $locale     The locale to use during the loading of this collection.
      *
-     * @return ChildrenCollection collection of child documents
-     *
      * @throws InvalidArgumentException if $document is not an object.
+     *
+     * @return ChildrenCollection collection of child documents
      */
     public function getChildren($document, $filter = null, $fetchDepth = null, $locale = null);
 
@@ -356,15 +356,15 @@ interface DocumentManagerInterface extends ObjectManager
      *
      * Note that this method only returns referrers that have been flushed.
      *
-     * @param object       $document The target of the references to be loaded.
-     * @param string|null  $type     The reference type, null|'weak'|'hard'.
-     * @param string|null  $name     Optional PHPCR property name that holds the reference.
-     * @param string       $locale   The locale to use during the loading of this collection.
-     * @param string|null  $refClass Class the referrer document must be instanceof.
-     *
-     * @return ReferrersCollection collection of referrer documents
+     * @param object      $document The target of the references to be loaded.
+     * @param string|null $type     The reference type, null|'weak'|'hard'.
+     * @param string|null $name     Optional PHPCR property name that holds the reference.
+     * @param string      $locale   The locale to use during the loading of this collection.
+     * @param string|null $refClass Class the referrer document must be instanceof.
      *
      * @throws InvalidArgumentException if $document is not an object.
+     *
+     * @return ReferrersCollection collection of referrer documents
      */
     public function getReferrers($document, $type = null, $name = null, $locale = null, $refClass = null);
 
@@ -432,8 +432,8 @@ interface DocumentManagerInterface extends ObjectManager
      *
      * @param string $documentVersion The version to be restored.
      * @param bool   $removeExisting  How to handle conflicts with unique
-     *      identifiers. If true, existing documents with the identical
-     *      identifier will be replaced, otherwise an exception is thrown.
+     *                                identifiers. If true, existing documents with the identical
+     *                                identifier will be replaced, otherwise an exception is thrown.
      */
     public function restoreVersion($documentVersion, $removeExisting = true);
 
@@ -450,17 +450,17 @@ interface DocumentManagerInterface extends ObjectManager
     public function removeVersion($documentVersion);
 
     /**
-     * Get the version history information for a document
+     * Get the version history information for a document.
      *
      * labels will be an empty array.
      *
      * @param object $document The document of which to get the version history.
      * @param int    $limit    An optional limit to only get the latest $limit information.
      *
-     * @return array of <versionname> => array("name" => <versionname>, "labels" => <array of labels>, "created" => <DateTime>)
-     *         oldest version first
-     *
      * @throws InvalidArgumentException if $document is not an object.
+     *
+     * @return array of <versionname> => array("name" => <versionname>, "labels" => <array of labels>, "created" => <DateTime>)
+     *               oldest version first
      */
     public function getAllLinearVersions($document, $limit = -1);
 
@@ -475,19 +475,19 @@ interface DocumentManagerInterface extends ObjectManager
      * @param string      $id          Id of the document.
      * @param string      $versionName The version name as given by getLinearPredecessors.
      *
-     * @return object the detached document or null if the document is not found
-     *
-     * @throws InvalidArgumentException if there is a document with $id but no
-     *      version with $name
+     * @throws InvalidArgumentException                if there is a document with $id but no
+     *                                                 version with $name
      * @throws UnsupportedRepositoryOperationException if the implementation
-     *      does not support versioning
+     *                                                 does not support versioning
+     *
+     * @return object the detached document or null if the document is not found
      */
     public function findVersionByName($className, $id, $versionName);
 
     /**
      * Client code should not access the UnitOfWork except in special
      * circumstances. Methods on UnitOfWork might be changed without special
-     * notice
+     * notice.
      *
      * @return UnitOfWork
      */
@@ -502,12 +502,12 @@ interface DocumentManagerInterface extends ObjectManager
      * argument to limit the flush to one or more specific documents.
      *
      * @param object|array|null $document optionally limit to a specific
-     *      document or an array of documents
-     *
-     * @return void
+     *                                    document or an array of documents
      *
      * @throws InvalidArgumentException if $document is neither null nor a
-     *      document or an array of documents
+     *                                  document or an array of documents
+     *
+     * @return void
      */
     public function flush($document = null);
 
@@ -519,14 +519,14 @@ interface DocumentManagerInterface extends ObjectManager
     public function close();
 
     /**
-     * Return the node of the given object
+     * Return the node of the given object.
      *
      * @param object $document
      *
-     * @return NodeInterface
-     *
      * @throws InvalidArgumentException if $document is not an object.
-     * @throws PHPCRException                if $document is not managed
+     * @throws PHPCRException           if $document is not managed
+     *
+     * @return NodeInterface
      */
     public function getNodeForDocument($document);
 
@@ -535,9 +535,9 @@ interface DocumentManagerInterface extends ObjectManager
      *
      * @param object $document A managed document
      *
-     * @return string
-     *
      * @throws PHPCRException if $document is not managed
+     *
+     * @return string
      */
     public function getDocumentId($document);
 }

--- a/lib/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -20,12 +20,12 @@
 namespace Doctrine\ODM\PHPCR;
 
 use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Query\Builder\ConstraintFactory;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Query\Query;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as Constants;
-use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
-use Doctrine\ODM\PHPCR\Query\Builder\ConstraintFactory;
 
 /**
  * A DocumentRepository serves as a repository for documents with generic as well as
@@ -35,8 +35,10 @@ use Doctrine\ODM\PHPCR\Query\Builder\ConstraintFactory;
  * write their own repositories with business-specific methods to locate documents.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Jordi Boggiano <j.boggiano@seld.be>
  * @author      Pascal Helfenstein <nicam@nicam.ch>
  */
@@ -80,7 +82,7 @@ class DocumentRepository implements ObjectRepository
     }
 
     /**
-     * Find a single document by its id
+     * Find a single document by its id.
      *
      * The id may either be a PHPCR path or UUID
      *
@@ -94,7 +96,7 @@ class DocumentRepository implements ObjectRepository
     }
 
     /**
-     * Find many document by id
+     * Find many document by id.
      *
      * The ids may either be PHPCR paths or UUID's, but all must be of the same type
      *
@@ -114,7 +116,7 @@ class DocumentRepository implements ObjectRepository
      */
     public function findAll()
     {
-        return $this->findBy(array());
+        return $this->findBy([]);
     }
 
     /**
@@ -124,10 +126,10 @@ class DocumentRepository implements ObjectRepository
      * an InvalidArgumentException if certain values of the sorting or limiting details are
      * not supported.
      *
-     * @param  array      $criteria
-     * @param  array|null $orderBy
-     * @param  int|null   $limit
-     * @param  int|null   $offset
+     * @param array      $criteria
+     * @param array|null $orderBy
+     * @param int|null   $limit
+     * @param int|null   $offset
      *
      * @return array The objects matching the criteria.
      */
@@ -147,7 +149,7 @@ class DocumentRepository implements ObjectRepository
         if ($orderBy) {
             foreach ($orderBy as $field => $order) {
                 $order = strtolower($order);
-                if (!in_array($order, array('asc', 'desc'))) {
+                if (!in_array($order, ['asc', 'desc'])) {
                     throw new InvalidArgumentException(sprintf(
                         'Invalid order specified by order, expected either "asc" or "desc", got "%s"',
                         $order
@@ -183,12 +185,12 @@ class DocumentRepository implements ObjectRepository
     }
 
     /**
-     * Constraints a field for a given value
+     * Constraints a field for a given value.
      *
      * @param ConstraintFactory $where
-     * @param string $field The field searched
-     * @param mixed $value The value to search for
-     * @param string $alias The alias used
+     * @param string            $field The field searched
+     * @param mixed             $value The value to search for
+     * @param string            $alias The alias used
      */
     protected function constraintField(ConstraintFactory $where, $field, $value, $alias)
     {
@@ -205,7 +207,7 @@ class DocumentRepository implements ObjectRepository
      * @param array $criteria
      *
      * @return object|null The first document matching the criteria or null if
-     *      none found
+     *                     none found
      */
     public function findOneBy(array $criteria)
     {
@@ -217,7 +219,7 @@ class DocumentRepository implements ObjectRepository
     /**
      * Refresh a document with the data from PHPCR.
      *
-     * @param  object $document
+     * @param object $document
      */
     public function refresh($document)
     {
@@ -259,7 +261,7 @@ class DocumentRepository implements ObjectRepository
     }
 
     /**
-     * Quote a string for inclusion in an SQL2 query
+     * Quote a string for inclusion in an SQL2 query.
      *
      * @param string $val
      * @param int    $type
@@ -288,7 +290,7 @@ class DocumentRepository implements ObjectRepository
     }
 
     /**
-     * Create a Query
+     * Create a Query.
      *
      * @param string $statement             the SQL2 statement
      * @param string $language              (see QueryInterface for list of supported types)
@@ -305,7 +307,7 @@ class DocumentRepository implements ObjectRepository
             if (1 === count($columns)) {
                 $column = reset($columns);
                 if ('*' === $column->getColumnName() && null == $column->getPropertyName()) {
-                    $qb->setColumns(array());
+                    $qb->setColumns([]);
                     foreach ($this->class->getFieldNames() as $name) {
                         $qb->addSelect('a', $name);
                     }
@@ -325,7 +327,7 @@ class DocumentRepository implements ObjectRepository
     }
 
     /**
-     * Create a QueryBuilder that is pre-populated for this repositories document
+     * Create a QueryBuilder that is pre-populated for this repositories document.
      *
      * The returned query builder will be pre-populated with the criteria
      * required to search for this repositories document class.

--- a/lib/Doctrine/ODM/PHPCR/Event.php
+++ b/lib/Doctrine/ODM/PHPCR/Event.php
@@ -44,22 +44,22 @@ final class Event
     const preRemoveTranslation = 'preRemoveTranslation';
     const postRemoveTranslation = 'postRemoveTranslation';
 
-    public static $lifecycleCallbacks = array(
-        self::prePersist => self::prePersist,
-        self::preRemove => self::preRemove ,
-        self::preUpdate => self::preUpdate,
-        self::preMove => self::preMove,
-        self::postRemove => self::postRemove,
-        self::postPersist => self::postPersist,
-        self::postUpdate => self::postUpdate,
-        self::postMove => self::postMove,
-        self::postLoad => self::postLoad,
-        self::postLoadTranslation => self::postLoadTranslation,
-        self::preCreateTranslation => self::preCreateTranslation,
-        self::preUpdateTranslation => self::preUpdateTranslation,
-        self::preRemoveTranslation => self::preRemoveTranslation,
+    public static $lifecycleCallbacks = [
+        self::prePersist            => self::prePersist,
+        self::preRemove             => self::preRemove,
+        self::preUpdate             => self::preUpdate,
+        self::preMove               => self::preMove,
+        self::postRemove            => self::postRemove,
+        self::postPersist           => self::postPersist,
+        self::postUpdate            => self::postUpdate,
+        self::postMove              => self::postMove,
+        self::postLoad              => self::postLoad,
+        self::postLoadTranslation   => self::postLoadTranslation,
+        self::preCreateTranslation  => self::preCreateTranslation,
+        self::preUpdateTranslation  => self::preUpdateTranslation,
+        self::preRemoveTranslation  => self::preRemoveTranslation,
         self::postRemoveTranslation => self::postRemoveTranslation,
-    );
+    ];
 
     private function __construct()
     {

--- a/lib/Doctrine/ODM/PHPCR/Event/ListenersInvoker.php
+++ b/lib/Doctrine/ODM/PHPCR/Event/ListenersInvoker.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\ODM\PHPCR\Event;
 
 use Doctrine\Common\EventArgs;
@@ -12,16 +11,17 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
  * A method invoker based on document lifecycle.
  *
  * @since  1.1
+ *
  * @author Fabio B. Silva      <fabio.bat.silva@gmail.com>
  * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
  */
 class ListenersInvoker
 {
-    const INVOKE_NONE       = 0;
+    const INVOKE_NONE = 0;
     // Actually not uses in the phpcr-odm
-    const INVOKE_LISTENERS  = 1;
-    const INVOKE_CALLBACKS  = 2;
-    const INVOKE_MANAGER    = 4;
+    const INVOKE_LISTENERS = 1;
+    const INVOKE_CALLBACKS = 2;
+    const INVOKE_MANAGER = 4;
 
     /**
      * The EventManager used for dispatching events.
@@ -47,12 +47,12 @@ class ListenersInvoker
     }
 
     /**
-     * Get the subscribed event systems
+     * Get the subscribed event systems.
      *
      * @param ClassMetadata $metadata
      * @param string        $eventName The entity lifecycle event.
      *
-     * @return integer                 Bitmask of subscribed event systems.
+     * @return int Bitmask of subscribed event systems.
      */
     public function getSubscribedSystems(ClassMetadata $metadata, $eventName)
     {
@@ -80,10 +80,10 @@ class ListenersInvoker
     /**
      * Dispatches the lifecycle event of the given entity.
      *
-     * @param ClassMetadata $metadata The entity metadata.
-     * @param string $eventName The entity lifecycle event.
-     * @param object $document The Entity on which the event occurred.
-     * @param EventArgs $event The Event args.
+     * @param ClassMetadata $metadata  The entity metadata.
+     * @param string        $eventName The entity lifecycle event.
+     * @param object        $document  The Entity on which the event occurred.
+     * @param EventArgs     $event     The Event args.
      * @param $invoke
      */
     public function invoke(ClassMetadata $metadata, $eventName, $document, EventArgs $event, $invoke)

--- a/lib/Doctrine/ODM/PHPCR/Event/MoveEventArgs.php
+++ b/lib/Doctrine/ODM/PHPCR/Event/MoveEventArgs.php
@@ -36,7 +36,7 @@ class MoveEventArgs extends LifecycleEventArgs
     private $targetPath;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param object                   $document
      * @param DocumentManagerInterface $dm

--- a/lib/Doctrine/ODM/PHPCR/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/PHPCR/Event/PreUpdateEventArgs.php
@@ -33,13 +33,13 @@ class PreUpdateEventArgs extends BasePreUpdateEventArgs
     /**
      * Constructor.
      *
-     * @param object                    $document
-     * @param DocumentManagerInterface  $objectManager
-     * @param array                     $changeSet
+     * @param object                   $document
+     * @param DocumentManagerInterface $objectManager
+     * @param array                    $changeSet
      */
     public function __construct($document, DocumentManagerInterface $documentManager, array &$changeSet)
     {
-        $fieldChangeSet = array();
+        $fieldChangeSet = [];
         if (isset($changeSet['fields'])) {
             $fieldChangeSet = &$changeSet['fields'];
         }

--- a/lib/Doctrine/ODM/PHPCR/Exception/BadMethodCallException.php
+++ b/lib/Doctrine/ODM/PHPCR/Exception/BadMethodCallException.php
@@ -22,7 +22,7 @@ namespace Doctrine\ODM\PHPCR\Exception;
 use Doctrine\ODM\PHPCR\PHPCRExceptionInterface;
 
 /**
- * InvalidArgumentException for the PHPCR-ODM
+ * InvalidArgumentException for the PHPCR-ODM.
  */
 class BadMethodCallException extends \BadMethodCallException implements PHPCRExceptionInterface
 {

--- a/lib/Doctrine/ODM/PHPCR/Exception/CascadeException.php
+++ b/lib/Doctrine/ODM/PHPCR/Exception/CascadeException.php
@@ -22,7 +22,7 @@ namespace Doctrine\ODM\PHPCR\Exception;
 use Doctrine\ODM\PHPCR\PHPCRException;
 
 /**
- * Missing translation exception class
+ * Missing translation exception class.
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
@@ -30,9 +30,9 @@ class CascadeException extends PHPCRException
 {
     public static function newDocumentFound($documentString)
     {
-        return new self("A new document was found through a relationship that was not"
-                        . " configured to cascade persist operations: $documentString."
-                        . " Explicitly persist the new document or configure cascading persist operations"
-                        . " on the relationship.");
+        return new self('A new document was found through a relationship that was not'
+                        ." configured to cascade persist operations: $documentString."
+                        .' Explicitly persist the new document or configure cascading persist operations'
+                        .' on the relationship.');
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/ODM/PHPCR/Exception/InvalidArgumentException.php
@@ -22,7 +22,7 @@ namespace Doctrine\ODM\PHPCR\Exception;
 use Doctrine\ODM\PHPCR\PHPCRExceptionInterface;
 
 /**
- * InvalidArgumentException for the PHPCR-ODM
+ * InvalidArgumentException for the PHPCR-ODM.
  */
 class InvalidArgumentException extends \InvalidArgumentException implements PHPCRExceptionInterface
 {

--- a/lib/Doctrine/ODM/PHPCR/Exception/OutOfBoundsException.php
+++ b/lib/Doctrine/ODM/PHPCR/Exception/OutOfBoundsException.php
@@ -22,7 +22,7 @@ namespace Doctrine\ODM\PHPCR\Exception;
 use Doctrine\ODM\PHPCR\PHPCRExceptionInterface;
 
 /**
- * InvalidArgumentException for the PHPCR-ODM
+ * InvalidArgumentException for the PHPCR-ODM.
  */
 class OutOfBoundsException extends \OutOfBoundsException implements PHPCRExceptionInterface
 {

--- a/lib/Doctrine/ODM/PHPCR/Exception/RuntimeException.php
+++ b/lib/Doctrine/ODM/PHPCR/Exception/RuntimeException.php
@@ -22,7 +22,7 @@ namespace Doctrine\ODM\PHPCR\Exception;
 use Doctrine\ODM\PHPCR\PHPCRExceptionInterface;
 
 /**
- * RuntimeException for the PHPCR-ODM
+ * RuntimeException for the PHPCR-ODM.
  */
 class RuntimeException extends \RuntimeException implements PHPCRExceptionInterface
 {

--- a/lib/Doctrine/ODM/PHPCR/Id/AssignedIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/AssignedIdGenerator.php
@@ -30,7 +30,7 @@ class AssignedIdGenerator extends IdGenerator
     /**
      * Use the identifier field as id and throw exception if not set.
      *
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function generate($document, ClassMetadata $cm, DocumentManagerInterface $dm, $parent = null)
     {

--- a/lib/Doctrine/ODM/PHPCR/Id/AutoIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/AutoIdGenerator.php
@@ -25,14 +25,14 @@ use PHPCR\RepositoryException;
 use PHPCR\Util\NodeHelper;
 
 /**
- * Generate the id using the auto naming strategy
+ * Generate the id using the auto naming strategy.
  */
 class AutoIdGenerator extends ParentIdGenerator
 {
     /**
-     * Use the parent field together with an auto generated name to generate the id
+     * Use the parent field together with an auto generated name to generate the id.
      *
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function generate($document, ClassMetadata $class, DocumentManagerInterface $dm, $parent = null)
     {
@@ -54,7 +54,7 @@ class AutoIdGenerator extends ParentIdGenerator
             $existingNames = (array) $parentNode->getNodeNames();
         } catch (RepositoryException $e) {
             // this typically happens while cascading persisting documents
-            $existingNames = array();
+            $existingNames = [];
         }
         $name = NodeHelper::generateAutoNodeName(
             $existingNames,

--- a/lib/Doctrine/ODM/PHPCR/Id/IdException.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/IdException.php
@@ -46,7 +46,7 @@ class IdException extends PHPCRException
     {
         $parentType = is_object($parentObject) ? ClassUtils::getClass($parentObject) : $parentObject;
         $message = sprintf(
-            'ParentDocument property "%s" of document of class "%s" contains an ' .
+            'ParentDocument property "%s" of document of class "%s" contains an '.
             'object for which no ID could be found',
             $parent,
             $document ? ClassUtils::getClass($document) : 'null',
@@ -76,7 +76,7 @@ class IdException extends PHPCRException
         $childNodeName)
     {
         $message = sprintf(
-            '%s discovered as new child of %s in field "%s" has a node name ' .
+            '%s discovered as new child of %s in field "%s" has a node name '.
             'mismatch. The mapping says "%s" but the child was assigned "%s".',
             $childDocument ? ClassUtils::getClass($childDocument) : 'null',
             $parentId,

--- a/lib/Doctrine/ODM/PHPCR/Id/IdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/IdGenerator.php
@@ -20,15 +20,17 @@
 namespace Doctrine\ODM\PHPCR\Id;
 
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 
 /**
- * Used to abstract ID generation
+ * Used to abstract ID generation.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  * @author      Lukas Kahwe Smith <smith@pooteeweet.org>
  */
@@ -65,7 +67,7 @@ abstract class IdGenerator
     }
 
     /**
-     * Generate the actual id, to be overwritten by extending classes
+     * Generate the actual id, to be overwritten by extending classes.
      *
      * @param object                   $document the object to create the id for
      * @param ClassMetadata            $class    class metadata of this object

--- a/lib/Doctrine/ODM/PHPCR/Id/ParentIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/ParentIdGenerator.php
@@ -29,9 +29,9 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 class ParentIdGenerator extends IdGenerator
 {
     /**
-     * Use the name and parent fields to generate the id
+     * Use the name and parent fields to generate the id.
      *
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function generate($document, ClassMetadata $class, DocumentManagerInterface $dm, $parent = null)
     {
@@ -82,6 +82,6 @@ class ParentIdGenerator extends IdGenerator
             $id = '';
         }
 
-        return $id . '/' . $name;
+        return $id.'/'.$name;
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Id/RepositoryIdGenerator.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/RepositoryIdGenerator.php
@@ -28,7 +28,7 @@ class RepositoryIdGenerator extends IdGenerator
     /**
      * Use a repository that implements RepositoryIdGenerator to generate the id.
      *
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function generate($document, ClassMetadata $class, DocumentManagerInterface $dm, $parent = null)
     {
@@ -42,7 +42,7 @@ class RepositoryIdGenerator extends IdGenerator
 
         $id = $repository->generateId($document, $parent);
         if (!$id) {
-            throw new IdException("ID could not be determined. Repository was unable to generate an ID");
+            throw new IdException('ID could not be determined. Repository was unable to generate an ID');
         }
 
         return $id;

--- a/lib/Doctrine/ODM/PHPCR/Id/RepositoryIdInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/Id/RepositoryIdInterface.php
@@ -25,7 +25,7 @@ namespace Doctrine\ODM\PHPCR\Id;
 interface RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
      * @param object $parent

--- a/lib/Doctrine/ODM/PHPCR/ImmutableReferrersCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ImmutableReferrersCollection.php
@@ -20,7 +20,7 @@
 namespace Doctrine\ODM\PHPCR;
 
 /**
- * Immutable referrer collection class
+ * Immutable referrer collection class.
  *
  * This class represents a collection of referrers of a document that can be
  * mixed and thus never can be persisted.

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Child.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Child.php
@@ -28,7 +28,8 @@ use Doctrine\Common\Annotations\Annotation;
 final class Child
 {
     /**
-     * PHPCR node name of the child to map
+     * PHPCR node name of the child to map.
+     *
      * @var string
      */
     public $nodeName;
@@ -36,5 +37,5 @@ final class Child
     /**
      * @var array
      */
-    public $cascade = array();
+    public $cascade = [];
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Children.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Children.php
@@ -33,17 +33,17 @@ final class Children
     public $filter;
 
     /**
-     *@var integer
+     *@var int
      */
     public $fetchDepth = -1;
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $ignoreUntranslated = true;
 
     /**
      * @var array
      */
-    public $cascade = array();
+    public $cascade = [];
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Document.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Document.php
@@ -48,7 +48,7 @@ class Document
     public $mixins;
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $inheritMixins;
 
@@ -58,22 +58,22 @@ class Document
     public $versionable;
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $referenceable;
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $uniqueNodeType;
 
     /**
      * @var array
      */
-    public $childClasses = array();
+    public $childClasses = [];
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $isLeaf;
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Id.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Id.php
@@ -28,7 +28,7 @@ use Doctrine\Common\Annotations\Annotation;
 final class Id
 {
     /**
-     * @var boolean
+     * @var bool
      */
     public $id = true;
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Nodename.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Nodename.php
@@ -22,7 +22,8 @@ namespace Doctrine\ODM\PHPCR\Mapping\Annotations;
 use Doctrine\Common\Annotations\Annotation;
 
 /**
- * The name of this node as in PHPCR\NodeInterface::getName
+ * The name of this node as in PHPCR\NodeInterface::getName.
+ *
  * @Annotation
  * @Target("PROPERTY")
  */

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/ParentDocument.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/ParentDocument.php
@@ -33,5 +33,5 @@ final class ParentDocument
     /**
      * @var array
      */
-    public $cascade = array();
+    public $cascade = [];
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Property.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Property.php
@@ -20,12 +20,13 @@
 namespace Doctrine\ODM\PHPCR\Mapping\Annotations;
 
 /**
- * base class for all property types
+ * base class for all property types.
  */
 class Property
 {
     /**
-     * The PHPCR property name to use
+     * The PHPCR property name to use.
+     *
      * @var string
      */
     public $property;
@@ -36,7 +37,7 @@ class Property
     public $type = 'undefined';
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $multivalue = false;
 
@@ -46,7 +47,7 @@ class Property
     public $assoc;
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $nullable = false;
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Reference.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Reference.php
@@ -20,12 +20,13 @@
 namespace Doctrine\ODM\PHPCR\Mapping\Annotations;
 
 /**
- * base class for the reference types
+ * base class for the reference types.
  */
 class Reference
 {
     /**
-     * The PHPCR property name to use
+     * The PHPCR property name to use.
+     *
      * @var string
      */
     public $property;
@@ -43,5 +44,5 @@ class Reference
     /**
      * @var array
      */
-    public $cascade = array();
+    public $cascade = [];
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Referrers.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/Referrers.php
@@ -28,7 +28,8 @@ use Doctrine\Common\Annotations\Annotation;
 final class Referrers
 {
     /**
-     * Name of the field in the other document referencing this document
+     * Name of the field in the other document referencing this document.
+     *
      * @var string
      */
     public $referencedBy;
@@ -41,5 +42,5 @@ final class Referrers
     /**
      * @var array
      */
-    public $cascade = array();
+    public $cascade = [];
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/TranslatableProperty.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/TranslatableProperty.php
@@ -20,12 +20,12 @@
 namespace Doctrine\ODM\PHPCR\Mapping\Annotations;
 
 /**
- * Base class for all the translatable properties (i.e. every property but Uuid and Version)
+ * Base class for all the translatable properties (i.e. every property but Uuid and Version).
  */
 class TranslatableProperty extends Property
 {
     /**
-     * @var boolean
+     * @var bool
      */
     public $translated = false;
 }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -19,26 +19,28 @@
 
 namespace Doctrine\ODM\PHPCR\Mapping;
 
-use Doctrine\ODM\PHPCR\Exception\BadMethodCallException;
+use Doctrine\Common\ClassLoader;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
+use Doctrine\Common\Persistence\Mapping\ReflectionService;
+use Doctrine\Instantiator\Instantiator;
+use Doctrine\Instantiator\InstantiatorInterface;
 use Doctrine\ODM\PHPCR\Event;
+use Doctrine\ODM\PHPCR\Exception\BadMethodCallException;
+use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
 use Doctrine\ODM\PHPCR\PHPCRException;
 use PHPCR\RepositoryException;
 use PHPCR\Util\PathHelper;
-use ReflectionProperty;
 use ReflectionClass;
-use Doctrine\Common\Persistence\Mapping\ReflectionService;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
-use Doctrine\Common\ClassLoader;
-use Doctrine\Instantiator\Instantiator;
-use Doctrine\Instantiator\InstantiatorInterface;
-use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
+use ReflectionProperty;
 
 /**
- * Metadata class
+ * Metadata class.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  * @author      Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author      Jonathan H. Wage <jonwage@gmail.com>
@@ -89,14 +91,14 @@ class ClassMetadata implements ClassMetadataInterface
      */
     const GENERATOR_TYPE_AUTO = 4;
 
-    protected static $validVersionableAnnotations = array('simple', 'full');
+    protected static $validVersionableAnnotations = ['simple', 'full'];
 
     /**
      * READ-ONLY: The ReflectionProperty instances of the mapped class.
      *
      * @var ReflectionProperty[]
      */
-    public $reflFields = array();
+    public $reflFields = [];
 
     /**
      * READ-ONLY: The ID generator used for generating IDs for this class.
@@ -111,12 +113,12 @@ class ClassMetadata implements ClassMetadataInterface
     public $identifier;
 
     /**
-     * READ-ONLY: The field name of the UUID field
+     * READ-ONLY: The field name of the UUID field.
      */
     public $uuidFieldName;
 
     /**
-     * READ-ONLY: The name of the document class that is stored in the phpcr:class property
+     * READ-ONLY: The name of the document class that is stored in the phpcr:class property.
      */
     public $name;
 
@@ -124,33 +126,34 @@ class ClassMetadata implements ClassMetadataInterface
      * READ-ONLY: The namespace the document class is contained in.
      *
      * @var string
+     *
      * @todo Not really needed. Usage could be localized.
      */
     public $namespace;
 
     /**
-     * READ-ONLY: The JCR Nodetype to be used for this node
+     * READ-ONLY: The JCR Nodetype to be used for this node.
      *
      * @var string
      */
     public $nodeType = 'nt:unstructured';
 
     /**
-     * READ-ONLY: The JCR Mixins to be used for this node (including inherited mixins)
+     * READ-ONLY: The JCR Mixins to be used for this node (including inherited mixins).
      *
      * @var array
      */
-    public $mixins = array();
+    public $mixins = [];
 
     /**
-     * READ-ONLY: Inherit parent class' mixins (default) or not
+     * READ-ONLY: Inherit parent class' mixins (default) or not.
      *
      * @var bool
      */
     public $inheritMixins = true;
 
     /**
-     * READ-ONLY: The field name of the node
+     * READ-ONLY: The field name of the node.
      *
      * @var string
      */
@@ -183,7 +186,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var array
      */
-    public $fieldMappings = array();
+    public $fieldMappings = [];
 
     /**
      * READ-ONLY: The all mappings of the class.
@@ -199,14 +202,14 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var array
      */
-    public $mappings = array();
+    public $mappings = [];
 
     /**
      * READ-ONLY: The registered lifecycle callbacks for documents of this class.
      *
      * @var array
      */
-    public $lifecycleCallbacks = array();
+    public $lifecycleCallbacks = [];
 
     /**
      * The ReflectionClass instance of the mapped class.
@@ -218,7 +221,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * READ-ONLY: Whether this class describes the mapping of a mapped superclass.
      *
-     * @var boolean
+     * @var bool
      */
     public $isMappedSuperclass = false;
 
@@ -227,81 +230,81 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var array
      */
-    public $referenceMappings = array();
+    public $referenceMappings = [];
 
     /**
      * READ-ONLY: The child mappings of the class.
      *
      * @var array
      */
-    public $childMappings = array();
+    public $childMappings = [];
 
     /**
      * READ-ONLY: The children mappings of the class.
      *
      * @var array
      */
-    public $childrenMappings = array();
+    public $childrenMappings = [];
 
     /**
      * READ-ONLY: The referrers mappings of the class.
      *
      * @var array
      */
-    public $referrersMappings = array();
+    public $referrersMappings = [];
 
     /**
      * READ-ONLY: The mixed referrers (read only) mappings of the class.
      *
      * @var array
      */
-    public $mixedReferrersMappings = array();
+    public $mixedReferrersMappings = [];
 
     /**
-     * READ-ONLY: Name of the locale property
+     * READ-ONLY: Name of the locale property.
      *
      * @var string
      */
     public $localeMapping;
 
     /**
-     * READ-ONLY: Name of the depth property
+     * READ-ONLY: Name of the depth property.
      *
      * @var string
      */
     public $depthMapping;
 
     /**
-     * READ-ONLY: Name of the version name property of this document
+     * READ-ONLY: Name of the version name property of this document.
      *
      * @var string
      */
     public $versionNameField;
 
     /**
-     * READ-ONLY: Name of the version created property of this document
+     * READ-ONLY: Name of the version created property of this document.
      *
      * @var string
      */
     public $versionCreatedField;
 
     /**
-     * READ-ONLY: List of translatable fields
+     * READ-ONLY: List of translatable fields.
      *
      * @var array
      */
-    public $translatableFields = array();
+    public $translatableFields = [];
 
     /**
      * READ-ONLY: Whether this document should be versioned. If this is not false, it will
-     * be one of the values from self::validVersionableAnnotations
+     * be one of the values from self::validVersionableAnnotations.
      *
      * @var bool|string
      */
     public $versionable = false;
 
     /**
-     * READ-ONLY: determines if the document is referenceable or not
+     * READ-ONLY: determines if the document is referenceable or not.
      *
      * @var bool
      */
@@ -316,7 +319,7 @@ class ClassMetadata implements ClassMetadataInterface
 
     /**
      * READ-ONLY: Strategy key to find field translations.
-     * This is the key used for DocumentManagerInterface::getTranslationStrategy
+     * This is the key used for DocumentManagerInterface::getTranslationStrategy.
      *
      * @var string
      */
@@ -327,7 +330,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var array
      */
-    public $parentClasses = array();
+    public $parentClasses = [];
 
     /**
      * READ-ONLY: Child class restrictions.
@@ -336,22 +339,22 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var array
      */
-    public $childClasses = array();
+    public $childClasses = [];
 
     /**
      * READ-ONLY: If the document should be act as a leaf-node and therefore
      *            not be allowed children.
      *
-     * @var boolean
+     * @var bool
      */
     public $isLeaf = false;
 
     /**
-     * The inherited fields of this class
+     * The inherited fields of this class.
      *
      * @var array
      */
-    private $inheritedFields = array();
+    private $inheritedFields = [];
 
     /**
      * @var InstantiatorInterface
@@ -394,8 +397,7 @@ class ClassMetadata implements ClassMetadataInterface
         foreach ($fieldNames as $fieldName) {
             $reflField = isset($this->mappings[$fieldName]['declared'])
                 ? new ReflectionProperty($this->mappings[$fieldName]['declared'], $fieldName)
-                : $this->reflClass->getProperty($fieldName)
-            ;
+                : $this->reflClass->getProperty($fieldName);
             $reflField->setAccessible(true);
             $this->reflFields[$fieldName] = $reflField;
         }
@@ -429,8 +431,6 @@ class ClassMetadata implements ClassMetadataInterface
         } catch (RepositoryException $e) {
             return $e;
         }
-
-        return null;
     }
 
     /**
@@ -441,7 +441,7 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function validateIdentifier()
     {
-        if (! $this->isMappedSuperclass) {
+        if (!$this->isMappedSuperclass) {
             if ($this->isIdGeneratorNone()) {
                 $this->determineIdStrategy();
             }
@@ -491,9 +491,10 @@ class ClassMetadata implements ClassMetadataInterface
      * metadata represents.
      *
      * @param string $classFqn
+     *
      * @throws OutOfBoundsException
      */
-    public function assertValidChildClass(ClassMetadata $class)
+    public function assertValidChildClass(self $class)
     {
         if ($this->isLeaf()) {
             throw new OutOfBoundsException(sprintf(
@@ -568,7 +569,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Validate lifecycle callbacks
+     * Validate lifecycle callbacks.
      *
      * @param ReflectionService $reflService
      *
@@ -593,7 +594,7 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function setIdentifier($identifier)
     {
-        if ($this->identifier &&  $this->identifier !== $identifier) {
+        if ($this->identifier && $this->identifier !== $identifier) {
             throw new MappingException('Cannot map the identifier to more than one property');
         }
 
@@ -618,7 +619,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @param string $lifecycleEvent
      *
-     * @return boolean
+     * @return bool
      */
     public function hasLifecycleCallbacks($lifecycleEvent)
     {
@@ -634,7 +635,7 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function getLifecycleCallbacks($event)
     {
-        return $this->lifecycleCallbacks[$event] ?? array();
+        return $this->lifecycleCallbacks[$event] ?? [];
     }
 
     /**
@@ -669,7 +670,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * @param string|boolean $versionable A valid versionable annotation or false to disable versioning.
+     * @param string|bool $versionable A valid versionable annotation or false to disable versioning.
      */
     public function setVersioned($versionable)
     {
@@ -688,7 +689,7 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function setReferenceable($referenceable)
     {
-        if ($this->referenceable && ! $referenceable) {
+        if ($this->referenceable && !$referenceable) {
             throw new MappingException('Can not overwrite referenceable attribute to false in child class');
         }
         $this->referenceable = $referenceable;
@@ -731,7 +732,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Set the JCR mixins
+     * Set the JCR mixins.
      *
      * @param array $mixins
      */
@@ -751,9 +752,9 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Set whether to inherit mixins from parent
+     * Set whether to inherit mixins from parent.
      *
-     * @param boolean $inheritMixins
+     * @param bool $inheritMixins
      */
     public function setInheritMixins($inheritMixins)
     {
@@ -761,16 +762,14 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Return whether to inherit mixins from parent
+     * Return whether to inherit mixins from parent.
      *
-     * @return boolean
+     * @return bool
      */
     public function getInheritMixins()
     {
         return $this->inheritMixins;
     }
-
-
 
     /**
      * Gets the ReflectionProperties of the mapped class.
@@ -804,7 +803,7 @@ class ClassMetadata implements ClassMetadataInterface
         return $this->namespace;
     }
 
-    public function mapId(array $mapping, ClassMetadata $inherited = null)
+    public function mapId(array $mapping, self $inherited = null)
     {
         if (isset($mapping['id']) && $mapping['id'] === true) {
             $mapping['type'] = 'string';
@@ -817,21 +816,21 @@ class ClassMetadata implements ClassMetadataInterface
         $this->validateAndCompleteFieldMapping($mapping, $inherited, false, false);
     }
 
-    public function mapNode(array $mapping, ClassMetadata $inherited = null)
+    public function mapNode(array $mapping, self $inherited = null)
     {
         $mapping['type'] = 'node';
         $this->validateAndCompleteFieldMapping($mapping, $inherited, false);
         $this->node = $mapping['fieldName'];
     }
 
-    public function mapNodename(array $mapping, ClassMetadata $inherited = null)
+    public function mapNodename(array $mapping, self $inherited = null)
     {
         $mapping['type'] = 'nodename';
         $this->validateAndCompleteFieldMapping($mapping, $inherited, false, false);
         $this->nodename = $mapping['fieldName'];
     }
 
-    public function mapParentDocument(array $mapping, ClassMetadata $inherited = null)
+    public function mapParentDocument(array $mapping, self $inherited = null)
     {
         if (empty($mapping['cascade'])) {
             $mapping['cascade'] = 0;
@@ -841,7 +840,7 @@ class ClassMetadata implements ClassMetadataInterface
         $this->parentMapping = $mapping['fieldName'];
     }
 
-    public function mapChild(array $mapping, ClassMetadata $inherited = null)
+    public function mapChild(array $mapping, self $inherited = null)
     {
         if (empty($mapping['cascade'])) {
             $mapping['cascade'] = 0;
@@ -854,7 +853,7 @@ class ClassMetadata implements ClassMetadataInterface
         $this->childMappings[$mapping['fieldName']] = $mapping['fieldName'];
     }
 
-    public function mapChildren(array $mapping, ClassMetadata $inherited = null)
+    public function mapChildren(array $mapping, self $inherited = null)
     {
         if (empty($mapping['cascade'])) {
             $mapping['cascade'] = 0;
@@ -873,7 +872,7 @@ class ClassMetadata implements ClassMetadataInterface
         $this->childrenMappings[$mapping['fieldName']] = $mapping['fieldName'];
     }
 
-    public function mapReferrers(array $mapping, ClassMetadata $inherited = null)
+    public function mapReferrers(array $mapping, self $inherited = null)
     {
         if (empty($mapping['referencedBy'])) {
             throw MappingException::referrerWithoutReferencedBy($this->name, $mapping['fieldName']);
@@ -896,9 +895,9 @@ class ClassMetadata implements ClassMetadataInterface
         $this->referrersMappings[$mapping['fieldName']] = $mapping['fieldName'];
     }
 
-    public function mapMixedReferrers(array $mapping, ClassMetadata $inherited = null)
+    public function mapMixedReferrers(array $mapping, self $inherited = null)
     {
-        if (!(array_key_exists('referenceType', $mapping) && in_array($mapping['referenceType'], array(null, "weak", "hard")))) {
+        if (!(array_key_exists('referenceType', $mapping) && in_array($mapping['referenceType'], [null, 'weak', 'hard']))) {
             throw new MappingException(sprintf(
                 'You have to specify a "referenceType" for the "%s" mapping which must be null, "weak" or "hard": %s',
                 $this->name,
@@ -921,28 +920,28 @@ class ClassMetadata implements ClassMetadataInterface
         $this->mixedReferrersMappings[$mapping['fieldName']] = $mapping['fieldName'];
     }
 
-    public function mapLocale(array $mapping, ClassMetadata $inherited = null)
+    public function mapLocale(array $mapping, self $inherited = null)
     {
         $mapping['type'] = 'locale';
         $mapping = $this->validateAndCompleteFieldMapping($mapping, $inherited, false, false);
         $this->localeMapping = $mapping['fieldName'];
     }
 
-    public function mapDepth(array $mapping, ClassMetadata $inherited = null)
+    public function mapDepth(array $mapping, self $inherited = null)
     {
         $mapping['type'] = 'depth';
         $mapping = $this->validateAndCompleteFieldMapping($mapping, $inherited, false, false);
         $this->depthMapping = $mapping['fieldName'];
     }
 
-    public function mapVersionName(array $mapping, ClassMetadata $inherited = null)
+    public function mapVersionName(array $mapping, self $inherited = null)
     {
         $mapping['type'] = 'versionname';
         $mapping = $this->validateAndCompleteFieldMapping($mapping, $inherited, false, false);
         $this->versionNameField = $mapping['fieldName'];
     }
 
-    public function mapVersionCreated(array $mapping, ClassMetadata $inherited = null)
+    public function mapVersionCreated(array $mapping, self $inherited = null)
     {
         $mapping['type'] = 'versioncreated';
         $mapping = $this->validateAndCompleteFieldMapping($mapping, $inherited, false, false);
@@ -962,11 +961,11 @@ class ClassMetadata implements ClassMetadataInterface
      *                                  except for child where this is name. referrers
      *                                  use false to not set anything.
      *
-     * @return mixed
-     *
      * @throws MappingException
+     *
+     * @return mixed
      */
-    protected function validateAndCompleteFieldMapping(array $mapping, ClassMetadata $inherited = null, $isField = true, $phpcrLabel = 'property')
+    protected function validateAndCompleteFieldMapping(array $mapping, self $inherited = null, $isField = true, $phpcrLabel = 'property')
     {
         if ($inherited) {
             if (!isset($mapping['inherited'])) {
@@ -1045,7 +1044,7 @@ class ClassMetadata implements ClassMetadataInterface
         return $mapping;
     }
 
-    protected function validateAndCompleteAssociationMapping($mapping, ClassMetadata $inherited = null, $phpcrLabel = 'property')
+    protected function validateAndCompleteAssociationMapping($mapping, self $inherited = null, $phpcrLabel = 'property')
     {
         $mapping = $this->validateAndCompleteFieldMapping($mapping, $inherited, false, $phpcrLabel);
         if ($inherited) {
@@ -1058,7 +1057,7 @@ class ClassMetadata implements ClassMetadataInterface
         }
         if (empty($mapping['strategy'])) {
             $mapping['strategy'] = 'weak';
-        } elseif (!in_array($mapping['strategy'], array(null, 'weak', 'hard', 'path'))) {
+        } elseif (!in_array($mapping['strategy'], [null, 'weak', 'hard', 'path'])) {
             throw new MappingException(sprintf(
                 'The attribute "strategy" for the "%s" association has to be either a null, "weak", "hard" or "path": "%s"',
                 $this->name,
@@ -1083,7 +1082,7 @@ class ClassMetadata implements ClassMetadataInterface
         // associative array fields need a separate property to store the keys.
         // make sure that generated or specified name does not collide with an
         // existing mapping.
-        $assocFields = array();
+        $assocFields = [];
         foreach ($this->fieldMappings as $fieldName) {
             $mapping = $this->mappings[$fieldName];
             if (empty($mapping['assoc'])) {
@@ -1147,7 +1146,7 @@ class ClassMetadata implements ClassMetadataInterface
                     ));
                 }
                 $reflection = new ReflectionClass($mapping['referringDocument']);
-                if (! $reflection->hasProperty($mapping['referencedBy'])) {
+                if (!$reflection->hasProperty($mapping['referencedBy'])) {
                     throw new MappingException(sprintf(
                         'Invalid referrer mapping on document "%s" for field "%s": The referringDocument "%s" has no property "%s"',
                         $this->name,
@@ -1192,14 +1191,14 @@ class ClassMetadata implements ClassMetadataInterface
         ));
     }
 
-    public function mapManyToOne($mapping, ClassMetadata $inherited = null)
+    public function mapManyToOne($mapping, self $inherited = null)
     {
         $mapping['type'] = self::MANY_TO_ONE;
         $mapping = $this->validateAndCompleteAssociationMapping($mapping, $inherited);
         $this->referenceMappings[$mapping['fieldName']] = $mapping['fieldName'];
     }
 
-    public function mapManyToMany($mapping, ClassMetadata $inherited = null)
+    public function mapManyToMany($mapping, self $inherited = null)
     {
         $mapping['type'] = self::MANY_TO_MANY;
         $mapping = $this->validateAndCompleteAssociationMapping($mapping, $inherited);
@@ -1214,13 +1213,13 @@ class ClassMetadata implements ClassMetadataInterface
     protected function setIdGenerator($generator)
     {
         if (is_string($generator)) {
-            $generator = constant('Doctrine\ODM\PHPCR\Mapping\ClassMetadata::GENERATOR_TYPE_' . strtoupper($generator));
+            $generator = constant('Doctrine\ODM\PHPCR\Mapping\ClassMetadata::GENERATOR_TYPE_'.strtoupper($generator));
         }
         $this->idGenerator = $generator;
     }
 
     /**
-     * Sets the translator strategy key
+     * Sets the translator strategy key.
      */
     public function setTranslator($translator)
     {
@@ -1228,7 +1227,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Set the mapped parent classes
+     * Set the mapped parent classes.
      *
      * @param array $parentClasses
      */
@@ -1238,7 +1237,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Return the mapped parent classes
+     * Return the mapped parent classes.
      *
      * @return array of mapped class FQNs
      */
@@ -1292,7 +1291,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * Checks whether the class will generate an id via the repository.
      *
-     * @return boolean TRUE if the class uses the Repository generator, FALSE otherwise.
+     * @return bool TRUE if the class uses the Repository generator, FALSE otherwise.
      */
     public function isIdGeneratorRepository()
     {
@@ -1302,7 +1301,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * Checks whether the class uses no id generator.
      *
-     * @return boolean TRUE if the class does not use any id generator, FALSE otherwise.
+     * @return bool TRUE if the class does not use any id generator, FALSE otherwise.
      */
     public function isIdGeneratorNone()
     {
@@ -1310,7 +1309,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getName()
     {
@@ -1318,11 +1317,11 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getIdentifier()
     {
-        return array($this->identifier);
+        return [$this->identifier];
     }
 
     /**
@@ -1335,11 +1334,11 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function getIdentifierFieldNames()
     {
-        return array($this->identifier);
+        return [$this->identifier];
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getReflectionClass()
     {
@@ -1347,7 +1346,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isIdentifier($fieldName)
     {
@@ -1355,13 +1354,14 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function hasField($fieldName)
     {
         if (null === $fieldName) {
             return false;
         }
+
         return in_array($fieldName, $this->fieldMappings)
             || isset($this->inheritedFields[$fieldName])
             || $this->identifier === $fieldName
@@ -1370,28 +1370,26 @@ class ClassMetadata implements ClassMetadataInterface
             || $this->node === $fieldName
             || $this->nodename === $fieldName
             || $this->versionNameField === $fieldName
-            || $this->versionCreatedField === $fieldName
-        ;
+            || $this->versionCreatedField === $fieldName;
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function hasAssociation($fieldName)
     {
         return isset($this->mappings[$fieldName])
-            && in_array($this->mappings[$fieldName]['type'], array(self::MANY_TO_ONE, self::MANY_TO_MANY, 'referrers', 'mixedreferrers', 'children', 'child', 'parent'))
-        ;
+            && in_array($this->mappings[$fieldName]['type'], [self::MANY_TO_ONE, self::MANY_TO_MANY, 'referrers', 'mixedreferrers', 'children', 'child', 'parent']);
     }
 
     /**
-     * @return array the association mapping with the field of this name
-     *
      * @throws MappingException if the class has no mapping field with this name
+     *
+     * @return array the association mapping with the field of this name
      */
     public function getAssociation($fieldName)
     {
-        if (! $this->hasAssociation($fieldName)) {
+        if (!$this->hasAssociation($fieldName)) {
             throw MappingException::associationNotFound($this->name, $fieldName);
         }
 
@@ -1399,30 +1397,28 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isSingleValuedAssociation($fieldName)
     {
         return isset($this->childMappings[$fieldName])
             || $fieldName === $this->parentMapping
-            || isset($this->referenceMappings[$fieldName]) && self::MANY_TO_ONE === $this->mappings[$fieldName]['type']
-        ;
+            || isset($this->referenceMappings[$fieldName]) && self::MANY_TO_ONE === $this->mappings[$fieldName]['type'];
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isCollectionValuedAssociation($fieldName)
     {
         return isset($this->referenceMappings[$fieldName]) && self::MANY_TO_MANY === $this->mappings[$fieldName]['type']
             || isset($this->referrersMappings[$fieldName])
             || isset($this->mixedReferrersMappings[$fieldName])
-            || isset($this->childrenMappings[$fieldName])
-        ;
+            || isset($this->childrenMappings[$fieldName]);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getFieldNames()
     {
@@ -1456,7 +1452,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAssociationNames()
     {
@@ -1475,7 +1471,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTypeOfField($fieldName)
     {
@@ -1484,7 +1480,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAssociationTargetClass($fieldName)
     {
@@ -1500,7 +1496,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAssociationMappedByTargetField($assocName)
     {
@@ -1512,7 +1508,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isAssociationInverseSide($assocName)
     {
@@ -1526,7 +1522,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * Checks whether a mapped field is inherited from an entity superclass.
      *
-     * @return boolean string class name if the field is inherited, FALSE otherwise.
+     * @return bool string class name if the field is inherited, FALSE otherwise.
      */
     public function isInheritedField($fieldName)
     {
@@ -1536,9 +1532,9 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * Check if the field is nullable or not.
      *
-     * @param string $fieldName  The field name
+     * @param string $fieldName The field name
      *
-     * @return boolean TRUE if the field is nullable, FALSE otherwise.
+     * @return bool TRUE if the field is nullable, FALSE otherwise.
      */
     public function isNullable($fieldName)
     {
@@ -1560,7 +1556,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @param array $mapping The mapping information.
      */
-    public function mapField(array $mapping, ClassMetadata $inherited = null)
+    public function mapField(array $mapping, self $inherited = null)
     {
         $parentMapping = isset($mapping['fieldName']) && isset($this->mappings[$mapping['fieldName']])
             ? $this->mappings[$mapping['fieldName']] : null;
@@ -1647,7 +1643,7 @@ class ClassMetadata implements ClassMetadataInterface
     public function __sleep()
     {
         // This metadata is always serialized/cached.
-        $serialized = array(
+        $serialized = [
             'nodeType',
             'identifier',
             'name',
@@ -1659,7 +1655,7 @@ class ClassMetadata implements ClassMetadataInterface
             'mixedReferrersMappings',
             'childrenMappings',
             'childMappings',
-        );
+        ];
 
         if ($this->customRepositoryClassName) {
             $serialized[] = 'customRepositoryClassName';
@@ -1795,9 +1791,9 @@ class ClassMetadata implements ClassMetadataInterface
     public function getIdentifierValues($document)
     {
         try {
-            return array($this->identifier => $this->getIdentifierValue($document));
+            return [$this->identifier => $this->getIdentifierValue($document)];
         } catch (PHPCRException $e) {
-            return array();
+            return [];
         }
     }
 
@@ -1820,15 +1816,13 @@ class ClassMetadata implements ClassMetadataInterface
      * @param string $field    the name of the field
      *
      * @return mixed|null the value of this field for the document or null if
-     *      not found
+     *                    not found
      */
     public function getFieldValue($document, $field)
     {
         if (isset($this->reflFields[$field])) {
             return $this->reflFields[$field]->getValue($document);
         }
-
-        return null;
     }
 
     /**
@@ -1837,9 +1831,9 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @param string $fieldName The field name.
      *
-     * @return array The field mapping.
-     *
      * @throws MappingException
+     *
+     * @return array The field mapping.
      */
     public function getFieldMapping($fieldName)
     {
@@ -1862,7 +1856,7 @@ class ClassMetadata implements ClassMetadataInterface
     {
         foreach ($this->lifecycleCallbacks[$lifecycleEvent] as $callback) {
             if ($arguments !== null) {
-                call_user_func_array(array($document, $callback), $arguments);
+                call_user_func_array([$document, $callback], $arguments);
             } else {
                 $document->$callback();
             }
@@ -1879,7 +1873,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @param string $fieldName
      *
-     * @return boolean True if $fieldName is mapped as the uuid, false otherwise.
+     * @return bool True if $fieldName is mapped as the uuid, false otherwise.
      */
     public function isUuid($fieldName)
     {
@@ -1887,13 +1881,14 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * @param   string $className
-     * @return  string
+     * @param string $className
+     *
+     * @return string
      */
     public function fullyQualifiedClassName($className)
     {
         if ($className !== null && strpos($className, '\\') === false && strlen($this->namespace) > 0) {
-            return $this->namespace . '\\' . $className;
+            return $this->namespace.'\\'.$className;
         }
 
         return $className;

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -20,22 +20,24 @@
 namespace Doctrine\ODM\PHPCR\Mapping;
 
 use Doctrine\Common\EventManager;
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\ODM\PHPCR\DocumentManagerInterface;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
-use Doctrine\Common\Persistence\Mapping\ReflectionService;
-use Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory;
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\Mapping\ReflectionService;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\ODM\PHPCR\Event;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the
  * metadata mapping information of a class which describes how a class should be mapped
  * to a document database.
-
+ *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  * @author      Lukas Kahwe Smith <smith@pooteeweet.org>
  */
@@ -89,6 +91,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if ($metadata) {
             return $metadata;
         }
+
         throw MappingException::classNotMapped($className);
     }
 
@@ -102,6 +105,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if (class_exists($className)) {
             return parent::loadMetadata($className);
         }
+
         throw MappingException::classNotFound($className);
     }
 
@@ -118,7 +122,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      */
     protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
     {
-        return $this->dm->getConfiguration()->getDocumentNamespace($namespaceAlias) . '\\' . $simpleClassName;
+        return $this->dm->getConfiguration()->getDocumentNamespace($namespaceAlias).'\\'.$simpleClassName;
     }
 
     /**
@@ -246,6 +250,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      *
      * @param ClassMetadata $class
      * @param $parent
+     *
      * @throws MappingException
      */
     protected function validateRuntimeMetadata($class, $parent)
@@ -265,6 +270,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         // verify inheritance
         // TODO
     }
+
     /**
      * {@inheritdoc}
      */
@@ -300,7 +306,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function isEntity(ClassMetadataInterface $class)
     {

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AnnotationDriver.php
@@ -19,22 +19,24 @@
 
 namespace Doctrine\ODM\PHPCR\Mapping\Driver;
 
-use Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver as AbstractAnnotationDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver as AbstractAnnotationDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ODM\PHPCR\Event;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as ODM;
-use Doctrine\ODM\PHPCR\Mapping\MappingException;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\Annotations\Document;
 use Doctrine\ODM\PHPCR\Mapping\Annotations\MappedSuperclass;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\MappingException;
 
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.org
  * @since       1.0
+ *
  * @author      Jordi Boggiano <j.boggiano@seld.be>
  * @author      Pascal Helfenstein <nicam@nicam.ch>
  * @author      Daniel Barsotti <daniel.barsotti@liip.ch>
@@ -47,10 +49,10 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
      *
      * Document annotation classes, ordered by precedence.
      */
-    protected $entityAnnotationClasses = array(
-        Document::class => 0,
+    protected $entityAnnotationClasses = [
+        Document::class         => 0,
         MappedSuperclass::class => 1,
-    );
+    ];
 
     /**
      * {@inheritdoc}
@@ -61,7 +63,7 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
     {
         $reflClass = $metadata->getReflectionClass();
 
-        $documentAnnots = array();
+        $documentAnnots = [];
         foreach ($this->reader->getClassAnnotations($reflClass) as $annot) {
             foreach ($this->entityAnnotationClasses as $annotClass => $i) {
                 if ($annot instanceof $annotClass) {
@@ -113,7 +115,7 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
             $metadata->setTranslator($documentAnnot->translator);
         }
 
-        if (array() !== $documentAnnot->childClasses) {
+        if ([] !== $documentAnnot->childClasses) {
             $metadata->setChildClasses($documentAnnot->childClasses);
         }
 
@@ -126,7 +128,7 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
                 continue;
             }
 
-            $mapping = array();
+            $mapping = [];
             $mapping['fieldName'] = $property->getName();
 
             foreach ($this->reader->getPropertyAnnotations($property) as $fieldAnnot) {
@@ -215,13 +217,13 @@ class AnnotationDriver extends AbstractAnnotationDriver implements MappingDriver
      *
      * @param array $cascadeList
      *
-     * @return integer a bitmask of cascade options.
+     * @return int a bitmask of cascade options.
      */
     private function getCascadeMode(array $cascadeList)
     {
         $cascade = 0;
         foreach ($cascadeList as $cascadeMode) {
-            $constantName = 'Doctrine\ODM\PHPCR\Mapping\ClassMetadata::CASCADE_' . strtoupper($cascadeMode);
+            $constantName = 'Doctrine\ODM\PHPCR\Mapping\ClassMetadata::CASCADE_'.strtoupper($cascadeMode);
             if (!defined($constantName)) {
                 throw new MappingException("Cascade mode '$cascadeMode' not supported.");
             }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/BuiltinDocumentsDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/BuiltinDocumentsDriver.php
@@ -8,17 +8,19 @@ use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 
 /**
  * The BuiltinDocumentsDriver is used internally to make sure
- * that the mapping for the built-in documents can be loaded
+ * that the mapping for the built-in documents can be loaded.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.org
  * @since       1.0
+ *
  * @author      Uwe Jäger <uwej711e@googlemail.com>
  */
 class BuiltinDocumentsDriver implements MappingDriver
 {
     /**
-     * namespace of built-in documents
+     * namespace of built-in documents.
      */
     const NAME_SPACE = 'Doctrine\ODM\PHPCR\Document';
 
@@ -33,7 +35,7 @@ class BuiltinDocumentsDriver implements MappingDriver
     private $builtinDriver;
 
     /**
-     * Create with a driver to wrap
+     * Create with a driver to wrap.
      *
      * @param MappingDriver $nestedDriver
      */
@@ -42,7 +44,7 @@ class BuiltinDocumentsDriver implements MappingDriver
         $this->wrappedDriver = $wrappedDriver;
 
         $reader = new AnnotationReader();
-        $this->builtinDriver = new AnnotationDriver($reader, array(realpath(__DIR__.'/../../Document')));
+        $this->builtinDriver = new AnnotationDriver($reader, [realpath(__DIR__.'/../../Document')]);
     }
 
     /**
@@ -60,7 +62,7 @@ class BuiltinDocumentsDriver implements MappingDriver
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAllClassNames()
     {
@@ -71,7 +73,7 @@ class BuiltinDocumentsDriver implements MappingDriver
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isTransient($className)
     {

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/XmlDriver.php
@@ -19,19 +19,21 @@
 
 namespace Doctrine\ODM\PHPCR\Mapping\Driver;
 
-use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\Common\Persistence\Mapping\MappingException as DoctrineMappingException;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
-use Doctrine\Common\Persistence\Mapping\MappingException as DoctrineMappingException;
 use SimpleXmlElement;
 
 /**
  * XmlDriver is a metadata driver that enables mapping through XML files.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.org
  * @since       1.0
+ *
  * @author      Jonathan H. Wage <jonwage@gmail.com>
  * @author      Roman Borschel <roman@code-factory.org>
  */
@@ -86,7 +88,7 @@ class XmlDriver extends FileDriver
         }
 
         if (isset($xmlRoot['is-leaf'])) {
-            if (!in_array($value = $xmlRoot['is-leaf'], array('true', 'false'))) {
+            if (!in_array($value = $xmlRoot['is-leaf'], ['true', 'false'])) {
                 throw new MappingException(sprintf(
                     'Value of is-leaf must be "true" or "false", got "%s" for class "%s"',
                     $value, $className
@@ -96,12 +98,11 @@ class XmlDriver extends FileDriver
             $class->setIsLeaf($value == 'true' ? true : false);
         }
 
-
         if (isset($xmlRoot->mixins)) {
-            $mixins = array();
+            $mixins = [];
             foreach ($xmlRoot->mixins->mixin as $mixin) {
                 $attributes = $mixin->attributes();
-                if (! isset($attributes['type'])) {
+                if (!isset($attributes['type'])) {
                     throw new MappingException('<mixin> missing mandatory type attribute');
                 }
                 $mixins[] = (string) $attributes['type'];
@@ -123,12 +124,12 @@ class XmlDriver extends FileDriver
 
         if (isset($xmlRoot->field)) {
             foreach ($xmlRoot->field as $field) {
-                $mapping = array();
+                $mapping = [];
                 $attributes = $field->attributes();
                 foreach ($attributes as $key => $value) {
                     $mapping[$key] = (string) $value;
                     // convert bool fields
-                    if (in_array($key, array('id', 'multivalue', 'assoc', 'translated', 'nullable'))) {
+                    if (in_array($key, ['id', 'multivalue', 'assoc', 'translated', 'nullable'])) {
                         $mapping[$key] = ('true' === $mapping[$key]) ? true : false;
                     }
                 }
@@ -141,35 +142,35 @@ class XmlDriver extends FileDriver
             }
         }
         if (isset($xmlRoot->id)) {
-            $mapping = array(
+            $mapping = [
                 'fieldName' => (string) $xmlRoot->id->attributes()->name,
-                'id' => true,
-            );
+                'id'        => true,
+            ];
             if (isset($xmlRoot->id->generator) && isset($xmlRoot->id->generator->attributes()->strategy)) {
                 $mapping['strategy'] = (string) $xmlRoot->id->generator->attributes()->strategy;
             }
             $class->mapId($mapping);
         }
         if (isset($xmlRoot->node)) {
-            $class->mapNode(array('fieldName' => (string) $xmlRoot->node->attributes()->name));
+            $class->mapNode(['fieldName' => (string) $xmlRoot->node->attributes()->name]);
         }
         if (isset($xmlRoot->nodename)) {
-            $class->mapNodename(array('fieldName' => (string) $xmlRoot->nodename->attributes()->name));
+            $class->mapNodename(['fieldName' => (string) $xmlRoot->nodename->attributes()->name]);
         }
         if (isset($xmlRoot->{'parent-document'})) {
-            $mapping = array(
+            $mapping = [
                 'fieldName' => (string) $xmlRoot->{'parent-document'}->attributes()->name,
-                'cascade' => (isset($xmlRoot->{'parent-document'}->cascade)) ? $this->getCascadeMode($xmlRoot->{'parent-document'}->cascade) : 0,
-            );
+                'cascade'   => (isset($xmlRoot->{'parent-document'}->cascade)) ? $this->getCascadeMode($xmlRoot->{'parent-document'}->cascade) : 0,
+            ];
             $class->mapParentDocument($mapping);
         }
         if (isset($xmlRoot->child)) {
             foreach ($xmlRoot->child as $child) {
                 $attributes = $child->attributes();
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string) $attributes->name,
-                    'cascade' => (isset($child->cascade)) ? $this->getCascadeMode($child->cascade) : 0,
-                );
+                    'cascade'   => (isset($child->cascade)) ? $this->getCascadeMode($child->cascade) : 0,
+                ];
                 if (isset($attributes['node-name'])) {
                     $mapping['nodeName'] = (string) $attributes->{'node-name'};
                 }
@@ -179,13 +180,13 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot->children)) {
             foreach ($xmlRoot->children as $children) {
                 $attributes = $children->attributes();
-                $mapping = array(
-                    'fieldName' => (string) $attributes->name,
-                    'cascade' => (isset($children->cascade)) ? $this->getCascadeMode($children->cascade) : 0,
-                    'filter' => isset($attributes['filter']) ? (array) $attributes->filter : null,
-                    'fetchDepth' => isset($attributes['fetch-depth']) ? (int) $attributes->{'fetch-depth'} : -1,
+                $mapping = [
+                    'fieldName'          => (string) $attributes->name,
+                    'cascade'            => (isset($children->cascade)) ? $this->getCascadeMode($children->cascade) : 0,
+                    'filter'             => isset($attributes['filter']) ? (array) $attributes->filter : null,
+                    'fetchDepth'         => isset($attributes['fetch-depth']) ? (int) $attributes->{'fetch-depth'} : -1,
                     'ignoreUntranslated' => !empty($attributes['ignore-untranslated']),
-            );
+            ];
                 $class->mapChildren($mapping);
             }
         }
@@ -207,57 +208,57 @@ class XmlDriver extends FileDriver
         }
 
         if (isset($xmlRoot->locale)) {
-            $class->mapLocale(array('fieldName' => (string) $xmlRoot->locale->attributes()->name));
+            $class->mapLocale(['fieldName' => (string) $xmlRoot->locale->attributes()->name]);
         }
 
         if (isset($xmlRoot->depth)) {
-            $class->mapDepth(array('fieldName' => (string) $xmlRoot->depth->attributes()->name));
+            $class->mapDepth(['fieldName' => (string) $xmlRoot->depth->attributes()->name]);
         }
 
         if (isset($xmlRoot->{'mixed-referrers'})) {
             foreach ($xmlRoot->{'mixed-referrers'} as $mixedReferrers) {
                 $attributes = $mixedReferrers->attributes();
-                $mapping = array(
-                    'fieldName' => (string) $attributes->name,
+                $mapping = [
+                    'fieldName'     => (string) $attributes->name,
                     'referenceType' => isset($attributes['reference-type']) ? strtolower((string) $attributes->{'reference-type'}) : null,
-                );
+                ];
                 $class->mapMixedReferrers($mapping);
             }
         }
         if (isset($xmlRoot->referrers)) {
             foreach ($xmlRoot->referrers as $referrers) {
                 $attributes = $referrers->attributes();
-                if (! isset($attributes['referenced-by'])) {
-                    throw new MappingException("$className is missing the referenced-by attribute for the referrer field " . $attributes->name);
+                if (!isset($attributes['referenced-by'])) {
+                    throw new MappingException("$className is missing the referenced-by attribute for the referrer field ".$attributes->name);
                 }
-                if (! isset($attributes['referring-document'])) {
-                    throw new MappingException("$className is missing the referring-document attribute for the referrer field " . $attributes->name);
+                if (!isset($attributes['referring-document'])) {
+                    throw new MappingException("$className is missing the referring-document attribute for the referrer field ".$attributes->name);
                 }
                 // referenceType is determined from the referencedBy field of referringDocument
-                $mapping = array(
-                    'fieldName' => (string) $attributes->name,
-                    'cascade' => (isset($referrers->cascade)) ? $this->getCascadeMode($referrers->cascade) : 0,
-                    'referencedBy' => (string) $attributes->{'referenced-by'},
+                $mapping = [
+                    'fieldName'         => (string) $attributes->name,
+                    'cascade'           => (isset($referrers->cascade)) ? $this->getCascadeMode($referrers->cascade) : 0,
+                    'referencedBy'      => (string) $attributes->{'referenced-by'},
                     'referringDocument' => (string) $attributes->{'referring-document'},
-                );
+                ];
                 $class->mapReferrers($mapping);
             }
         }
         if (isset($xmlRoot->{'version-name'})) {
-            $class->mapVersionName(array('fieldName' => (string) $xmlRoot->{'version-name'}->attributes()->name));
+            $class->mapVersionName(['fieldName' => (string) $xmlRoot->{'version-name'}->attributes()->name]);
         }
         if (isset($xmlRoot->{'version-created'})) {
-            $class->mapVersionCreated(array('fieldName' => (string) $xmlRoot->{'version-created'}->attributes()->name));
+            $class->mapVersionCreated(['fieldName' => (string) $xmlRoot->{'version-created'}->attributes()->name]);
         }
 
         if (isset($xmlRoot->{'lifecycle-callbacks'})) {
             foreach ($xmlRoot->{'lifecycle-callbacks'}->{'lifecycle-callback'} as $lifecycleCallback) {
-                $class->addLifecycleCallback((string) $lifecycleCallback['method'], constant('Doctrine\ODM\PHPCR\Event::' . (string) $lifecycleCallback['type']));
+                $class->addLifecycleCallback((string) $lifecycleCallback['method'], constant('Doctrine\ODM\PHPCR\Event::'.(string) $lifecycleCallback['type']));
             }
         }
 
         if (isset($xmlRoot->uuid)) {
-            $mapping = array();
+            $mapping = [];
             $attributes = $xmlRoot->uuid->attributes();
 
             foreach ($attributes as $key => $value) {
@@ -274,7 +275,7 @@ class XmlDriver extends FileDriver
         }
 
         if (isset($xmlRoot->{'child-class'})) {
-            $childClasses = array();
+            $childClasses = [];
             foreach ($xmlRoot->{'child-class'} as $requiredClass) {
                 $childClasses[] = (string) $requiredClass['name'];
             }
@@ -292,7 +293,7 @@ class XmlDriver extends FileDriver
     private function addReferenceMapping(PhpcrClassMetadata $class, $reference, $type)
     {
         $attributes = (array) $reference->attributes();
-        $mapping = $attributes["@attributes"];
+        $mapping = $attributes['@attributes'];
         $mapping['strategy'] = isset($mapping['strategy']) ? strtolower($mapping['strategy']) : null;
         $mapping['targetDocument'] = $mapping['target-document'] ?? null;
         unset($mapping['target-document']);
@@ -309,12 +310,12 @@ class XmlDriver extends FileDriver
      */
     protected function loadMappingFile($file)
     {
-        $result = array();
+        $result = [];
         $entity = libxml_disable_entity_loader(true);
         $xmlElement = simplexml_load_string(file_get_contents($file));
         libxml_disable_entity_loader($entity);
 
-        foreach (array('document', 'mapped-superclass') as $type) {
+        foreach (['document', 'mapped-superclass'] as $type) {
             if (isset($xmlElement->$type)) {
                 foreach ($xmlElement->$type as $documentElement) {
                     $className = (string) $documentElement['name'];
@@ -331,7 +332,7 @@ class XmlDriver extends FileDriver
      *
      * @param SimpleXMLElement $cascadeElement cascade element.
      *
-     * @return integer a bitmask of cascade options.
+     * @return int a bitmask of cascade options.
      */
     private function getCascadeMode(SimpleXMLElement $cascadeElement)
     {
@@ -343,7 +344,7 @@ class XmlDriver extends FileDriver
             // and we want to make sure that this driver doesn't need to know
             // anything about the supported cascading actions
             $cascadeMode = str_replace('cascade-', '', $action->getName());
-            $constantName = 'Doctrine\ODM\PHPCR\Mapping\ClassMetadata::CASCADE_' . strtoupper($cascadeMode);
+            $constantName = 'Doctrine\ODM\PHPCR\Mapping\ClassMetadata::CASCADE_'.strtoupper($cascadeMode);
             if (!defined($constantName)) {
                 throw new MappingException("Cascade mode '$cascadeMode' not supported.");
             }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
@@ -19,20 +19,22 @@
 
 namespace Doctrine\ODM\PHPCR\Mapping\Driver;
 
-use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\Common\Persistence\Mapping\MappingException as DoctrineMappingException;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
-use Doctrine\Common\Persistence\Mapping\MappingException as DoctrineMappingException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
  * The YamlDriver reads the mapping metadata from yaml schema files.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.org
  * @since       1.0
+ *
  * @author      Jonathan H. Wage <jonwage@gmail.com>
  * @author      Roman Borschel <roman@code-factory.org>
  */
@@ -53,7 +55,7 @@ class YamlDriver extends FileDriver
      */
     public function loadMetadataForClass($className, ClassMetadata $class)
     {
-        /** @var PhpcrClassMetadata $class */
+        /* @var PhpcrClassMetadata $class */
         try {
             $element = $this->getElement($className);
         } catch (DoctrineMappingException $e) {
@@ -87,7 +89,7 @@ class YamlDriver extends FileDriver
         }
 
         if (isset($element['mixins'])) {
-            $mixins = array();
+            $mixins = [];
             foreach ($element['mixins'] as $mixin) {
                 $mixins[] = $mixin;
             }
@@ -110,7 +112,7 @@ class YamlDriver extends FileDriver
             foreach ($element['fields'] as $fieldName => $mapping) {
                 if (is_string($mapping)) {
                     $type = $mapping;
-                    $mapping = array();
+                    $mapping = [];
                     $mapping['type'] = $type;
                 }
                 if (!isset($mapping['fieldName'])) {
@@ -121,38 +123,38 @@ class YamlDriver extends FileDriver
         }
 
         if (isset($element['uuid'])) {
-            $mapping = array(
+            $mapping = [
                 'fieldName' => $element['uuid'],
                 'uuid'      => true,
-            );
+            ];
             $class->mapField($mapping);
         }
         if (isset($element['id'])) {
             if (is_array($element['id'])) {
                 if (!isset($element['id']['fieldName'])) {
-                    throw new MappingException("Missing fieldName property for id field");
+                    throw new MappingException('Missing fieldName property for id field');
                 }
                 $fieldName = $element['id']['fieldName'];
             } else {
                 $fieldName = $element['id'];
             }
-            $mapping = array('fieldName' => $fieldName, 'id' => true);
+            $mapping = ['fieldName' => $fieldName, 'id' => true];
             if (isset($element['id']['generator']['strategy'])) {
                 $mapping['strategy'] = $element['id']['generator']['strategy'];
             }
             $class->mapId($mapping);
         }
         if (isset($element['node'])) {
-            $class->mapNode(array('fieldName' => $element['node']));
+            $class->mapNode(['fieldName' => $element['node']]);
         }
         if (isset($element['nodename'])) {
-            $class->mapNodename(array('fieldName' => $element['nodename']));
+            $class->mapNodename(['fieldName' => $element['nodename']]);
         }
         if (isset($element['parentdocument'])) {
-            $mapping = array(
+            $mapping = [
                 'fieldName' => $element['parentdocument'],
-                'cascade' => (isset($element['cascade'])) ? $this->getCascadeMode($element['cascade']) : 0,
-            );
+                'cascade'   => (isset($element['cascade'])) ? $this->getCascadeMode($element['cascade']) : 0,
+            ];
 
             $class->mapParentDocument($mapping);
         }
@@ -160,7 +162,7 @@ class YamlDriver extends FileDriver
             foreach ($element['child'] as $fieldName => $mapping) {
                 if (is_string($mapping)) {
                     $name = $mapping;
-                    $mapping = array();
+                    $mapping = [];
                     $mapping['nodeName'] = $name;
                 }
                 if (!isset($mapping['fieldName'])) {
@@ -175,7 +177,7 @@ class YamlDriver extends FileDriver
                 // TODO should we really support this syntax?
                 if (is_string($mapping)) {
                     $filter = $mapping;
-                    $mapping = array();
+                    $mapping = [];
                     $mapping['filter'] = $filter;
                 }
                 if (!isset($mapping['fieldName'])) {
@@ -208,50 +210,50 @@ class YamlDriver extends FileDriver
         }
 
         if (isset($element['locale'])) {
-            $class->mapLocale(array('fieldName' => $element['locale']));
+            $class->mapLocale(['fieldName' => $element['locale']]);
         }
 
         if (isset($element['depth'])) {
-            $class->mapDepth(array('fieldName' => $element['depth']));
+            $class->mapDepth(['fieldName' => $element['depth']]);
         }
 
         if (isset($element['mixedReferrers'])) {
             foreach ($element['mixedReferrers'] as $name => $attributes) {
-                $mapping = array(
-                    'fieldName' => $name,
+                $mapping = [
+                    'fieldName'     => $name,
                     'referenceType' => $attributes['referenceType'] ?? null,
-                );
+                ];
                 $class->mapMixedReferrers($mapping);
             }
         }
         if (isset($element['referrers'])) {
             foreach ($element['referrers'] as $name => $attributes) {
-                if (! isset($attributes['referencedBy'])) {
+                if (!isset($attributes['referencedBy'])) {
                     throw new MappingException("$className is missing the referencedBy attribute for the referrer field $name");
                 }
-                if (! isset($attributes['referringDocument'])) {
+                if (!isset($attributes['referringDocument'])) {
                     throw new MappingException("$className is missing the referringDocument attribute for the referrer field $name");
                 }
-                $mapping = array(
-                    'fieldName' => $name,
-                    'referencedBy' => $attributes['referencedBy'],
+                $mapping = [
+                    'fieldName'         => $name,
+                    'referencedBy'      => $attributes['referencedBy'],
                     'referringDocument' => $attributes['referringDocument'],
-                    'cascade' => (isset($attributes['cascade'])) ? $this->getCascadeMode($attributes['cascade']) : 0,
-                );
+                    'cascade'           => (isset($attributes['cascade'])) ? $this->getCascadeMode($attributes['cascade']) : 0,
+                ];
                 $class->mapReferrers($mapping);
             }
         }
         if (isset($element['versionName'])) {
-            $class->mapVersionName(array('fieldName' => $element['versionName']));
+            $class->mapVersionName(['fieldName' => $element['versionName']]);
         }
         if (isset($element['versionCreated'])) {
-            $class->mapVersionCreated(array('fieldName' => $element['versionCreated']));
+            $class->mapVersionCreated(['fieldName' => $element['versionCreated']]);
         }
 
         if (isset($element['lifecycleCallbacks'])) {
             foreach ($element['lifecycleCallbacks'] as $type => $methods) {
                 foreach ($methods as $method) {
-                    $class->addLifecycleCallback($method, constant('Doctrine\ODM\PHPCR\Event::' . $type));
+                    $class->addLifecycleCallback($method, constant('Doctrine\ODM\PHPCR\Event::'.$type));
                 }
             }
         }
@@ -270,12 +272,12 @@ class YamlDriver extends FileDriver
     private function addMappingFromReference(ClassMetadata $class, $fieldName, $reference, $type)
     {
         /** @var PhpcrClassMetadata $class */
-        $mapping = array_merge(array('fieldName' => $fieldName), $reference);
+        $mapping = array_merge(['fieldName' => $fieldName], $reference);
 
         $mapping['cascade'] = (isset($reference['cascade'])) ? $this->getCascadeMode($reference['cascade']) : 0;
         $mapping['name'] = $reference['name'] ?? null;
 
-        if (! isset($mapping['targetDocument'])) {
+        if (!isset($mapping['targetDocument'])) {
             $mapping['targetDocument'] = null;
         }
 
@@ -294,6 +296,7 @@ class YamlDriver extends FileDriver
         if (!is_file($file)) {
             throw new InvalidArgumentException(sprintf('File "%s" not found', $file));
         }
+
         return Yaml::parse(file_get_contents($file));
     }
 
@@ -302,13 +305,13 @@ class YamlDriver extends FileDriver
      *
      * @param array $cascadeElement The cascade element.
      *
-     * @return integer a bitmask of cascade options.
+     * @return int a bitmask of cascade options.
      */
     private function getCascadeMode(array $cascadeElement)
     {
         $cascade = 0;
         foreach ($cascadeElement as $cascadeMode) {
-            $constantName = 'Doctrine\ODM\PHPCR\Mapping\ClassMetadata::CASCADE_' . strtoupper($cascadeMode);
+            $constantName = 'Doctrine\ODM\PHPCR\Mapping\ClassMetadata::CASCADE_'.strtoupper($cascadeMode);
             if (!defined($constantName)) {
                 throw new MappingException("Cascade mode '$cascadeMode' not supported.");
             }

--- a/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/MappingException.php
@@ -23,11 +23,13 @@ use Doctrine\Common\Persistence\Mapping\MappingException as BaseMappingException
 use Doctrine\ODM\PHPCR\PHPCRExceptionInterface;
 
 /**
- * Mapping exception class
+ * Mapping exception class.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  * @author      Lukas Kahwe Smith <smith@pooteeweet.org>
  */
@@ -160,17 +162,17 @@ class MappingException extends BaseMappingException implements PHPCRExceptionInt
 
     public static function invalidTargetDocumentClass($targetDocument, $sourceDocument, $associationName)
     {
-        return new self("The target-document " . $targetDocument . " cannot be found in '" . $sourceDocument."#".$associationName."'.");
+        return new self('The target-document '.$targetDocument." cannot be found in '".$sourceDocument.'#'.$associationName."'.");
     }
 
     public static function lifecycleCallbackMethodNotFound($className, $methodName)
     {
-        return new self("Document '" . $className . "' has no method '" . $methodName . "' to be registered as lifecycle callback.");
+        return new self("Document '".$className."' has no method '".$methodName."' to be registered as lifecycle callback.");
     }
 
     public static function noTranslatorStrategy($className, $fieldNames)
     {
-        return new self("Document '" .$className."' does not have a translation strategy, but the fields ('".implode('\', \'', $fieldNames)."') have been set as translatable.");
+        return new self("Document '".$className."' does not have a translation strategy, but the fields ('".implode('\', \'', $fieldNames)."') have been set as translatable.");
     }
 
     public static function notReferenceable($className, $fieldName)

--- a/lib/Doctrine/ODM/PHPCR/NodeTypeRegistrator.php
+++ b/lib/Doctrine/ODM/PHPCR/NodeTypeRegistrator.php
@@ -48,8 +48,7 @@ final class NodeTypeRegistrator
 mixin
 - phpcr:class (STRING)
 - phpcr:classparents (STRING) multiple
-CND
-        ;
+CND;
 
         $nodeTypeManager = $session->getWorkspace()->getNodeTypeManager();
         $nodeTypeManager->registerNodeTypesCnd($cnd, true);

--- a/lib/Doctrine/ODM/PHPCR/PHPCRException.php
+++ b/lib/Doctrine/ODM/PHPCR/PHPCRException.php
@@ -31,7 +31,7 @@ class PHPCRException extends \Exception implements PHPCRExceptionInterface
 
     public static function documentManagerClosed()
     {
-        return new self("The DocumentManager is closed.");
+        return new self('The DocumentManager is closed.');
     }
 
     public static function cannotMoveByAssignment($objInfo)

--- a/lib/Doctrine/ODM/PHPCR/PersistentCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/PersistentCollection.php
@@ -19,16 +19,18 @@
 
 namespace Doctrine\ODM\PHPCR;
 
-use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Collections\ArrayCollection;
 use Closure;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 /**
- * Persistent collection class
+ * Persistent collection class.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  */
 abstract class PersistentCollection implements Collection
@@ -45,7 +47,7 @@ abstract class PersistentCollection implements Collection
      * Whether the collection is dirty and needs to be synchronized with the database
      * when the UnitOfWork that manages its persistent state commits.
      *
-     * @var boolean
+     * @var bool
      */
     protected $isDirty = false;
 
@@ -75,7 +77,7 @@ abstract class PersistentCollection implements Collection
     }
 
     /**
-     * Set the collection not dirty
+     * Set the collection not dirty.
      */
     public function takeSnapshot()
     {
@@ -94,7 +96,7 @@ abstract class PersistentCollection implements Collection
         return new ArrayCollection();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function add($element)
     {
         $this->initialize();
@@ -103,7 +105,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->add($element);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function clear()
     {
         $this->initialize();
@@ -111,7 +113,7 @@ abstract class PersistentCollection implements Collection
         $this->collection->clear();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function contains($element)
     {
         $this->initialize();
@@ -119,7 +121,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->contains($element);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function containsKey($key)
     {
         $this->initialize();
@@ -127,7 +129,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->containsKey($key);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function count()
     {
         $this->initialize();
@@ -135,7 +137,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->count();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function current()
     {
         $this->initialize();
@@ -143,7 +145,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->current();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function exists(Closure $p)
     {
         $this->initialize();
@@ -151,7 +153,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->exists($p);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function filter(Closure $p)
     {
         $this->initialize();
@@ -159,7 +161,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->filter($p);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function first()
     {
         $this->initialize();
@@ -167,7 +169,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->first();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function forAll(Closure $p)
     {
         $this->initialize();
@@ -175,7 +177,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->forAll($p);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function get($key)
     {
         $this->initialize();
@@ -183,7 +185,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->get($key);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function getIterator()
     {
         $this->initialize();
@@ -191,7 +193,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->getIterator();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function getKeys()
     {
         $this->initialize();
@@ -199,7 +201,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->getKeys();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function getValues()
     {
         $this->initialize();
@@ -207,7 +209,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->getValues();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function indexOf($element)
     {
         $this->initialize();
@@ -215,7 +217,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->indexOf($element);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function isEmpty()
     {
         $this->initialize();
@@ -223,7 +225,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->isEmpty();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function key()
     {
         $this->initialize();
@@ -231,7 +233,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->key();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function last()
     {
         $this->initialize();
@@ -239,7 +241,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->last();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function map(Closure $func)
     {
         $this->initialize();
@@ -247,7 +249,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->map($func);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function next()
     {
         $this->initialize();
@@ -255,7 +257,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->next();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function offsetExists($offset)
     {
         $this->initialize();
@@ -263,7 +265,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->offsetExists($offset);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function offsetGet($offset)
     {
         $this->initialize();
@@ -271,7 +273,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->offsetGet($offset);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function offsetSet($offset, $value)
     {
         $this->initialize();
@@ -280,7 +282,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->offsetSet($offset, $value);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function offsetUnset($offset)
     {
         $this->initialize();
@@ -289,7 +291,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->offsetUnset($offset);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function partition(Closure $p)
     {
         $this->initialize();
@@ -297,7 +299,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->partition($p);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function remove($key)
     {
         $this->initialize();
@@ -306,7 +308,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->remove($key);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function removeElement($element)
     {
         $this->initialize();
@@ -315,7 +317,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->removeElement($element);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function set($key, $value)
     {
         $this->initialize();
@@ -323,7 +325,7 @@ abstract class PersistentCollection implements Collection
         $this->collection->set($key, $value);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function slice($offset, $length = null)
     {
         $this->initialize();
@@ -331,7 +333,7 @@ abstract class PersistentCollection implements Collection
         return $this->collection->slice($offset, $length);
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function toArray()
     {
         $this->initialize();
@@ -346,11 +348,11 @@ abstract class PersistentCollection implements Collection
      */
     public function __toString()
     {
-        return __CLASS__ . '@' . spl_object_hash($this);
+        return __CLASS__.'@'.spl_object_hash($this);
     }
 
     /**
-     * Refresh the collection form the database, all local changes are lost
+     * Refresh the collection form the database, all local changes are lost.
      */
     public function refresh()
     {
@@ -361,7 +363,7 @@ abstract class PersistentCollection implements Collection
     /**
      * Checks whether this collection has been initialized.
      *
-     * @return boolean
+     * @return bool
      */
     public function isInitialized()
     {
@@ -372,7 +374,7 @@ abstract class PersistentCollection implements Collection
      * Gets a boolean flag indicating whether this collection is dirty which means
      * its state needs to be synchronized with the database.
      *
-     * @return boolean TRUE if the collection is dirty, FALSE otherwise.
+     * @return bool TRUE if the collection is dirty, FALSE otherwise.
      */
     public function isDirty()
     {
@@ -382,7 +384,7 @@ abstract class PersistentCollection implements Collection
     /**
      * Sets a boolean flag, indicating whether this collection is dirty.
      *
-     * @param boolean $dirty Whether the collection should be marked dirty or not.
+     * @param bool $dirty Whether the collection should be marked dirty or not.
      */
     public function setDirty($dirty)
     {
@@ -390,7 +392,7 @@ abstract class PersistentCollection implements Collection
     }
 
     /**
-     * Set the default locale for this collection
+     * Set the default locale for this collection.
      *
      * @param $locale
      */
@@ -400,8 +402,8 @@ abstract class PersistentCollection implements Collection
     }
 
     /**
-     * @param array|Collection $collection          The collection to initialize with
-     * @param bool             $forceOverwrite     If to force the database to be forced to the state of the collection
+     * @param array|Collection $collection     The collection to initialize with
+     * @param bool             $forceOverwrite If to force the database to be forced to the state of the collection
      */
     protected function initializeFromCollection($collection, $forceOverwrite = false)
     {

--- a/lib/Doctrine/ODM/PHPCR/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Proxy/ProxyFactory.php
@@ -19,16 +19,16 @@
 
 namespace Doctrine\ODM\PHPCR\Proxy;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata as BaseClassMetadata;
+use Doctrine\Common\Proxy\AbstractProxyFactory;
+use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
+use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
+use Doctrine\Common\Proxy\Proxy;
+use Doctrine\Common\Proxy\ProxyDefinition;
+use Doctrine\Common\Proxy\ProxyGenerator;
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata as BaseClassMetadata;
-use Doctrine\Common\Util\ClassUtils;
-use Doctrine\Common\Proxy\AbstractProxyFactory;
-use Doctrine\Common\Proxy\ProxyGenerator;
-use Doctrine\Common\Proxy\ProxyDefinition;
-use Doctrine\Common\Proxy\Proxy;
-use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
-use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
 use ReflectionProperty;
 
@@ -61,7 +61,7 @@ class ProxyFactory extends AbstractProxyFactory
      * @param DocumentManagerInterface $documentManager The DocumentManager the new factory works for.
      * @param string                   $proxyDir        The directory to use for the proxy classes. It must exist.
      * @param string                   $proxyNamespace  The namespace to use for the proxy classes.
-     * @param boolean                  $autoGenerate    Whether to automatically generate proxy classes.
+     * @param bool                     $autoGenerate    Whether to automatically generate proxy classes.
      */
     public function __construct(DocumentManagerInterface $documentManager, $proxyDir, $proxyNamespace, $autoGenerate = false)
     {
@@ -72,33 +72,33 @@ class ProxyFactory extends AbstractProxyFactory
         );
 
         $this->documentManager = $documentManager;
-        $this->proxyNamespace  = $proxyNamespace;
+        $this->proxyNamespace = $proxyNamespace;
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function skipClass(BaseClassMetadata $metadata)
     {
-        if (! $metadata instanceof ClassMetadata) {
-            throw new InvalidArgumentException('Did not get the expected type of metadata but ' . get_class($metadata));
+        if (!$metadata instanceof ClassMetadata) {
+            throw new InvalidArgumentException('Did not get the expected type of metadata but '.get_class($metadata));
         }
 
         return $metadata->isMappedSuperclass || $metadata->getReflectionClass()->isAbstract();
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function createProxyDefinition($className)
     {
         $classMetadata = $this->documentManager->getClassMetadata($className);
 
         if ($classMetadata->identifier) {
-            $identifierFields = array($classMetadata->identifier);
+            $identifierFields = [$classMetadata->identifier];
             $reflectionId = $classMetadata->reflFields[$classMetadata->identifier];
         } else {
-            $identifierFields = array();
+            $identifierFields = [];
             $reflectionId = null;
         }
 
@@ -112,7 +112,7 @@ class ProxyFactory extends AbstractProxyFactory
     }
 
     /**
-     * Generates a closure capable of initializing a proxy
+     * Generates a closure capable of initializing a proxy.
      *
      * @param PhpcrClassMetadata $classMetadata
      *
@@ -120,7 +120,7 @@ class ProxyFactory extends AbstractProxyFactory
      */
     private function createInitializer(ClassMetadata $classMetadata)
     {
-        $className       = $classMetadata->getName();
+        $className = $classMetadata->getName();
         $documentManager = $this->documentManager;
 
         if ($classMetadata->getReflectionClass()->hasMethod('__wakeup')) {
@@ -168,18 +168,18 @@ class ProxyFactory extends AbstractProxyFactory
     }
 
     /**
-     * Generates a closure capable of finalizing a cloned proxy
+     * Generates a closure capable of finalizing a cloned proxy.
      *
      * @param PhpcrClassMetadata  $classMetadata
      * @param \ReflectionProperty $reflectionId
      *
-     * @return \Closure
-     *
      * @throws UnexpectedValueException
+     *
+     * @return \Closure
      */
     private function createCloner(ClassMetadata $classMetadata, ReflectionProperty $reflectionId = null)
     {
-        $className       = $classMetadata->getName();
+        $className = $classMetadata->getName();
         $documentManager = $this->documentManager;
 
         return function (Proxy $cloned) use ($className, $classMetadata, $documentManager, $reflectionId) {

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/AbstractLeafNode.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/AbstractLeafNode.php
@@ -36,12 +36,12 @@ abstract class AbstractLeafNode extends AbstractNode
     public function getCardinalityMap()
     {
         // no children , no cardinality map...
-        return array();
+        return [];
     }
 
     /**
      * Return the alias name and field name
-     * from the given string of form
+     * from the given string of form.
      *
      *     [alias].[field_name]
      *

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/AbstractNode.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/AbstractNode.php
@@ -40,10 +40,10 @@ abstract class AbstractNode
     const NT_WHERE_AND = 'where_and';
     const NT_WHERE_OR = 'where_or';
 
-    protected $children = array();
+    protected $children = [];
     protected $parent;
 
-    public function __construct(AbstractNode $parent = null)
+    public function __construct(self $parent = null)
     {
         $this->parent = $parent;
     }
@@ -117,9 +117,10 @@ abstract class AbstractNode
      *
      * @return AbstractNode
      */
-    public function setChild(AbstractNode $node)
+    public function setChild(self $node)
     {
         $this->removeChildrenOfType($node->getNodeType());
+
         return $this->addChild($node);
     }
 
@@ -138,7 +139,7 @@ abstract class AbstractNode
      *
      * @return AbstractNode
      */
-    public function addChild(AbstractNode $node)
+    public function addChild(self $node)
     {
         $cardinalityMap = $this->getCardinalityMap();
         $nodeType = $node->getNodeType();
@@ -199,7 +200,7 @@ abstract class AbstractNode
      */
     public function getChildren()
     {
-        $children = array();
+        $children = [];
         foreach ($this->children as $type) {
             foreach ($type as $child) {
                 $children[] = $child;
@@ -219,7 +220,7 @@ abstract class AbstractNode
     public function getChildrenOfType($type)
     {
         if (!isset($this->children[$type])) {
-            return array();
+            return [];
         }
 
         return $this->children[$type];
@@ -233,9 +234,9 @@ abstract class AbstractNode
     /**
      * Return child of node, there must be exactly one child of any type.
      *
-     * @return AbstractNode
-     *
      * @throws OutOfBoundsException if there are more than one or none
+     *
+     * @return AbstractNode
      */
     public function getChild()
     {
@@ -265,9 +266,9 @@ abstract class AbstractNode
      *
      * @param string $type The name of the type.
      *
-     * @return AbstractNode
-     *
      * @throws OutOfBoundsException if there are more than one or none
+     *
+     * @return AbstractNode
      */
     public function getChildOfType($type)
     {
@@ -305,7 +306,7 @@ abstract class AbstractNode
     public function validate()
     {
         $cardinalityMap = $this->getCardinalityMap();
-        $typeCount = array();
+        $typeCount = [];
 
         foreach (array_keys($cardinalityMap) as $type) {
             $typeCount[$type] = 0;
@@ -340,6 +341,7 @@ abstract class AbstractNode
     public function end()
     {
         $this->validate();
+
         return $this->parent;
     }
 
@@ -376,7 +378,7 @@ abstract class AbstractNode
     {
         $refl = new \ReflectionClass($this);
 
-        $fMethods = array();
+        $fMethods = [];
         foreach ($refl->getMethods() as $rMethod) {
             $comment = $rMethod->getDocComment();
             if ($comment) {

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintAndx.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintAndx.php
@@ -21,8 +21,8 @@ class ConstraintAndx extends ConstraintFactory
 
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_CONSTRAINT => array(1, null),
-        );
+        return [
+            self::NT_CONSTRAINT => [1, null],
+        ];
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintComparison.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintComparison.php
@@ -28,10 +28,10 @@ class ConstraintComparison extends OperandFactory
 
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_OPERAND_DYNAMIC => array('1', '1'),
-            self::NT_OPERAND_STATIC => array('1', '1'),
-        );
+        return [
+            self::NT_OPERAND_DYNAMIC => ['1', '1'],
+            self::NT_OPERAND_STATIC  => ['1', '1'],
+        ];
     }
 
     public function getNodeType()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintFactory.php
@@ -9,15 +9,16 @@ use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
  * return nodes of type "constraint".
  *
  * @IgnoreAnnotation("factoryMethod")
+ *
  * @author Daniel Leech <daniel@dantleech.com>
  */
 class ConstraintFactory extends AbstractNode
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_CONSTRAINT => array(1, 1),
-        );
+        return [
+            self::NT_CONSTRAINT => [1, 1],
+        ];
     }
 
     public function getNodeType()
@@ -26,7 +27,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * And composite constraint::
+     * And composite constraint::.
      *
      * <code>
      * $qb->where()
@@ -70,6 +71,7 @@ class ConstraintFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod ConstraintAndx
+     *
      * @return ConstraintAndx
      */
     public function andX()
@@ -78,7 +80,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Or composite constraint::
+     * Or composite constraint::.
      *
      * <code>
      * $qb->where()
@@ -92,6 +94,7 @@ class ConstraintFactory extends AbstractNode
      * As with "andX", "orX" allows one to many operands.
      *
      * @factoryMethod ConstraintOrx
+     *
      * @return ConstraintOrx
      */
     public function orX()
@@ -100,7 +103,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Field existance constraint::
+     * Field existance constraint::.
      *
      * <code>
      * $qb->where()->fieldIsset('sel_1.prop_1')->end();
@@ -109,6 +112,7 @@ class ConstraintFactory extends AbstractNode
      * @param string $field - Field to check
      *
      * @factoryMethod ConstraintFieldIsset
+     *
      * @return ConstraintFactory
      */
     public function fieldIsset($field)
@@ -117,16 +121,17 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Full text search constraint::
+     * Full text search constraint::.
      *
      * <code>
      * $qb->where()->fullTextSearch('sel_1.prop_1', 'search_expression')->end();
      * </code>
      *
-     * @param string $field - Name of field to check, including alias name.
+     * @param string $field                    - Name of field to check, including alias name.
      * @param string $fullTextSearchExpression - Search expression.
      *
      * @factoryMethod ConstraintFullTextSearch
+     *
      * @return ConstraintFactory
      */
     public function fullTextSearch($field, $fullTextSearchExpression)
@@ -135,7 +140,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Same document constraint::
+     * Same document constraint::.
      *
      * <code>
      * $qb->where()->same('/path/to/doc', 'sel_1')->end();
@@ -143,10 +148,11 @@ class ConstraintFactory extends AbstractNode
      *
      * Relates to PHPCR QOM SameNodeInterface.
      *
-     * @param string $path - Path to reference document.
+     * @param string $path  - Path to reference document.
      * @param string $alias - Name of alias to use.
      *
      * @factoryMethod ConstraintSame
+     *
      * @return ConstraintFactory
      */
     public function same($path, $alias)
@@ -155,7 +161,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Descendant document constraint::
+     * Descendant document constraint::.
      *
      * <code>
      *   $qb->where()->descendant('/ancestor/path', 'sel_1')->end();
@@ -164,9 +170,10 @@ class ConstraintFactory extends AbstractNode
      * Relates to PHPCR QOM DescendantNodeInterface
      *
      * @param string $ancestorPath - Select descendants of this path.
-     * @param string $alias - Name of alias to use.
+     * @param string $alias        - Name of alias to use.
      *
      * @factoryMethod ConstraintDescendant
+     *
      * @return ConstraintFactory
      */
     public function descendant($ancestorPath, $alias)
@@ -175,7 +182,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Select children of the aliased document at the given path::
+     * Select children of the aliased document at the given path::.
      *
      * <code>
      * $qb->where()->child('/parent/path', 'sel_1')->end();
@@ -184,9 +191,10 @@ class ConstraintFactory extends AbstractNode
      * Relates to PHPCR QOM ChildNodeInterface.
      *
      * @param string $parentPath - Select children of this path.
-     * @param string $alias - Name of alias to use
+     * @param string $alias      - Name of alias to use
      *
      * @factoryMethod ConstraintChild
+     *
      * @return ConstraintFactory
      */
     public function child($parentPath, $alias)
@@ -205,7 +213,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Equality comparison constraint::
+     * Equality comparison constraint::.
      *
      * <code>
      * $qb->where()
@@ -216,6 +224,7 @@ class ConstraintFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod ConstraintComparison
+     *
      * @return ConstraintComparison
      */
     public function eq()
@@ -226,7 +235,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Inequality comparison constraint::
+     * Inequality comparison constraint::.
      *
      * <code>
      * $qb->where()
@@ -237,6 +246,7 @@ class ConstraintFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod ConstraintComparison
+     *
      * @return ConstraintComparison
      */
     public function neq()
@@ -247,7 +257,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Less than comparison constraint::
+     * Less than comparison constraint::.
      *
      * <code>
      * $qb->where()
@@ -258,6 +268,7 @@ class ConstraintFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod ConstraintComparison
+     *
      * @return ConstraintComparison
      */
     public function lt()
@@ -268,7 +279,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Less than or equal to comparison constraint::
+     * Less than or equal to comparison constraint::.
      *
      * <code>
      * $qb->where()
@@ -279,6 +290,7 @@ class ConstraintFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod ConstraintComparison
+     *
      * @return ConstraintComparison
      */
     public function lte()
@@ -289,7 +301,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Greater than comparison constraint::
+     * Greater than comparison constraint::.
      *
      * <code>
      * $qb->where()
@@ -300,6 +312,7 @@ class ConstraintFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod ConstraintComparison
+     *
      * @return ConstraintComparison
      */
     public function gt()
@@ -310,7 +323,7 @@ class ConstraintFactory extends AbstractNode
     }
 
     /**
-     * Greater than or equal to comparison constraint::
+     * Greater than or equal to comparison constraint::.
      *
      * <code>
      * $qb->where()
@@ -321,6 +334,7 @@ class ConstraintFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod ConstraintComparison
+     *
      * @return ConstraintComparison
      */
     public function gte()
@@ -346,6 +360,7 @@ class ConstraintFactory extends AbstractNode
      * The above example will match "foo" and "foobar" but not "barfoo".
      *
      * @factoryMethod ConstraintComparison
+     *
      * @return ConstraintComparison
      */
     public function like()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintNot.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintNot.php
@@ -12,9 +12,9 @@ class ConstraintNot extends ConstraintFactory
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_CONSTRAINT => array(1, 1),
-        );
+        return [
+            self::NT_CONSTRAINT => [1, 1],
+        ];
     }
 
     public function getNodeType()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintOrx.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/ConstraintOrx.php
@@ -15,9 +15,9 @@ class ConstraintOrx extends ConstraintFactory
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_CONSTRAINT => array(1, null),
-        );
+        return [
+            self::NT_CONSTRAINT => [1, null],
+        ];
     }
 
     public function getNodeType()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/ConverterBase.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/ConverterBase.php
@@ -19,17 +19,17 @@
 
 namespace Doctrine\ODM\PHPCR\Query\Builder;
 
-use PHPCR\Query\QOM\OrderingInterface;
-use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
-use PHPCR\Query\QOM\ConstraintInterface;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
 use PHPCR\Query\QOM\ColumnInterface;
+use PHPCR\Query\QOM\ConstraintInterface;
+use PHPCR\Query\QOM\OrderingInterface;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Query\QOM\SourceInterface;
 
 /**
- * Base class for PHPCR based query converters
+ * Base class for PHPCR based query converters.
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */
@@ -43,12 +43,12 @@ abstract class ConverterBase implements ConverterInterface
     /**
      * @var ColumnInterface[]
      */
-    protected $columns = array();
+    protected $columns = [];
 
     /**
      * @var OrderingInterface[]
      */
-    protected $orderings = array();
+    protected $orderings = [];
 
     /**
      * @var ConstraintInterface
@@ -65,22 +65,22 @@ abstract class ConverterBase implements ConverterInterface
      * @param string $originalAlias As specified in the query source.
      * @param string $odmField      Name of ODM document property.
      *
-     * @return array first element is the real alias to use, second element is
-     *      the property name
-     *
      * @throws \Exception If a field used in the query does not exist on the document.
+     *
+     * @return array first element is the real alias to use, second element is
+     *               the property name
      */
     abstract protected function getPhpcrProperty($originalAlias, $odmField);
 
     /**
-     * Walk the source document
+     * Walk the source document.
      *
      * @param SourceDocument
      */
     abstract protected function walkSourceDocument(SourceDocument $node);
 
     /**
-     * Walk the dynamic field
+     * Walk the dynamic field.
      *
      * Implementations should map their domain field name to the PHPCR field name here.
      *
@@ -89,7 +89,7 @@ abstract class ConverterBase implements ConverterInterface
     abstract protected function walkOperandDynamicField(OperandDynamicField $node);
 
     /**
-     * Return the query object model factory
+     * Return the query object model factory.
      *
      * @return QueryObjectModelFactoryInterface
      */
@@ -103,9 +103,9 @@ abstract class ConverterBase implements ConverterInterface
      *
      * @param string $alias Alias to validate and return
      *
-     * @return string Return the alias to allow this function to be used inline
-     *
      * @throws InvalidArgumentException
+     *
+     * @return string Return the alias to allow this function to be used inline
      */
     abstract protected function validateAlias($alias);
 
@@ -148,7 +148,7 @@ abstract class ConverterBase implements ConverterInterface
 
     public function walkSelect(AbstractNode $node)
     {
-        $columns = array();
+        $columns = [];
 
         /** @var $property Field */
         foreach ($node->getChildren() as $property) {
@@ -494,7 +494,7 @@ abstract class ConverterBase implements ConverterInterface
     // ordering
     protected function walkOrderBy(OrderBy $node)
     {
-        $this->orderings = array();
+        $this->orderings = [];
 
         $orderings = $node->getChildren();
 

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/ConverterPhpcr.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/ConverterPhpcr.php
@@ -19,19 +19,19 @@
 
 namespace Doctrine\ODM\PHPCR\Query\Builder;
 
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\ODM\PHPCR\Exception\RuntimeException;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\TranslationStrategyInterface;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
-use Doctrine\ODM\PHPCR\Query\Query;
-use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
-use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
-use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
+use Doctrine\ODM\PHPCR\Query\Query;
+use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\TranslationStrategyInterface;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 
 /**
- * Class which converts a Builder tree to a PHPCR Query
+ * Class which converts a Builder tree to a PHPCR Query.
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */
@@ -58,7 +58,7 @@ class ConverterPhpcr extends ConverterBase
      *
      * @var ClassMetadata[]
      */
-    protected $aliasMetadata = array();
+    protected $aliasMetadata = [];
 
     /**
      * When document sources are registered we put the translator
@@ -66,7 +66,7 @@ class ConverterPhpcr extends ConverterBase
      *
      * @var TranslationStrategyInterface[]
      */
-    protected $translator = array();
+    protected $translator = [];
 
     /**
      * Ugly: We need to store the document source types so that we
@@ -100,7 +100,7 @@ class ConverterPhpcr extends ConverterBase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function qomf()
     {
@@ -108,7 +108,7 @@ class ConverterPhpcr extends ConverterBase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function validateAlias($alias)
     {
@@ -125,7 +125,7 @@ class ConverterPhpcr extends ConverterBase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getPhpcrProperty($originalAlias, $odmField)
     {
@@ -148,7 +148,7 @@ class ConverterPhpcr extends ConverterBase
         if (empty($fieldMeta['translated'])
             || empty($this->translator[$originalAlias])
         ) {
-            return array($originalAlias, $propertyName);
+            return [$originalAlias, $propertyName];
         }
 
         $propertyPath = $this->translator[$originalAlias]->getTranslatedPropertyPath($originalAlias, $propertyName, $this->locale);
@@ -159,11 +159,11 @@ class ConverterPhpcr extends ConverterBase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getQuery(QueryBuilder $builder)
     {
-        $this->aliasWithTranslatedFields = array();
+        $this->aliasWithTranslatedFields = [];
         $this->locale = $builder->getLocale();
         if (null === $this->locale && $this->dm->hasLocaleChooserStrategy()) {
             $this->locale = $this->dm->getLocaleChooserStrategy()->getLocale();
@@ -179,12 +179,12 @@ class ConverterPhpcr extends ConverterBase
             );
         }
 
-        $dispatches = array(
+        $dispatches = [
             QBConstants::NT_FROM,
             QBConstants::NT_SELECT,
             QBConstants::NT_WHERE,
             QBConstants::NT_ORDER_BY,
-        );
+        ];
 
         foreach ($dispatches as $dispatchType) {
             $this->dispatchMany($builder->getChildrenOfType($dispatchType));
@@ -255,7 +255,7 @@ class ConverterPhpcr extends ConverterBase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function walkSourceDocument(SourceDocument $node)
     {
@@ -295,7 +295,7 @@ class ConverterPhpcr extends ConverterBase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function walkOperandDynamicField(OperandDynamicField $node)
     {
@@ -343,16 +343,16 @@ class ConverterPhpcr extends ConverterBase
                 $fieldMapping = $meta->getFieldMapping($field->getField());
                 $type = $fieldMapping['type'];
 
-                $typeMapping = array(
-                    'string' => 'string',
-                    'long' => 'integer',
+                $typeMapping = [
+                    'string'  => 'string',
+                    'long'    => 'integer',
                     'decimal' => 'string',
                     'boolean' => 'boolean',
-                    'name' => 'string',
-                    'path' => 'string',
-                    'uri' => 'string',
-                    'uuid' => 'string',
-                );
+                    'name'    => 'string',
+                    'path'    => 'string',
+                    'uri'     => 'string',
+                    'uuid'    => 'string',
+                ];
 
                 if (array_key_exists($type, $typeMapping)) {
                     settype($value, $typeMapping[$type]);

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/From.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/From.php
@@ -12,9 +12,9 @@ class From extends SourceFactory
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_SOURCE => array(1, 1),
-        );
+        return [
+            self::NT_SOURCE => [1, 1],
+        ];
     }
 
     public function getNodeType()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandDynamicFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandDynamicFactory.php
@@ -18,14 +18,14 @@ class OperandDynamicFactory extends AbstractNode
 
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_OPERAND_DYNAMIC => array(1, 1),
-        );
+        return [
+            self::NT_OPERAND_DYNAMIC => [1, 1],
+        ];
     }
 
     /**
      * Represents the aliased documents rank by relevance to the full text
-     * search expression given by the "fullTextSearch" constraint::
+     * search expression given by the "fullTextSearch" constraint::.
      *
      * <code>
      * $qb->where()
@@ -45,6 +45,7 @@ class OperandDynamicFactory extends AbstractNode
      * @param string $alias - Name of alias to use
      *
      * @factoryMethod OperandDynamicFullTextSearchScore
+     *
      * @return OperandDynamicFactory
      */
     public function fullTextSearchScore($alias)
@@ -53,7 +54,7 @@ class OperandDynamicFactory extends AbstractNode
     }
 
     /**
-     * Length operand resolves to length of aliased document::
+     * Length operand resolves to length of aliased document::.
      *
      * <code>
      * $qb->where()
@@ -69,6 +70,7 @@ class OperandDynamicFactory extends AbstractNode
      * @param string $field - Name of field to check.
      *
      * @factoryMethod OperandDynamicLength
+     *
      * @return OperandDynamicFactory
      */
     public function length($field)
@@ -77,7 +79,7 @@ class OperandDynamicFactory extends AbstractNode
     }
 
     /**
-     * LowerCase operand evaluates to lower-cased string of child operand::
+     * LowerCase operand evaluates to lower-cased string of child operand::.
      *
      * <code>
      * $qb->where()
@@ -89,6 +91,7 @@ class OperandDynamicFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod OperandDynamicLowerCase
+     *
      * @return OperandDynamicLowerCase
      */
     public function lowerCase()
@@ -97,7 +100,7 @@ class OperandDynamicFactory extends AbstractNode
     }
 
     /**
-     * UpperCase operand evaluates to upper-cased string of child operand::
+     * UpperCase operand evaluates to upper-cased string of child operand::.
      *
      * <code>
      * $qb->where()
@@ -109,6 +112,7 @@ class OperandDynamicFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod OperandDynamicUpperCase
+     *
      * @return OperandDynamicUpperCase
      */
     public function upperCase()
@@ -137,6 +141,7 @@ class OperandDynamicFactory extends AbstractNode
      * @param string $alias - Name of alias to use
      *
      * @factoryMethod OperandDynamicLocalName
+     *
      * @return OperandDynamicFactory
      */
     public function localName($alias)
@@ -164,6 +169,7 @@ class OperandDynamicFactory extends AbstractNode
      * @param string $alias - Name of alias to use
      *
      * @factoryMethod OperandDynamicName
+     *
      * @return OperandDynamicFactory
      */
     public function name($alias)
@@ -172,7 +178,7 @@ class OperandDynamicFactory extends AbstractNode
     }
 
     /**
-     * Evaluates to the value of the specified field::
+     * Evaluates to the value of the specified field::.
      *
      * <code>
      * $qb->where()
@@ -186,6 +192,7 @@ class OperandDynamicFactory extends AbstractNode
      * @param string $field - name of field to check, including alias name.
      *
      * @factoryMethod OperandDynamicField
+     *
      * @return OperandDynamicFactory
      */
     public function field($field)

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandDynamicLowerCase.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandDynamicLowerCase.php
@@ -11,9 +11,9 @@ class OperandDynamicLowerCase extends OperandDynamicFactory
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_OPERAND_DYNAMIC => array(1, 1),    // 1..*
-        );
+        return [
+            self::NT_OPERAND_DYNAMIC => [1, 1],    // 1..*
+        ];
     }
 
     public function getNodeType()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandDynamicUpperCase.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandDynamicUpperCase.php
@@ -11,9 +11,9 @@ class OperandDynamicUpperCase extends OperandDynamicFactory
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_OPERAND_DYNAMIC => array(1, 1),    // 1..*
-        );
+        return [
+            self::NT_OPERAND_DYNAMIC => [1, 1],    // 1..*
+        ];
     }
 
     public function getNodeType()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandFactory.php
@@ -24,6 +24,7 @@ class OperandFactory extends OperandDynamicFactory
      * @param string $name - Name of parameter to resolve.
      *
      * @factoryMethod OperandStaticParameter
+     *
      * @return OperandFactory
      */
     public function parameter($name)
@@ -32,7 +33,7 @@ class OperandFactory extends OperandDynamicFactory
     }
 
     /**
-     * Evaluates to the given literal value::
+     * Evaluates to the given literal value::.
      *
      * <code>
      * $qb->where()->eq()->field('f.foobar')->literal('Literal Value')->end();
@@ -41,6 +42,7 @@ class OperandFactory extends OperandDynamicFactory
      * @param string $value - Literal value.
      *
      * @factoryMethod OperandStaticLiteral
+     *
      * @return OperandStaticLiteral
      */
     public function literal($value)

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandStaticFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/OperandStaticFactory.php
@@ -14,9 +14,9 @@ class OperandStaticFactory extends OperandFactory
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_OPERAND_STATIC => array(1, 1),
-        );
+        return [
+            self::NT_OPERAND_STATIC => [1, 1],
+        ];
     }
 
     public function getNodeType()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/OrderBy.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/OrderBy.php
@@ -18,19 +18,20 @@ class OrderBy extends AbstractNode
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_ORDERING => array(0, null)
-        );
+        return [
+            self::NT_ORDERING => [0, null],
+        ];
     }
 
     /**
-     * Add ascending ordering::
+     * Add ascending ordering::.
      *
      * <code>
      * $qb->orderBy()->asc()->field('sel_1.prop_1')->end();
      * </code>
      *
      * @factoryMethod Ordering
+     *
      * @return Ordering
      */
     public function asc()
@@ -39,13 +40,14 @@ class OrderBy extends AbstractNode
     }
 
     /**
-     * Add descending ordering::
+     * Add descending ordering::.
      *
      * <code>
      * $qb->orderBy()->desc()->field('sel_1.prop_1')->end();
      * </code>
      *
      * @factoryMethod Ordering
+     *
      * @return Ordering
      */
     public function desc()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/Ordering.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/Ordering.php
@@ -14,9 +14,9 @@ class Ordering extends OperandDynamicFactory
 
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_OPERAND_DYNAMIC => array(1, 1),
-        );
+        return [
+            self::NT_OPERAND_DYNAMIC => [1, 1],
+        ];
     }
 
     public function getOrder()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/QueryBuilder.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/QueryBuilder.php
@@ -2,10 +2,10 @@
 
 namespace Doctrine\ODM\PHPCR\Query\Builder;
 
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
-use Doctrine\ODM\PHPCR\Query\Query;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
 use Doctrine\ODM\PHPCR\Exception\RuntimeException;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
+use Doctrine\ODM\PHPCR\Query\Query;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 
 /**
  * The Query Builder root node.
@@ -59,7 +59,7 @@ class QueryBuilder extends AbstractNode
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * This is an NT_BUILDER
      */
@@ -97,20 +97,20 @@ class QueryBuilder extends AbstractNode
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_SELECT => array(0, null),    // 1..*
-            self::NT_FROM => array(1, 1),         // 1..1
-            self::NT_WHERE => array(0, 1),        // 0..1
-            self::NT_ORDER_BY => array(0, null),  // 0..*
-        );
+        return [
+            self::NT_SELECT   => [0, null],    // 1..*
+            self::NT_FROM     => [1, 1],         // 1..1
+            self::NT_WHERE    => [0, 1],        // 0..1
+            self::NT_ORDER_BY => [0, null],  // 0..*
+        ];
     }
 
     /**
-     * Where factory node is used to specify selection criteria::
+     * Where factory node is used to specify selection criteria::.
      *
      * <code>
      * $qb->where()
@@ -121,11 +121,13 @@ class QueryBuilder extends AbstractNode
      * </code>
      *
      * @factoryMethod Where
+     *
      * @return Where
      */
     public function where($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->setChild(new Where($this));
     }
 
@@ -133,11 +135,13 @@ class QueryBuilder extends AbstractNode
      * Add additional selection criteria using the AND operator.
      *
      * @factoryMethod WhereAnd
+     *
      * @return WhereAnd
      */
     public function andWhere($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->addChild(new WhereAnd($this));
     }
 
@@ -145,16 +149,18 @@ class QueryBuilder extends AbstractNode
      * Add additional selection criteria using the OR operator.
      *
      * @factoryMethod WhereOr
+     *
      * @return WhereOr
      */
     public function orWhere($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->addChild(new WhereOr($this));
     }
 
     /**
-     * Set the from source for the query::
+     * Set the from source for the query::.
      *
      * <code>
      * $qb->from()->document('Foobar', 'a');
@@ -171,6 +177,7 @@ class QueryBuilder extends AbstractNode
      * @param string $primaryAlias - Alias to use as primary source (optional for single sources)
      *
      * @factoryMethod From
+     *
      * @return From
      */
     public function from($primaryAlias = null)
@@ -181,7 +188,7 @@ class QueryBuilder extends AbstractNode
     }
 
     /**
-     * Shortcut for::
+     * Shortcut for::.
      *
      * <code>
      * $qb->from()
@@ -197,10 +204,11 @@ class QueryBuilder extends AbstractNode
      *
      * Replaces any existing from source.
      *
-     * @param string $documentFqn - Fully qualified class name for document.
+     * @param string $documentFqn  - Fully qualified class name for document.
      * @param string $primaryAlias - Alias for document source and primary alias when using multiple sources.
      *
      * @factoryMethod From
+     *
      * @return QueryBuilder
      */
     public function fromDocument($documentFqn, $primaryAlias)
@@ -210,6 +218,7 @@ class QueryBuilder extends AbstractNode
         $from = new From($this);
         $from->document($documentFqn, $primaryAlias);
         $this->setChild($from);
+
         return $from->end();
     }
 
@@ -232,7 +241,7 @@ class QueryBuilder extends AbstractNode
 
     /**
      * Replace the existing source with a left outer join source using the existing
-     * source as the left operand::
+     * source as the left operand::.
      *
      * <code>
      * $qb->fromDocument('Foobar', 'a')
@@ -249,17 +258,19 @@ class QueryBuilder extends AbstractNode
      * will behave as an inner join.
      *
      * @factoryMethod Select
+     *
      * @return SourceJoin
      */
     public function addJoinLeftOuter($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->addJoin(QOMConstants::JCR_JOIN_TYPE_LEFT_OUTER);
     }
 
     /**
      * Replace the existing source with a right outer join source using the existing
-     * source as the left operand::
+     * source as the left operand::.
      *
      * <code>
      * $qb->fromDocument('Foobar', 'a')
@@ -276,17 +287,19 @@ class QueryBuilder extends AbstractNode
      * will behave as an inner join.
      *
      * @factoryMethod Select
+     *
      * @return SourceJoin
      */
     public function addJoinRightOuter($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->addJoin(QOMConstants::JCR_JOIN_TYPE_RIGHT_OUTER);
     }
 
     /**
      * Replace the existing source with an inner join source using the existing
-     * source as the left operand::
+     * source as the left operand::.
      *
      * <code>
      * $qb->fromDocument('Foobar', 'a')
@@ -303,11 +316,13 @@ class QueryBuilder extends AbstractNode
      * will behave as an inner join.
      *
      * @factoryMethod Select
+     *
      * @return SourceJoin
      */
     public function addJoinInner($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->addJoin(QOMConstants::JCR_JOIN_TYPE_INNER);
     }
 
@@ -326,16 +341,18 @@ class QueryBuilder extends AbstractNode
      * </code>
      *
      * @factoryMethod Select
+     *
      * @return Select
      */
     public function select($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->setChild(new Select($this));
     }
 
     /**
-     * Add additional properties to selection::
+     * Add additional properties to selection::.
      *
      * <code>
      * $qb->select()
@@ -349,11 +366,13 @@ class QueryBuilder extends AbstractNode
      * </code>
      *
      * @factoryMethod SelectAdd
+     *
      * @return SelectAdd
      */
     public function addSelect($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->setChild(new SelectAdd($this));
     }
 
@@ -370,11 +389,13 @@ class QueryBuilder extends AbstractNode
      * </code>
      *
      * @factoryMethod OrderBy
+     *
      * @return OrderBy
      */
     public function orderBy($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->setChild(new OrderBy($this));
     }
 
@@ -382,18 +403,20 @@ class QueryBuilder extends AbstractNode
      * Add additional orderings to the builder tree.
      *
      * @factoryMethod OrderByAdd
+     *
      * @return OrderByAdd
      */
     public function addOrderBy($void = null)
     {
         $this->ensureNoArguments(__METHOD__, $void);
+
         return $this->addChild(new OrderByAdd($this));
     }
 
     /**
      * Return the offset of the first result in the resultset.
      *
-     * @return integer
+     * @return int
      */
     public function getFirstResult()
     {
@@ -403,7 +426,7 @@ class QueryBuilder extends AbstractNode
     /**
      * Set the offset of the first result in the resultset.
      *
-     * @param integer $firstResult
+     * @param int $firstResult
      */
     public function setFirstResult($firstResult)
     {
@@ -413,7 +436,7 @@ class QueryBuilder extends AbstractNode
     /**
      * Return the maximum number of results to be imposed on the generated query.
      *
-     * @return integer
+     * @return int
      */
     public function getMaxResults()
     {
@@ -423,7 +446,7 @@ class QueryBuilder extends AbstractNode
     /**
      * Set the maximum number of results to be returned by the generated query.
      *
-     * @param integer $maxResults
+     * @param int $maxResults
      */
     public function setMaxResults($maxResults)
     {

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/Select.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/Select.php
@@ -13,13 +13,13 @@ class Select extends AbstractNode
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_PROPERTY => array(0, null)
-        );
+        return [
+            self::NT_PROPERTY => [0, null],
+        ];
     }
 
     /**
-     * Field to select::
+     * Field to select::.
      *
      * <code>
      * $qb->select()
@@ -31,6 +31,7 @@ class Select extends AbstractNode
      * @param string $field - name of field to check, including alias name
      *
      * @factoryMethod
+     *
      * @return Select
      */
     public function field($field)

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/SourceFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/SourceFactory.php
@@ -21,23 +21,24 @@ abstract class SourceFactory extends AbstractNode
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_SOURCE => array(1, 1)
-        );
+        return [
+            self::NT_SOURCE => [1, 1],
+        ];
     }
 
     /**
      * Select documents of specified class. The alias name is mandatory
-     * and will be used to reference documents selected from this source::
+     * and will be used to reference documents selected from this source::.
      *
      * <code>
      * $qb->from('my_alias')->document('My/Document/Class', 'my_alias')->end();
      * </code>
      *
      * @param string $documentFqn - Fully qualified class name for document.
-     * @param string $alias - Alias name.
+     * @param string $alias       - Alias name.
      *
      * @factoryMethod SourceDocument
+     *
      * @return SourceDocument
      */
     public function document($documentFqn, $alias)
@@ -46,7 +47,7 @@ abstract class SourceFactory extends AbstractNode
     }
 
     /**
-     * Inner Join::
+     * Inner Join::.
      *
      * <code>
      * $qb->from('sel_1')
@@ -59,6 +60,7 @@ abstract class SourceFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod SourceJoin
+     *
      * @return SourceJoin
      */
     public function joinInner()
@@ -69,7 +71,7 @@ abstract class SourceFactory extends AbstractNode
     }
 
     /**
-     * Left Outer Join::
+     * Left Outer Join::.
      *
      * <code>
      * $qb->from('sel_2')
@@ -82,6 +84,7 @@ abstract class SourceFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod SourceJoin
+     *
      * @return SourceJoin
      */
     public function joinLeftOuter()
@@ -92,7 +95,7 @@ abstract class SourceFactory extends AbstractNode
     }
 
     /**
-     * Right Outer Join::
+     * Right Outer Join::.
      *
      * <code>
      * $qb->from('sel_1')
@@ -105,6 +108,7 @@ abstract class SourceFactory extends AbstractNode
      * </code>
      *
      * @factoryMethod SourceJoin
+     *
      * @return SourceJoin
      */
     public function joinRightOuter()

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/SourceJoin.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/SourceJoin.php
@@ -24,6 +24,7 @@ class SourceJoin extends AbstractNode
      * Specify the document source for the "left" side of a join.
      *
      * @factoryMethod
+     *
      * @return SourceJoinLeft
      */
     public function left()
@@ -35,6 +36,7 @@ class SourceJoin extends AbstractNode
      * Specify the document source for the "right" side of a join.
      *
      * @factoryMethod
+     *
      * @return SourceJoinRight
      */
     public function right()
@@ -46,6 +48,7 @@ class SourceJoin extends AbstractNode
      * Specify the join condition.
      *
      * @factoryMethod
+     *
      * @return SourceJoinConditionFactory
      */
     public function condition()
@@ -60,10 +63,10 @@ class SourceJoin extends AbstractNode
 
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_SOURCE_JOIN_CONDITION_FACTORY => array(1, 1),
-            self::NT_SOURCE_JOIN_LEFT => array(1, 1),
-            self::NT_SOURCE_JOIN_RIGHT => array(1, 1),
-        );
+        return [
+            self::NT_SOURCE_JOIN_CONDITION_FACTORY => [1, 1],
+            self::NT_SOURCE_JOIN_LEFT              => [1, 1],
+            self::NT_SOURCE_JOIN_RIGHT             => [1, 1],
+        ];
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/SourceJoinConditionFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/SourceJoinConditionFactory.php
@@ -6,15 +6,16 @@ namespace Doctrine\ODM\PHPCR\Query\Builder;
  * Factory node for join conditions.
  *
  * @IgnoreAnnotation('factoryMethod');
+ *
  * @author Daniel Leech <daniel@dantleech.com>
  */
 class SourceJoinConditionFactory extends AbstractNode
 {
     public function getCardinalityMap()
     {
-        return array(
-            self::NT_SOURCE_JOIN_CONDITION => array(1, 1)
-        );
+        return [
+            self::NT_SOURCE_JOIN_CONDITION => [1, 1],
+        ];
     }
 
     public function getNodeType()
@@ -23,7 +24,7 @@ class SourceJoinConditionFactory extends AbstractNode
     }
 
     /**
-     * Descendant join condition::
+     * Descendant join condition::.
      *
      * <code>
      *   $qb->from('alias_1')
@@ -37,9 +38,10 @@ class SourceJoinConditionFactory extends AbstractNode
      * </code>
      *
      * @param string $descendantAlias - Name of alias for descendant documents.
-     * @param string $ancestorAlias - Name of alias to match for ancestor documents.
+     * @param string $ancestorAlias   - Name of alias to match for ancestor documents.
      *
      * @factoryMethod SourceJoinConditionDescendant
+     *
      * @return SourceJoinConditionFactory
      */
     public function descendant($descendantAlias, $ancestorAlias)
@@ -50,7 +52,7 @@ class SourceJoinConditionFactory extends AbstractNode
     }
 
     /**
-     * Equi (equality) join condition::
+     * Equi (equality) join condition::.
      *
      * <code>
      *   $qb->from('alias_1')
@@ -68,6 +70,7 @@ class SourceJoinConditionFactory extends AbstractNode
      * @param string $field2 - Field name for second field.
      *
      * @factoryMethod SourceJoinConditionEqui
+     *
      * @return SourceJoinConditionFactory
      */
     public function equi($field1, $field2)
@@ -78,7 +81,7 @@ class SourceJoinConditionFactory extends AbstractNode
     }
 
     /**
-     * Child document join condition::
+     * Child document join condition::.
      *
      * <code>
      *   $qb->from('alias_1')
@@ -90,10 +93,11 @@ class SourceJoinConditionFactory extends AbstractNode
      *  ->end();
      * </code>
      *
-     * @param string $childAlias - Name of alias for child documents.
+     * @param string $childAlias  - Name of alias for child documents.
      * @param string $parentAlias - Name of alias to match for parent documents.
      *
      * @factoryMethod SourceJoinConditionChildDocument
+     *
      * @return SourceJoinConditionFactory
      */
     public function child($childAlias, $parentAlias)
@@ -104,7 +108,7 @@ class SourceJoinConditionFactory extends AbstractNode
     }
 
     /**
-     * Same document join condition::
+     * Same document join condition::.
      *
      * <code>
      *   $qb->from('alias_1')
@@ -118,11 +122,12 @@ class SourceJoinConditionFactory extends AbstractNode
      *   ->end();
      * </code>
      *
-     * @param string $alias1 - Name of first alias.
-     * @param string $alias2 - Name of first alias.
+     * @param string $alias1     - Name of first alias.
+     * @param string $alias2     - Name of first alias.
      * @param string $alias2Path - Path for documents of second alias.
      *
      * @factoryMethod SourceJoinConditionSameDocument
+     *
      * @return SourceJoinConditionFactory
      */
     public function same($alias1, $alias2, $alias2Path)

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/WhereAnd.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/WhereAnd.php
@@ -3,7 +3,7 @@
 namespace Doctrine\ODM\PHPCR\Query\Builder;
 
 /**
- * Factory node for appending additional "wheres" with an AND
+ * Factory node for appending additional "wheres" with an AND.
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */

--- a/lib/Doctrine/ODM/PHPCR/Query/Builder/WhereOr.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Builder/WhereOr.php
@@ -3,7 +3,7 @@
 namespace Doctrine\ODM\PHPCR\Query\Builder;
 
 /**
- * Factory node for appending additional "wheres" with an OR
+ * Factory node for appending additional "wheres" with an OR.
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */

--- a/lib/Doctrine/ODM/PHPCR/Query/Expression/Comparison.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Expression/Comparison.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Collections\Expr\Comparison as BaseComparison;
 /**
  * This class purpose is to provide  provide a place
  * for the LIKE constant. Everything  else is handled
- * in Doctrine\Common\Collections\Expr\Comparison
+ * in Doctrine\Common\Collections\Expr\Comparison.
  */
 class Comparison extends BaseComparison
 {

--- a/lib/Doctrine/ODM/PHPCR/Query/Query.php
+++ b/lib/Doctrine/ODM/PHPCR/Query/Query.php
@@ -2,12 +2,12 @@
 
 namespace Doctrine\ODM\PHPCR\Query;
 
-use PHPCR\Query\QueryInterface;
-use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+use PHPCR\Query\QueryInterface;
 
 /**
- * Query
+ * Query.
  *
  * Wraps the given PHPCR query object in the ODM, emulating
  * the Query object from the ORM.
@@ -20,7 +20,7 @@ class Query
     const HYDRATE_PHPCR = 2;
 
     protected $hydrationMode = self::HYDRATE_DOCUMENT;
-    protected $parameters = array();
+    protected $parameters = [];
     protected $primaryAlias;
     protected $firstResult;
     protected $maxResults;
@@ -48,9 +48,9 @@ class Query
      *
      * @param string $hydrationMode The mode to return the result in execute.
      *
-     * @return Query This query instance.
-     *
      * @throws QueryException If $hydrationMode is not known.
+     *
+     * @return Query This query instance.
      *
      * @see execute
      */
@@ -124,14 +124,14 @@ class Query
     public function getParameter($key)
     {
         if (!isset($this->parameters[$key])) {
-            return null;
+            return;
         }
 
         return $this->parameters[$key];
     }
 
     /**
-     * Set the document class to use when using HYDRATION_DOCUMENT
+     * Set the document class to use when using HYDRATION_DOCUMENT.
      *
      * Note: This is useful in the following two cases:
      *
@@ -157,9 +157,9 @@ class Query
      * @param int   $hydrationMode Processing mode to be used during the hydration
      *                             process. One of the Query::HYDRATE_* constants.
      *
-     * @return mixed A Collection for HYDRATE_DOCUMENT, \PHPCR\Query\QueryResultInterface for HYDRATE_PHPCR
-     *
      * @throws QueryException If $hydrationMode is not known.
+     *
+     * @return mixed A Collection for HYDRATE_DOCUMENT, \PHPCR\Query\QueryResultInterface for HYDRATE_PHPCR
      */
     public function execute($parameters = null, $hydrationMode = null)
     {
@@ -232,9 +232,9 @@ class Query
      *
      * @param int $hydrationMode
      *
-     * @return mixed
-     *
      * @throws QueryException if more than one result found
+     *
+     * @return mixed
      */
     public function getOneOrNullResult($hydrationMode = null)
     {
@@ -243,7 +243,7 @@ class Query
         if (count($result) > 1) {
             throw QueryException::nonUniqueResult();
         } elseif (count($result) <= 0) {
-            return null;
+            return;
         }
 
         return $result->first();
@@ -257,11 +257,11 @@ class Query
      * If the result is not unique, a NonUniqueResultException is thrown.
      * If there is no result, a NoResultException is thrown.
      *
-     * @param integer $hydrationMode
-     *
-     * @return mixed
+     * @param int $hydrationMode
      *
      * @throws QueryException if no result or more than one result found
+     *
+     * @return mixed
      */
     public function getSingleResult($hydrationMode = null)
     {
@@ -278,8 +278,8 @@ class Query
      * Executes the query and returns an IterableResult that can be used to incrementally
      * iterate over the result.
      *
-     * @param  array   $parameters    The query parameters.
-     * @param  integer $hydrationMode The hydration mode to use.
+     * @param array $parameters    The query parameters.
+     * @param int   $hydrationMode The hydration mode to use.
      *
      * @return TODO \Doctrine\ORM\Internal\Hydration\IterableResult
      */
@@ -291,7 +291,7 @@ class Query
     /**
      * Sets the maximum number of results to retrieve (the "limit").
      *
-     * @param integer $maxResults
+     * @param int $maxResults
      *
      * @return Query This query object.
      */
@@ -307,7 +307,7 @@ class Query
      * (the "limit"). Returns NULL if {@link setMaxResults} was not applied to
      * this query.
      *
-     * @return integer Maximum number of results.
+     * @return int Maximum number of results.
      */
     public function getMaxResults()
     {
@@ -317,7 +317,7 @@ class Query
     /**
      * Sets the position of the first result to retrieve (the "offset").
      *
-     * @param integer $firstResult The first result to return.
+     * @param int $firstResult The first result to return.
      *
      * @return Query This query object.
      */
@@ -333,7 +333,7 @@ class Query
      * retrieve (the "offset"). Returns NULL if {@link setFirstResult} was not
      * applied to this query.
      *
-     * @return integer The position of the first result.
+     * @return int The position of the first result.
      */
     public function getFirstResult()
     {
@@ -341,7 +341,7 @@ class Query
     }
 
     /**
-     * Proxy method to return statement of the wrapped PHPCR Query
+     * Proxy method to return statement of the wrapped PHPCR Query.
      *
      * @return string The query statement.
      */
@@ -351,7 +351,7 @@ class Query
     }
 
     /**
-     * Proxy method to return language of the wrapped PHPCR Query
+     * Proxy method to return language of the wrapped PHPCR Query.
      *
      * @return string The language used
      */
@@ -361,7 +361,7 @@ class Query
     }
 
     /**
-     * Return wrapped PHPCR query object
+     * Return wrapped PHPCR query object.
      *
      * @return QueryInterface
      */

--- a/lib/Doctrine/ODM/PHPCR/ReferenceManyCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ReferenceManyCollection.php
@@ -19,13 +19,13 @@
 
 namespace Doctrine\ODM\PHPCR;
 
-use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 
 /**
- * Property collection class
+ * Property collection class.
  *
  * This class stores all documents or their proxies referenced by a reference many property
  */
@@ -44,13 +44,13 @@ class ReferenceManyCollection extends PersistentCollection
     /**
      * Creates a new persistent collection.
      *
-     * @param DocumentManagerInterface $dm     The DocumentManager the collection will be associated with.
-     * @param object          $document        The document with the references property
-     * @param string          $property        The node property name with the multivalued references
-     * @param array           $referencedNodes An array of referenced nodes (UUID or path)
-     * @param string          $targetDocument  The class name of the target documents
-     * @param string          $locale          The locale to use during the loading of this collection
-     * @param string          $referenceType   Identifiers used for reference nodes in this collection, either path or default uuid
+     * @param DocumentManagerInterface $dm              The DocumentManager the collection will be associated with.
+     * @param object                   $document        The document with the references property
+     * @param string                   $property        The node property name with the multivalued references
+     * @param array                    $referencedNodes An array of referenced nodes (UUID or path)
+     * @param string                   $targetDocument  The class name of the target documents
+     * @param string                   $locale          The locale to use during the loading of this collection
+     * @param string                   $referenceType   Identifiers used for reference nodes in this collection, either path or default uuid
      */
     public function __construct(DocumentManagerInterface $dm, $document, $property, array $referencedNodes, $targetDocument, $locale = null, $referenceType = self::REFERENCE_TYPE_UUID)
     {
@@ -64,31 +64,31 @@ class ReferenceManyCollection extends PersistentCollection
     }
 
     /**
-     * @param DocumentManagerInterface  $dm     The DocumentManager the collection will be associated with.
-     * @param object           $document        The document with the references property
-     * @param string           $property        The node property name with the multivalued references
-     * @param array|Collection $collection      The collection to initialize with
-     * @param string           $targetDocument  The class name of the target documents
-     * @param bool             $forceOverwrite If to force the database to be forced to the state of the collection
+     * @param DocumentManagerInterface $dm             The DocumentManager the collection will be associated with.
+     * @param object                   $document       The document with the references property
+     * @param string                   $property       The node property name with the multivalued references
+     * @param array|Collection         $collection     The collection to initialize with
+     * @param string                   $targetDocument The class name of the target documents
+     * @param bool                     $forceOverwrite If to force the database to be forced to the state of the collection
      *
      * @return ReferenceManyCollection
      */
     public static function createFromCollection(DocumentManagerInterface $dm, $document, $property, $collection, $targetDocument, $forceOverwrite = false)
     {
-        $referenceCollection = new self($dm, $document, $property, array(), $targetDocument);
+        $referenceCollection = new self($dm, $document, $property, [], $targetDocument);
         $referenceCollection->initializeFromCollection($collection, $forceOverwrite);
 
         return $referenceCollection;
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function refresh()
     {
         try {
             $property = $this->dm->getNodeForDocument($this->document)->getProperty($this->property);
             $this->referencedNodes = $property->getString();
         } catch (InvalidArgumentException $e) {
-            $this->referencedNodes = array();
+            $this->referencedNodes = [];
         }
 
         parent::refresh();
@@ -101,18 +101,17 @@ class ReferenceManyCollection extends PersistentCollection
     public function initialize()
     {
         if (!$this->isInitialized()) {
-            $referencedDocs = array();
+            $referencedDocs = [];
             if (self::REFERENCE_TYPE_UUID === $this->referenceType) {
                 $referencedNodes = $this->dm->getPhpcrSession()->getNodesByIdentifier($this->referencedNodes);
             } else {
                 $referencedNodes = $this->dm->getPhpcrSession()->getNodes($this->referencedNodes);
             }
 
-
             $uow = $this->dm->getUnitOfWork();
             $uow->getPrefetchHelper()->prefetch($this->dm, $referencedNodes, $this->locale);
 
-            $this->originalReferencePaths = array();
+            $this->originalReferencePaths = [];
             foreach ($referencedNodes as $referencedNode) {
                 $proxy = $uow->getOrCreateProxyFromNode($referencedNode, $this->locale);
                 if (isset($targetDocument) && !$proxy instanceof $this->targetDocument) {
@@ -127,7 +126,7 @@ class ReferenceManyCollection extends PersistentCollection
         }
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function count()
     {
         if (!$this->isInitialized()) {
@@ -137,7 +136,7 @@ class ReferenceManyCollection extends PersistentCollection
         return parent::count();
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function isEmpty()
     {
         if (!$this->isInitialized()) {
@@ -148,14 +147,14 @@ class ReferenceManyCollection extends PersistentCollection
     }
 
     /**
-     * Return the ordered list of references that existed when the collection was initialized
+     * Return the ordered list of references that existed when the collection was initialized.
      *
      * @return array
      */
     public function getOriginalPaths()
     {
         if (null === $this->originalReferencePaths) {
-            $this->originalReferencePaths = array();
+            $this->originalReferencePaths = [];
             if (self::INITIALIZED_FROM_COLLECTION === $this->initialized) {
                 $uow = $this->dm->getUnitOfWork();
                 foreach ($this->collection as $reference) {
@@ -177,7 +176,7 @@ class ReferenceManyCollection extends PersistentCollection
     }
 
     /**
-     * Reset original reference paths and mark the collection as non dirty
+     * Reset original reference paths and mark the collection as non dirty.
      */
     public function takeSnapshot()
     {

--- a/lib/Doctrine/ODM/PHPCR/ReferrersCollection.php
+++ b/lib/Doctrine/ODM/PHPCR/ReferrersCollection.php
@@ -19,15 +19,14 @@
 
 namespace Doctrine\ODM\PHPCR;
 
-use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 /**
- * Referrer collection class
+ * Referrer collection class.
  *
  * This class represents a collection of referrers of a document which phpcr
  * names match a optional name
- *
  */
 class ReferrersCollection extends PersistentCollection
 {
@@ -38,12 +37,12 @@ class ReferrersCollection extends PersistentCollection
     private $originalReferrerPaths;
 
     /**
-     * @param DocumentManagerInterface  $dm The DocumentManager the collection will be associated with.
-     * @param object           $document    The parent document instance
-     * @param string|null      $type        Type can be 'weak', 'hard' or null to get both weak and hard references.
-     * @param string|null      $name        If set, name of the referencing property.
-     * @param string|null      $locale      The locale to use.
-     * @param string|null      $refClass    Class the referrer document must be instanceof.
+     * @param DocumentManagerInterface $dm       The DocumentManager the collection will be associated with.
+     * @param object                   $document The parent document instance
+     * @param string|null              $type     Type can be 'weak', 'hard' or null to get both weak and hard references.
+     * @param string|null              $name     If set, name of the referencing property.
+     * @param string|null              $locale   The locale to use.
+     * @param string|null              $refClass Class the referrer document must be instanceof.
      */
     public function __construct(DocumentManagerInterface $dm, $document, $type = null, $name = null, $locale = null, $refClass = null)
     {
@@ -56,13 +55,13 @@ class ReferrersCollection extends PersistentCollection
     }
 
     /**
-     * @param DocumentManagerInterface  $dm    The DocumentManager the collection will be associated with.
-     * @param object           $document       The parent document instance
-     * @param array|Collection $collection     The collection to initialize with
-     * @param string|null      $type           Type can be 'weak', 'hard' or null to get both weak and hard references.
-     * @param string|null      $name           If set, name of the referencing property.
-     * @param string|null      $refClass       Class the referrer document must be instanceof.
-     * @param bool             $forceOverwrite If to force the database to be forced to the state of the collection
+     * @param DocumentManagerInterface $dm             The DocumentManager the collection will be associated with.
+     * @param object                   $document       The parent document instance
+     * @param array|Collection         $collection     The collection to initialize with
+     * @param string|null              $type           Type can be 'weak', 'hard' or null to get both weak and hard references.
+     * @param string|null              $name           If set, name of the referencing property.
+     * @param string|null              $refClass       Class the referrer document must be instanceof.
+     * @param bool                     $forceOverwrite If to force the database to be forced to the state of the collection
      *
      * @return ReferrersCollection
      */
@@ -91,7 +90,7 @@ class ReferrersCollection extends PersistentCollection
                 break;
             default:
                 $referrerProperties = $node->getWeakReferences($this->name)->getArrayCopy();
-                $referrerProperties= array_merge($node->getReferences($this->name)->getArrayCopy(), $referrerProperties);
+                $referrerProperties = array_merge($node->getReferences($this->name)->getArrayCopy(), $referrerProperties);
         }
 
         return $referrerProperties;
@@ -106,9 +105,9 @@ class ReferrersCollection extends PersistentCollection
         if (!$this->isInitialized()) {
             $uow = $this->dm->getUnitOfWork();
 
-            $referrerDocuments = array();
+            $referrerDocuments = [];
             $referrerProperties = $this->getReferrerProperties();
-            $referringNodes = array();
+            $referringNodes = [];
             foreach ($referrerProperties as $prop) {
                 $referringNodes[] = $prop->getParent();
             }
@@ -116,11 +115,11 @@ class ReferrersCollection extends PersistentCollection
 
             $uow->getPrefetchHelper()->prefetch($this->dm, $referringNodes, $locale);
 
-            $this->originalReferrerPaths = array();
+            $this->originalReferrerPaths = [];
             foreach ($referrerProperties as $referrerProperty) {
                 $referrerNode = $referrerProperty->getParent();
                 $document = $uow->getOrCreateProxyFromNode($referrerNode, $locale);
-                if (! $this->refClass || $document instanceof $this->refClass) {
+                if (!$this->refClass || $document instanceof $this->refClass) {
                     $referrerDocuments[] = $document;
                     $this->originalReferrerPaths[] = $referrerNode->getPath();
                 }
@@ -140,7 +139,7 @@ class ReferrersCollection extends PersistentCollection
     public function getOriginalPaths()
     {
         if (null === $this->originalReferrerPaths) {
-            $this->originalReferrerPaths = array();
+            $this->originalReferrerPaths = [];
             if (self::INITIALIZED_FROM_COLLECTION === $this->initialized) {
                 $uow = $this->dm->getUnitOfWork();
                 foreach ($this->collection as $referrer) {
@@ -158,7 +157,7 @@ class ReferrersCollection extends PersistentCollection
     }
 
     /**
-     * Reset original referrer paths and mark the collection as non dirty
+     * Reset original referrer paths and mark the collection as non dirty.
      */
     public function takeSnapshot()
     {

--- a/lib/Doctrine/ODM/PHPCR/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Repository/DefaultRepositoryFactory.php
@@ -26,6 +26,7 @@ use Doctrine\ODM\PHPCR\DocumentManagerInterface;
  * This factory is used to create default repository objects for entities at runtime.
  *
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ *
  * @since 1.1
  */
 class DefaultRepositoryFactory implements RepositoryFactory
@@ -35,7 +36,7 @@ class DefaultRepositoryFactory implements RepositoryFactory
      *
      * @var array<\Doctrine\Common\Persistence\ObjectRepository>
      */
-    private $repositoryList = array();
+    private $repositoryList = [];
 
     /**
      * {@inheritdoc}
@@ -58,18 +59,18 @@ class DefaultRepositoryFactory implements RepositoryFactory
     /**
      * Create a new repository instance for a document class.
      *
-     * @param DocumentManagerInterface  $dm             The DocumentManager instance.
-     * @param string                    $documentName   The name of the document.
+     * @param DocumentManagerInterface $dm           The DocumentManager instance.
+     * @param string                   $documentName The name of the document.
      *
      * @return ObjectRepository
      */
     protected function createRepository(DocumentManagerInterface $dm, $documentName)
     {
-        $metadata            = $dm->getClassMetadata($documentName);
+        $metadata = $dm->getClassMetadata($documentName);
         $repositoryClassName = $metadata->customRepositoryClassName;
 
         if ($repositoryClassName === null) {
-            $configuration       = $dm->getConfiguration();
+            $configuration = $dm->getConfiguration();
             $repositoryClassName = $configuration->getDefaultRepositoryClassName();
         }
 

--- a/lib/Doctrine/ODM/PHPCR/Repository/RepositoryFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Repository/RepositoryFactory.php
@@ -32,8 +32,8 @@ interface RepositoryFactory
     /**
      * Gets the repository for a document class.
      *
-     * @param DocumentManagerInterface  $dm             The DocumentManager instance.
-     * @param string                    $documentName   The name of the document.
+     * @param DocumentManagerInterface $dm           The DocumentManager instance.
+     * @param string                   $documentName The name of the document.
      *
      * @return ObjectRepository
      */

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/DocumentConvertTranslationCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/DocumentConvertTranslationCommand.php
@@ -44,7 +44,7 @@ class DocumentConvertTranslationCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -57,20 +57,20 @@ class DocumentConvertTranslationCommand extends Command
                 'Name of the previous translation strategy if there was one. Omit for converting from non-translated to translated',
                 'none'
             )
-            ->addOption('fields', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL,
+            ->addOption('fields', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL,
                 'The fields to convert. If not specified, all fields configured as translated will be converted.',
-                array()
+                []
             )
-            ->addOption('locales', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL,
+            ->addOption('locales', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL,
                 'Locales to copy previously untranslated fields into.',
-                array()
+                []
             )
             ->addOption('force', null, InputOption::VALUE_NONE, 'Use to bypass the confirmation dialog')
-            ->setHelp(<<<HERE
+            ->setHelp(<<<'HERE'
 The <info>doctrine:phpcr:document:convert-translation</info> command migrates translations
 from a previous format to the current mapping.
 
-  <info>$ php ./app/console/phpcr doctrine:phpcr:document:convert-translation "Document\\ClassName"</info>
+  <info>$ php ./app/console/phpcr doctrine:phpcr:document:convert-translation "Document\ClassName"</info>
 
 <comment>When some fields already where translated, you need to specify which fields to convert.</comment>
 Failing to do that would erase all fields already translated previously.
@@ -83,7 +83,7 @@ HERE
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -147,13 +147,14 @@ HERE
 
         return $this->translationConverter;
     }
+
     /**
      * Ask for confirmation with the question helper or the dialog helper for symfony < 2.5 compatibility.
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
      * @param string          $question
-     * @param boolean         $default
+     * @param bool            $default
      *
      * @return string
      */

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/DocumentMigrateClassCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/DocumentMigrateClassCommand.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DocumentMigrateClassCommand extends NodesUpdateCommand
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -41,12 +41,12 @@ class DocumentMigrateClassCommand extends NodesUpdateCommand
 
             ->addArgument('classname', InputArgument::REQUIRED, 'Old class name (does not need to exist in current codebase')
             ->addArgument('new-classname', InputArgument::REQUIRED, 'New class name (must exist in current codebase')
-            ->setHelp(<<<HERE
+            ->setHelp(<<<'HERE'
 The <info>doctrine:phpcr:docment:migrate-class</info> command migrates document
 classes from the old class to the new class, updating the parent class
 information too.
 
-  <info>$ php ./app/console/phpcr doctrine:phpcr:document:migrate-class "Old\\ClassName" "New\\ClassName"</info>
+  <info>$ php ./app/console/phpcr doctrine:phpcr:document:migrate-class "Old\ClassName" "New\ClassName"</info>
 
 Note that the command only changes the class meta information, but does <comment>not</comment>
 validate whether the repository contains all required properties for your
@@ -57,7 +57,7 @@ HERE
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -83,11 +83,11 @@ HERE
             $classname
         ));
 
-        $input->setOption('apply-closure', array(
+        $input->setOption('apply-closure', [
             function ($session, $node) use ($newClassname, $documentManager, $mapper) {
                 $mapper->writeMetadata($documentManager, $node, $newClassname);
-            }
-        ));
+            },
+        ]);
 
         return parent::execute($input, $output);
     }

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/DumpQueryBuilderReferenceCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/DumpQueryBuilderReferenceCommand.php
@@ -19,11 +19,11 @@
 
 namespace Doctrine\ODM\PHPCR\Tools\Console\Command;
 
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
 
 /**
  * Command to generate the official query builder reference.
@@ -44,7 +44,7 @@ class DumpQueryBuilderReferenceCommand extends Command
             ->setName('doctrine:phpcr:qb:dump-reference')
             ->addArgument('search', InputArgument::OPTIONAL)
             ->setDescription('Generate the official query builder reference in RST format')
-            ->setHelp(<<<HERE
+            ->setHelp(<<<'HERE'
 This command generates the official query builder reference in RST format, you can optionally
 pass a "search" parameter to limit the reference to only those nodes matching the given regex:
 
@@ -81,24 +81,27 @@ HERE
 
     protected function formatMapRst($map)
     {
-        $f = array(
+        $f = [
             'humanize' => function ($string) {
                 $string = str_replace('_', ' ', $string);
+
                 return ucfirst($string);
             },
             'genRef' => function ($string, $prefix) {
                 $ref = strtolower($string);
+
                 return sprintf(':ref:`%s <qbref_%s_%s>`', $string, $prefix, $ref);
             },
             'genAnc' => function ($string, $prefix) {
                 $ref = strtolower($string);
+
                 return sprintf('.. _qbref_%s_%s:', $prefix, $ref);
             },
             'underline' => function ($string, $underChar = '=') {
                 return str_repeat($underChar, strlen($string));
             },
             'formatDoc' => function ($string) {
-                $out = array();
+                $out = [];
                 $indent = 0;
                 foreach (explode("\n", $string) as $line) {
                     if (false !== strpos($line, '<code>')) {
@@ -115,10 +118,10 @@ HERE
                 }
 
                 return implode("\n", $out);
-            }
-        );
+            },
+        ];
 
-        $out = array();
+        $out = [];
         $out[] = 'Query Builder Reference';
         $out[] = '=======================';
         $out[] = '';
@@ -131,7 +134,7 @@ HERE
         $out[] = '';
         $out[] = '.. Run bin/phpcr-odm doctrine:phpcr:qb:dump-reference to re-generate';
 
-        $nti = array();
+        $nti = [];
         $nti[] = 'Node Type Index';
         $nti[] = '---------------';
         $nti[] = '';
@@ -175,7 +178,7 @@ HERE
                 $out[] = '**Extends**: '.$f['genRef']($nData['parent'], 'node');
                 $out[] = '';
 
-                $inheritedMethodLinks = array();
+                $inheritedMethodLinks = [];
                 foreach ($nData['inheritedMethods'] as $inheritedMethod => $inheritedMethodClass) {
                     $inheritedMethodLinks[] = $f['genRef']($inheritedMethod, 'method_'.strtolower($inheritedMethodClass));
                 }
@@ -234,9 +237,9 @@ HERE
 
     protected function buildMap()
     {
-        $map = array();
-        $nodeMap = array();
-        $nodeTypeIndex = array();
+        $map = [];
+        $nodeMap = [];
+        $nodeTypeIndex = [];
 
         $dirHandle = opendir(__DIR__.'/../../../Query/Builder');
 
@@ -259,7 +262,7 @@ HERE
 
                 $inst = $refl->newInstanceWithoutConstructor();
                 $fMethRetMap = $this->getFactoryMethodMap($refl);
-                $fMethData = array();
+                $fMethData = [];
 
                 foreach ($fMethRetMap as $fMeth => $fmData) {
                     $fmReflMeth = $refl->getMethod($fMeth);
@@ -280,13 +283,13 @@ HERE
                     $fMethDoc = $this->parseDocComment($fmReflMeth->getDocComment(), 0);
                     $fParams = $this->parseDocParams($fmReflMeth);
 
-                    $fMethData[$fMeth] = array(
-                        'args' => $fParams,
-                        'rType' => $fmReturnType,
+                    $fMethData[$fMeth] = [
+                        'args'      => $fParams,
+                        'rType'     => $fmReturnType,
                         'rNodeType' => $fmNodeType,
-                        'fType' => $fmFactoryType,
-                        'doc' => $fMethDoc,
-                    );
+                        'fType'     => $fmFactoryType,
+                        'doc'       => $fMethDoc,
+                    ];
                 }
 
                 $cardinalityMap = $inst->getCardinalityMap();
@@ -294,7 +297,7 @@ HERE
                 $isLeaf = $refl->isSubclassOf(AbstractLeafNode::class);
 
                 $parentName = null;
-                $inheritedMethods = array();
+                $inheritedMethods = [];
 
                 if ($parentRefl = $refl->getParentClass()) {
                     if ($parentRefl->isInstantiable()) {
@@ -312,20 +315,20 @@ HERE
                     }
                 }
 
-                $nodeData = array(
-                    'nodeType' => $inst->getNodeType(),
-                    'parent' => $parentName,
+                $nodeData = [
+                    'nodeType'         => $inst->getNodeType(),
+                    'parent'           => $parentName,
                     'inheritedMethods' => $inheritedMethods,
-                    'doc' => $doc,
-                    'fMeths' => $fMethData,
-                    'cardMap' => $cardinalityMap,
-                    'isLeaf' => $isLeaf,
-                );
+                    'doc'              => $doc,
+                    'fMeths'           => $fMethData,
+                    'cardMap'          => $cardinalityMap,
+                    'isLeaf'           => $isLeaf,
+                ];
 
                 $nodeMap[$refl->getShortName()] = $nodeData;
 
                 if (!isset($nodeTypeMap['nodeTypeMap'][$inst->getNodeType()])) {
-                    $nodeTypeMap[$inst->getNodeType()] = array();
+                    $nodeTypeMap[$inst->getNodeType()] = [];
                 }
 
                 $nodeTypeIndex[$inst->getNodeType()][] = $refl->getShortName();
@@ -342,16 +345,16 @@ HERE
 
     protected function parseDocParams($reflMethod)
     {
-        $params = array();
+        $params = [];
 
         $docComment = $reflMethod->getDocComment();
         $reflParams = $reflMethod->getParameters();
 
         // parse @params
-        $docParams = array();
+        $docParams = [];
         foreach (explode("\n", $docComment) as $line) {
             if (preg_match('&@param +([a-zA-Z]+) ?\$([a-zA-Z0-9_]+) +(.*)&', $line, $matches)) {
-                $docParams[$matches[2]] = array('type' => $matches[1], 'doc' => $matches[3]);
+                $docParams[$matches[2]] = ['type' => $matches[1], 'doc' => $matches[3]];
             }
         }
 
@@ -375,7 +378,7 @@ HERE
 
     protected function parseDocComment($comment, $indent = 0)
     {
-        $out = array();
+        $out = [];
         foreach (explode("\n", $comment) as $line) {
             if (strstr($line, '/**')) {
                 continue;
@@ -400,15 +403,15 @@ HERE
     protected function getFactoryMethodMap($refl)
     {
         $reflMethods = $refl->getMethods();
-        $fMethods = array();
+        $fMethods = [];
 
         foreach ($reflMethods as $rMethod) {
             $comment = $rMethod->getDocComment();
             if (preg_match('&@factoryMethod ([A-Za-z]+)&', $comment, $matches)) {
-                $fMethods[$rMethod->name] = array(
-                    'returnType' => null,
+                $fMethods[$rMethod->name] = [
+                    'returnType'  => null,
                     'factoryType' => null,
-                );
+                ];
 
                 if (!isset($matches[1])) {
                     throw new \Exception(sprintf(

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/GenerateProxiesCommand.php
@@ -20,12 +20,12 @@
 namespace Doctrine\ODM\PHPCR\Tools\Console\Command;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Tools\Console\MetadataFilter;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Doctrine\ODM\PHPCR\Tools\Console\MetadataFilter;
 
 /**
  * Command to (re)generate the proxy classes used by doctrine.
@@ -34,6 +34,7 @@ use Doctrine\ODM\PHPCR\Tools\Console\MetadataFilter;
  *
  * @link    www.doctrine-project.org
  * @since   PHPCR-ODM 1.1
+ *
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
@@ -42,14 +43,14 @@ use Doctrine\ODM\PHPCR\Tools\Console\MetadataFilter;
 class GenerateProxiesCommand extends Command
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function configure()
     {
         $this
         ->setName('doctrine:phpcr:generate-proxies')
         ->setDescription('Generates proxy classes for document classes.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -58,15 +59,15 @@ class GenerateProxiesCommand extends Command
                 'dest-path', InputArgument::OPTIONAL,
                 'The path to generate your proxy classes. If none is provided, the path from the configuration will be used.'
             ),
-        ))
-        ->setHelp(<<<EOT
+        ])
+        ->setHelp(<<<'EOT'
 Generates proxy classes for entity classes.
 EOT
         );
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -81,17 +82,17 @@ EOT
             $destPath = $documentManager->getConfiguration()->getProxyDir();
         }
 
-        if (! is_dir($destPath)) {
+        if (!is_dir($destPath)) {
             mkdir($destPath, 0775, true);
         }
 
         $destPath = realpath($destPath);
 
-        if (! file_exists($destPath)) {
+        if (!file_exists($destPath)) {
             throw new \InvalidArgumentException(
                 sprintf("Proxies destination directory '<info>%s</info>' does not exist.", $documentManager->getConfiguration()->getProxyDir())
             );
-        } elseif (! is_writable($destPath)) {
+        } elseif (!is_writable($destPath)) {
             throw new \InvalidArgumentException(
                 sprintf("Proxies destination directory '<info>%s</info>' does not have write permissions.", $destPath)
             );
@@ -100,7 +101,7 @@ EOT
         if (count($metadatas)) {
             foreach ($metadatas as $metadata) {
                 $output->write(
-                    sprintf('Processing entity "<info>%s</info>"', $metadata->name) . PHP_EOL
+                    sprintf('Processing entity "<info>%s</info>"', $metadata->name).PHP_EOL
                 );
             }
 
@@ -108,9 +109,9 @@ EOT
             $documentManager->getProxyFactory()->generateProxyClasses($metadatas, $destPath);
 
             // Outputting information message
-            $output->write(PHP_EOL . sprintf('Proxy classes generated to "<info>%s</INFO>"', $destPath) . PHP_EOL);
+            $output->write(PHP_EOL.sprintf('Proxy classes generated to "<info>%s</INFO>"', $destPath).PHP_EOL);
         } else {
-            $output->write('No Metadata Classes to process.' . PHP_EOL);
+            $output->write('No Metadata Classes to process.'.PHP_EOL);
         }
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/InfoDoctrineCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/InfoDoctrineCommand.php
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Show information about mapped documents
+ * Show information about mapped documents.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
@@ -37,7 +37,7 @@ class InfoDoctrineCommand extends Command
         $this
             ->setName('doctrine:phpcr:mapping:info')
             ->setDescription('Shows basic information about all mapped documents')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>%command.name%</info> shows basic information about which
 documents exist and possibly if their mapping information contains errors or
 not.
@@ -63,17 +63,17 @@ EOT
             );
         }
 
-        $output->writeln(sprintf("Found <info>%d</info> documents mapped in document manager:", count($documentClassNames)));
+        $output->writeln(sprintf('Found <info>%d</info> documents mapped in document manager:', count($documentClassNames)));
 
         $failure = false;
 
         foreach ($documentClassNames as $documentClassName) {
             try {
                 $documentManager->getClassMetadata($documentClassName);
-                $output->writeln(sprintf("<info>[OK]</info>   %s", $documentClassName));
+                $output->writeln(sprintf('<info>[OK]</info>   %s', $documentClassName));
             } catch (MappingException $e) {
-                $output->writeln("<error>[FAIL]</error> ".$documentClassName);
-                $output->writeln(sprintf("<comment>%s</comment>", $e->getMessage()));
+                $output->writeln('<error>[FAIL]</error> '.$documentClassName);
+                $output->writeln(sprintf('<comment>%s</comment>', $e->getMessage()));
 
                 if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
                     $this->getApplication()->renderException($e, $output);

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/RegisterSystemNodeTypesCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/RegisterSystemNodeTypesCommand.php
@@ -19,13 +19,11 @@
 
 namespace Doctrine\ODM\PHPCR\Tools\Console\Command;
 
+use Doctrine\ODM\PHPCR\NodeTypeRegistrator;
 use PHPCR\SessionInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use PHPCR\Util\Console\Command\NodeTypeRegisterCommand;
-use Doctrine\ODM\PHPCR\Translation\Translation;
-use Doctrine\ODM\PHPCR\NodeTypeRegistrator;
 
 /**
  * Command to register the phcpr-odm required node types.
@@ -41,7 +39,7 @@ class RegisterSystemNodeTypesCommand extends Command
     {
         $this->setName('doctrine:phpcr:register-system-node-types');
         $this->setDescription('Register system node types in the PHPCR repository');
-        $this->setHelp(<<<EOT
+        $this->setHelp(<<<'EOT'
 Register system node types in the PHPCR repository.
 
 This command registers the node types necessary for the ODM to work.
@@ -66,7 +64,7 @@ EOT
             return 1;
         }
 
-        $output->write(PHP_EOL.sprintf('Successfully registered system node types.') . PHP_EOL);
+        $output->write(PHP_EOL.sprintf('Successfully registered system node types.').PHP_EOL);
 
         return 0;
     }

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/VerifyUniqueNodeTypesMappingCommand.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Command/VerifyUniqueNodeTypesMappingCommand.php
@@ -40,7 +40,7 @@ class VerifyUniqueNodeTypesMappingCommand extends Command
         $this
             ->setName('doctrine:phpcr:mapping:verify-unique-node-types')
             ->setDescription('Verify that documents claiming to have unique node types are truly unique')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command checks all mapped PHPCR-ODM documents
 and verifies that any claiming to use unique node types are truly unique.
 EOT
@@ -48,7 +48,7 @@ EOT
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/Helper/DocumentManagerHelper.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/Helper/DocumentManagerHelper.php
@@ -20,11 +20,11 @@
 namespace Doctrine\ODM\PHPCR\Tools\Console\Helper;
 
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
-use PHPCR\Util\Console\Helper\PhpcrHelper;
 use PHPCR\SessionInterface;
+use PHPCR\Util\Console\Helper\PhpcrHelper;
 
 /**
- * Helper class to make DocumentManager available to console command
+ * Helper class to make DocumentManager available to console command.
  */
 class DocumentManagerHelper extends PhpcrHelper
 {
@@ -34,7 +34,7 @@ class DocumentManagerHelper extends PhpcrHelper
     protected $dm;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param SessionInterface         $session
      * @param DocumentManagerInterface $dm

--- a/lib/Doctrine/ODM/PHPCR/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Console/MetadataFilter.php
@@ -25,8 +25,10 @@ namespace Doctrine\ODM\PHPCR\Tools\Console;
  * Copied from Doctrine\ODM\PHPCR\Tools\Console\MetadataFilter
  *
  * @license     http://www.opensource.org/licenses/mit-license.php MIT
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  * @author      Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author      Jonathan Wage <jonwage@gmail.com>
@@ -37,7 +39,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
     /**
      * @var array
      */
-    private $filter = array();
+    private $filter = [];
 
     /**
      * Filter Metadatas by one or more filter options.
@@ -49,7 +51,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
      */
     public static function filter(array $metadatas, $filter)
     {
-        $metadatas = new MetadataFilter(new \ArrayIterator($metadatas), $filter);
+        $metadatas = new self(new \ArrayIterator($metadatas), $filter);
 
         return iterator_to_array($metadatas);
     }

--- a/lib/Doctrine/ODM/PHPCR/Tools/Helper/PrefetchHelper.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Helper/PrefetchHelper.php
@@ -2,10 +2,10 @@
 
 namespace Doctrine\ODM\PHPCR\Tools\Helper;
 
-use PHPCR\NodeInterface;
-use PHPCR\Util\PathHelper;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use PHPCR\NodeInterface;
+use PHPCR\Util\PathHelper;
 
 /**
  * This helper collects information about what nodes will be loaded when
@@ -28,8 +28,8 @@ class PrefetchHelper
         if (!count($nodes)) {
             return;
         }
-        $uuids = array();
-        $paths = array();
+        $uuids = [];
+        $paths = [];
         $documentClassMapper = $dm->getConfiguration()->getDocumentClassMapper();
 
         foreach ($nodes as $node) {
@@ -51,10 +51,10 @@ class PrefetchHelper
     }
 
     /**
-     * Prefetch all mapped ReferenceOne annotations
+     * Prefetch all mapped ReferenceOne annotations.
      *
-     * @param ClassMetadata $class  The metadata about the document to know what to do.
-     * @param NodeInterface $node   The node to prefetch parent and childs for.
+     * @param ClassMetadata $class The metadata about the document to know what to do.
+     * @param NodeInterface $node  The node to prefetch parent and childs for.
      */
     public function prefetchReferences(ClassMetadata $class, NodeInterface $node)
     {
@@ -70,7 +70,7 @@ class PrefetchHelper
      * @param ClassMetadata $class  The metadata about the document to know what to do.
      * @param NodeInterface $node   The node to prefetch parent and childs for.
      * @param string|null   $locale The locale to also prefetch the translation
-     *      child if applicable.
+     *                              child if applicable.
      */
     public function prefetchHierarchy(ClassMetadata $class, NodeInterface $node, $locale = null)
     {
@@ -90,7 +90,7 @@ class PrefetchHelper
      */
     public function collectPrefetchReferences(ClassMetadata $class, NodeInterface $node)
     {
-        $refNodeUUIDs = array();
+        $refNodeUUIDs = [];
         foreach ($class->referenceMappings as $fieldName) {
             $mapping = $class->mappings[$fieldName];
             if (!$node->hasProperty($mapping['property'])) {
@@ -114,13 +114,13 @@ class PrefetchHelper
      * @param ClassMetadata $class  The metadata about the document to know what to do.
      * @param NodeInterface $node   The node to prefetch parent and childs for.
      * @param string|null   $locale The locale to also prefetch the translation
-     *      child if applicable.
+     *                              child if applicable.
      *
      * @return array List of absolute paths to nodes that should be prefetched.
      */
     public function collectPrefetchHierarchy(ClassMetadata $class, NodeInterface $node, $locale = null)
     {
-        $prefetch = array();
+        $prefetch = [];
         if ($class->parentMapping && $node->getDepth() > 0) {
             $prefetch[] = PathHelper::getParentPath($node->getPath());
         }
@@ -129,7 +129,7 @@ class PrefetchHelper
             $prefetch[] = PathHelper::absolutizePath($childName, $node->getPath());
         }
         if ($locale && count($prefetch) && 'child' === $class->translator) {
-            $prefetch[] = $node->getPath() . '/phpcr_locale:'.$locale;
+            $prefetch[] = $node->getPath().'/phpcr_locale:'.$locale;
         }
 
         return $prefetch;

--- a/lib/Doctrine/ODM/PHPCR/Tools/Helper/TranslationConverter.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Helper/TranslationConverter.php
@@ -3,14 +3,14 @@
 namespace Doctrine\ODM\PHPCR\Tools\Helper;
 
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\PHPCRExceptionInterface;
 use Doctrine\ODM\PHPCR\Translation\Translation;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\ChildTranslationStrategy;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\NonTranslatedStrategy;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\TranslationStrategyInterface;
-use Doctrine\ODM\PHPCR\DocumentManagerInterface;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 
 /**
  * Migrate a field that has become translated or changed its translation
@@ -41,7 +41,7 @@ class TranslationConverter
     /**
      * @var array
      */
-    private $notices = array();
+    private $notices = [];
 
     /**
      * @param DocumentManagerInterface $dm
@@ -91,17 +91,17 @@ class TranslationConverter
      * @param string $previousStrategyName Name of previous strategy or "none" if field was not
      *                                     previously translated
      *
-     * @return boolean true if there are more documents to convert and this method needs to be
-     *                      called again.
-     *
      * @throws PHPCRExceptionInterface if the document can not be found.
+     *
+     * @return bool true if there are more documents to convert and this method needs to be
+     *              called again.
      *
      * @see getLastNotices()
      */
     public function convert(
         $class,
         $locales,
-        array $fields = array(),
+        array $fields = [],
         $previousStrategyName = NonTranslatedStrategy::NAME
     ) {
         /** @var ClassMetadata $currentMeta */
@@ -116,13 +116,14 @@ class TranslationConverter
             } else {
                 $message .= sprintf(' Document is currently at %s', $currentStrategyName);
             }
+
             throw new InvalidArgumentException($message);
         }
         if (!count($locales) && NonTranslatedStrategy::NAME !== $currentStrategyName) {
             throw new InvalidArgumentException('When converting to translated content, the locales must be specified.');
         }
 
-        $this->notices = array();
+        $this->notices = [];
         $translated = null;
         foreach ($fields as $field) {
             $current = !empty($currentMeta->mappings[$field]['translated']);
@@ -182,7 +183,7 @@ class TranslationConverter
         // restore meta data to the real thing
         $currentMeta->translator = NonTranslatedStrategy::NAME === $currentStrategyName ? null : $currentStrategyName;
         if (NonTranslatedStrategy::NAME === $currentStrategyName) {
-            $currentMeta->translatableFields = array();
+            $currentMeta->translatableFields = [];
             foreach ($fields as $field) {
                 unset($currentMeta->mappings[$field]['translated']);
             }
@@ -249,7 +250,7 @@ class TranslationConverter
     ) {
         $node = $this->dm->getNodeForDocument($document);
 
-        $data = array();
+        $data = [];
         foreach ($fields as $field) {
             $data[$field] = $currentMeta->getFieldValue($document, $field);
         }

--- a/lib/Doctrine/ODM/PHPCR/Tools/Helper/UniqueNodeTypeHelper.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Helper/UniqueNodeTypeHelper.php
@@ -34,14 +34,14 @@ class UniqueNodeTypeHelper
      *
      * @param DocumentManagerInterface $documentManager The document manager to check mappings for.
      *
-     * @return array
-     *
      * @throws MappingException
+     *
+     * @return array
      */
     public function checkNodeTypeMappings(DocumentManagerInterface $documentManager)
     {
-        $knownNodeTypes = array();
-        $debugInformation = array();
+        $knownNodeTypes = [];
+        $debugInformation = [];
         $allMetadata = $documentManager->getMetadataFactory()->getAllMetadata();
 
         foreach ($allMetadata as $classMetadata) {
@@ -56,10 +56,10 @@ class UniqueNodeTypeHelper
 
             $knownNodeTypes[$classMetadata->getNodeType()] = $classMetadata->name;
 
-            $debugInformation[$classMetadata->name] = array(
+            $debugInformation[$classMetadata->name] = [
                 'unique_node_type' => $classMetadata->hasUniqueNodeType(),
-                'node_type' => $classMetadata->getNodeType()
-            );
+                'node_type'        => $classMetadata->getNodeType(),
+            ];
         }
 
         return $debugInformation;

--- a/lib/Doctrine/ODM/PHPCR/Tools/Test/QueryBuilderTester.php
+++ b/lib/Doctrine/ODM/PHPCR/Tools/Test/QueryBuilderTester.php
@@ -3,9 +3,9 @@
 namespace Doctrine\ODM\PHPCR\Tools\Test;
 
 use Doctrine\ODM\PHPCR\Exception\BadMethodCallException;
-use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 
 /**
  * Utility class to help making test assertions on the query
@@ -35,15 +35,15 @@ class QueryBuilderTester
      *
      * @param string $path
      *
-     * @return AbstractNode
-     *
      * @throws BadMethodCallException
+     *
+     * @return AbstractNode
      */
     public function getNode($path)
     {
         $node = $this->qb;
         $parts = explode('.', $path);
-        $currentPath = array();
+        $currentPath = [];
         $currentNode = $node;
 
         $index = 0;
@@ -93,8 +93,8 @@ class QueryBuilderTester
      */
     public function dumpPaths(AbstractNode $node = null)
     {
-        $children = array();
-        $paths = array();
+        $children = [];
+        $paths = [];
 
         if (null === $node) {
             $node = $this->qb;
@@ -102,7 +102,7 @@ class QueryBuilderTester
 
         foreach ($node->getChildren() as $child) {
             if (!isset($children[$child->getNodeType()])) {
-                $children[$child->getNodeType()] = array();
+                $children[$child->getNodeType()] = [];
             }
 
             $paths[] = $this->getPath($child).' ('.$child->getName().')';
@@ -124,7 +124,7 @@ class QueryBuilderTester
      */
     public function getPath(AbstractNode $node)
     {
-        $path = array();
+        $path = [];
         $currentNode = $node;
 
         do {
@@ -144,7 +144,7 @@ class QueryBuilderTester
      */
     public function getAllNodes(AbstractNode $node = null)
     {
-        $nodes = array();
+        $nodes = [];
         if (!$node) {
             $node = $this->qb;
         }

--- a/lib/Doctrine/ODM/PHPCR/Translation/LocaleChooser/LocaleChooser.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/LocaleChooser/LocaleChooser.php
@@ -31,7 +31,7 @@ use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
 class LocaleChooser implements LocaleChooserInterface
 {
     /**
-     * locale fallback list indexed by source locale
+     * locale fallback list indexed by source locale.
      *
      * example:
      *  array(
@@ -43,7 +43,8 @@ class LocaleChooser implements LocaleChooserInterface
     protected $localePreference;
 
     /**
-     * The current locale to use
+     * The current locale to use.
+     *
      * @var string
      */
     protected $locale;
@@ -57,9 +58,9 @@ class LocaleChooser implements LocaleChooserInterface
     protected $defaultLocale;
 
     /**
-     * @param array $localePreference array of arrays with a preferred locale order list
-     *      for each locale
-     * @param string $defaultLocale the default locale to be used if locale is not set
+     * @param array  $localePreference array of arrays with a preferred locale order list
+     *                                 for each locale
+     * @param string $defaultLocale    the default locale to be used if locale is not set
      */
     public function __construct($localePreference, $defaultLocale)
     {
@@ -67,11 +68,11 @@ class LocaleChooser implements LocaleChooserInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function setLocalePreference($localePreference)
     {
-        if (! isset($localePreference[$this->defaultLocale])) {
+        if (!isset($localePreference[$this->defaultLocale])) {
             throw new MissingTranslationException("The supplied list of locales does not contain '$this->defaultLocale'");
         }
 
@@ -84,9 +85,9 @@ class LocaleChooser implements LocaleChooserInterface
      * Update both parameters at once to be able to specify a new defaultLocale that was previously
      * not contained in the localePreferences.
      *
-     * @param array $localePreference array of arrays with a preferred locale order list
-     *      for each locale
-     * @param string $defaultLocale the default locale to be used if locale is not set
+     * @param array  $localePreference array of arrays with a preferred locale order list
+     *                                 for each locale
+     * @param string $defaultLocale    the default locale to be used if locale is not set
      */
     public function setLocalePreferenceAndDefaultLocale($localePreference, $defaultLocale)
     {
@@ -95,7 +96,7 @@ class LocaleChooser implements LocaleChooserInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function setFallbackLocales($locale, array $order, $replace = false)
     {
@@ -111,7 +112,7 @@ class LocaleChooser implements LocaleChooserInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getFallbackLocales($document, ClassMetadata $metadata, $forLocale = null)
     {
@@ -126,7 +127,7 @@ class LocaleChooser implements LocaleChooserInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDefaultLocalesOrder()
     {
@@ -137,7 +138,7 @@ class LocaleChooser implements LocaleChooserInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getLocale()
     {
@@ -149,13 +150,13 @@ class LocaleChooser implements LocaleChooserInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @throws MissingTranslationException if the specified locale is not defined in the $localePreference array.
      */
     public function setLocale($locale)
     {
-        if (! isset($this->localePreference[$locale])) {
+        if (!isset($this->localePreference[$locale])) {
             $localeBase = substr($locale, 0, 2);
 
             // Strip region from locale if not configured
@@ -172,7 +173,7 @@ class LocaleChooser implements LocaleChooserInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDefaultLocale()
     {

--- a/lib/Doctrine/ODM/PHPCR/Translation/LocaleChooser/LocaleChooserInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/LocaleChooser/LocaleChooserInterface.php
@@ -49,10 +49,10 @@ interface LocaleChooserInterface
      * )
      *
      * @param array $localePreference array of arrays with a preferred locale
-     *      order list for each locale
+     *                                order list for each locale
      *
      * @throws MissingTranslationException if no entry for the default locale
-     *      is found in $localePreference
+     *                                     is found in $localePreference
      */
     public function setLocalePreference($localePreference);
 
@@ -78,9 +78,9 @@ interface LocaleChooserInterface
      *                                 order, e.g. the current request locale.
      *                                 If null, the default locale is to be used.
      *
-     * @return array $preferredLocales
-     *
      * @throws MissingTranslationException
+     *
+     * @return array $preferredLocales
      */
     public function getFallbackLocales($document, ClassMetadata $metadata, $forLocale = null);
 

--- a/lib/Doctrine/ODM/PHPCR/Translation/MissingTranslationException.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/MissingTranslationException.php
@@ -22,11 +22,13 @@ namespace Doctrine\ODM\PHPCR\Translation;
 use Doctrine\ODM\PHPCR\PHPCRException;
 
 /**
- * Missing translation exception class
+ * Missing translation exception class.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Lukas Kahwe Smith <smith@pooteeweet.org>
  */
 class MissingTranslationException extends PHPCRException

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AbstractTranslationStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AbstractTranslationStrategy.php
@@ -24,8 +24,10 @@ use Doctrine\ODM\PHPCR\Translation\Translation;
 
 /**
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Daniel Barsotti <daniel.barsotti@liip.ch>
  */
 abstract class AbstractTranslationStrategy implements TranslationStrategyInterface
@@ -48,7 +50,7 @@ abstract class AbstractTranslationStrategy implements TranslationStrategyInterfa
     }
 
     /**
-     * Set the namespace alias for translation extra properties
+     * Set the namespace alias for translation extra properties.
      *
      * @param string $prefix
      */
@@ -71,7 +73,7 @@ abstract class AbstractTranslationStrategy implements TranslationStrategyInterfa
     }
 
     /**
-     * Determine the locale specific property names for an assoc property
+     * Determine the locale specific property names for an assoc property.
      *
      * @param string $locale
      * @param array  $mapping the mapping for the property
@@ -80,10 +82,10 @@ abstract class AbstractTranslationStrategy implements TranslationStrategyInterfa
      */
     public function getTranslatedPropertyNameAssoc($locale, $mapping)
     {
-        return array(
-            'property' => $this->getTranslatedPropertyName($locale, $mapping['property']),
-            'assoc' => $this->getTranslatedPropertyName($locale, $mapping['assoc']),
-            'assocNulls' => $this->getTranslatedPropertyName($locale, $mapping['assocNulls'])
-        );
+        return [
+            'property'   => $this->getTranslatedPropertyName($locale, $mapping['property']),
+            'assoc'      => $this->getTranslatedPropertyName($locale, $mapping['assoc']),
+            'assocNulls' => $this->getTranslatedPropertyName($locale, $mapping['assocNulls']),
+        ];
     }
 }

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php
@@ -20,24 +20,27 @@
 namespace Doctrine\ODM\PHPCR\Translation\TranslationStrategy;
 
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use PHPCR\NodeInterface;
 use Doctrine\ODM\PHPCR\Translation\Translation;
+use PHPCR\NodeInterface;
 use PHPCR\Query\QOM\ConstraintInterface;
 use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Query\QOM\SourceInterface;
 
 /**
  * Translation strategy that stores the translations in attributes of the same node.
+ *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Daniel Barsotti <daniel.barsotti@liip.ch>
  * @author      David Buchmann <david@liip.ch>
  */
 class AttributeTranslationStrategy extends AbstractTranslationStrategy
 {
     /**
-     * Identifier of this strategy
+     * Identifier of this strategy.
      */
     const NAME = 'attribute';
 
@@ -49,7 +52,7 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
     public function saveTranslation(array $data, NodeInterface $node, ClassMetadata $metadata, $locale)
     {
         // no need to validate non-nullable condition, the UoW does that for all fields
-        $nullFields = array();
+        $nullFields = [];
         foreach ($data as $field => $propValue) {
             $mapping = $metadata->mappings[$field];
             $propName = $this->getTranslatedPropertyName($locale, $mapping['property']);
@@ -71,7 +74,7 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
         if (empty($nullFields)) {
             $nullFields = null;
         }
-        $node->setProperty($this->prefix . ':' . $locale . self::NULLFIELDS, $nullFields); // no '-' to avoid name clashes
+        $node->setProperty($this->prefix.':'.$locale.self::NULLFIELDS, $nullFields); // no '-' to avoid name clashes
     }
 
     /**
@@ -86,7 +89,7 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
      */
     private function checkHasFields(NodeInterface $node, ClassMetadata $metadata, $locale)
     {
-        if ($node->hasProperty($this->prefix . ':' . $locale . self::NULLFIELDS)) {
+        if ($node->hasProperty($this->prefix.':'.$locale.self::NULLFIELDS)) {
             return true;
         }
 
@@ -128,7 +131,7 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
                 }
             } else {
                 // A null field or a missing field
-                $value = ($metadata->mappings[$field]['multivalue']) ? array() : null;
+                $value = ($metadata->mappings[$field]['multivalue']) ? [] : null;
             }
 
             $metadata->reflFields[$field]->setValue($document, $value);
@@ -158,8 +161,8 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
             }
         }
 
-        if ($node->hasProperty($this->prefix . ':' . $locale . self::NULLFIELDS)) {
-            $node->setProperty($this->prefix . ':' . $locale . self::NULLFIELDS, null);
+        if ($node->hasProperty($this->prefix.':'.$locale.self::NULLFIELDS)) {
+            $node->setProperty($this->prefix.':'.$locale.self::NULLFIELDS, null);
         }
     }
 
@@ -183,10 +186,10 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
      */
     public function getLocalesFor($document, NodeInterface $node, ClassMetadata $metadata)
     {
-        $locales = array();
-        foreach ($node->getProperties($this->prefix . ':*') as $prop) {
+        $locales = [];
+        foreach ($node->getProperties($this->prefix.':*') as $prop) {
             $matches = null;
-            if (preg_match('/' . $this->prefix . ':([a-zA-Z1-9_]+)-/', $prop->getName(), $matches)) {
+            if (preg_match('/'.$this->prefix.':([a-zA-Z1-9_]+)-/', $prop->getName(), $matches)) {
                 if (is_array($matches) && count($matches) > 1 && !in_array($matches[1], $locales)) {
                     $locales[] = $matches[1];
                 }
@@ -197,17 +200,17 @@ class AttributeTranslationStrategy extends AbstractTranslationStrategy
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * Translated properties are on the same node, but have a different name.
      */
     public function getTranslatedPropertyPath($alias, $propertyName, $locale)
     {
-        return array($alias, $this->getTranslatedPropertyName($locale, $propertyName));
+        return [$alias, $this->getTranslatedPropertyName($locale, $propertyName)];
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * Nothing to do, the properties are on the same node.
      */

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/ChildTranslationStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/ChildTranslationStrategy.php
@@ -30,16 +30,19 @@ use PHPCR\SessionInterface;
 
 /**
  * Translation strategy that stores the translations in a child nodes of the current node.
+ *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      Daniel Barsotti <daniel.barsotti@liip.ch>
  * @author      David Buchmann <david@liip.ch>
  */
 class ChildTranslationStrategy extends AttributeTranslationStrategy implements TranslationNodesWarmer
 {
     /**
-     * Identifier of this strategy
+     * Identifier of this strategy.
      */
     const NAME = 'child';
 
@@ -90,11 +93,11 @@ class ChildTranslationStrategy extends AttributeTranslationStrategy implements T
      */
     public function getLocalesFor($document, NodeInterface $node, ClassMetadata $metadata)
     {
-        $translations = $node->getNodes(Translation::LOCALE_NAMESPACE . ':*');
-        $locales = array();
+        $translations = $node->getNodes(Translation::LOCALE_NAMESPACE.':*');
+        $locales = [];
         foreach ($translations as $name => $node) {
             if ($p = strpos($name, ':')) {
-                $locales[] = substr($name, $p+1);
+                $locales[] = substr($name, $p + 1);
             }
         }
 
@@ -107,15 +110,15 @@ class ChildTranslationStrategy extends AttributeTranslationStrategy implements T
      *
      * @param NodeInterface $parentNode
      * @param string        $locale
-     * @param boolean       $create      whether to create the node if it is
-     *      not yet existing
+     * @param bool          $create     whether to create the node if it is
+     *                                  not yet existing
      *
-     * @return boolean|NodeInterface the node or false if $create is false and
-     *      the node is not existing.
+     * @return bool|NodeInterface the node or false if $create is false and
+     *                            the node is not existing.
      */
     protected function getTranslationNode(NodeInterface $parentNode, $locale, $create = true)
     {
-        $name = Translation::LOCALE_NAMESPACE . ":$locale";
+        $name = Translation::LOCALE_NAMESPACE.":$locale";
         if (!$parentNode->hasNode($name)) {
             if (!$create) {
                 return false;
@@ -129,7 +132,7 @@ class ChildTranslationStrategy extends AttributeTranslationStrategy implements T
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * We namespace the property by putting it in a different node, the name
      * itself does not change.
@@ -140,7 +143,7 @@ class ChildTranslationStrategy extends AttributeTranslationStrategy implements T
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * We need to select the field on the joined child node.
      */
@@ -148,11 +151,11 @@ class ChildTranslationStrategy extends AttributeTranslationStrategy implements T
     {
         $childAlias = sprintf('_%s_%s', $locale, $alias);
 
-        return array($childAlias, $this->getTranslatedPropertyName($locale, $propertyName));
+        return [$childAlias, $this->getTranslatedPropertyName($locale, $propertyName)];
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * Join document with translation children, and filter on the right child
      * node.
@@ -176,7 +179,7 @@ class ChildTranslationStrategy extends AttributeTranslationStrategy implements T
         $languageConstraint = $qomf->comparison(
             $qomf->nodeName($childAlias),
             QueryObjectModelConstantsInterface::JCR_OPERATOR_EQUAL_TO,
-            $qomf->literal(Translation::LOCALE_NAMESPACE . ":$locale")
+            $qomf->literal(Translation::LOCALE_NAMESPACE.":$locale")
         );
 
         if ($constraint) {
@@ -190,11 +193,11 @@ class ChildTranslationStrategy extends AttributeTranslationStrategy implements T
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTranslationsForNodes($nodes, $locales, SessionInterface $session)
     {
-        $absolutePaths = array();
+        $absolutePaths = [];
 
         foreach ($locales as $locale) {
             foreach ($nodes as $node) {

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/NonTranslatedStrategy.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/NonTranslatedStrategy.php
@@ -29,17 +29,19 @@ use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Query\QOM\SourceInterface;
 
 /**
- * A dummy translation strategy for non-translated fields
+ * A dummy translation strategy for non-translated fields.
  *
  * @license     http://www.opensource.org/licenses/MIT-license.php MIT license
+ *
  * @link        www.doctrine-project.com
  * @since       1.0
+ *
  * @author      David Buchmann <mail@davidbu.ch>
  */
 class NonTranslatedStrategy implements TranslationStrategyInterface
 {
     /**
-     * Identifier of this strategy
+     * Identifier of this strategy.
      */
     const NAME = 'none';
 
@@ -57,7 +59,7 @@ class NonTranslatedStrategy implements TranslationStrategyInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function saveTranslation(array $data, NodeInterface $node, ClassMetadata $metadata, $locale)
     {
@@ -77,7 +79,7 @@ class NonTranslatedStrategy implements TranslationStrategyInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function loadTranslation($document, NodeInterface $node, ClassMetadata $metadata, $locale)
     {
@@ -85,7 +87,7 @@ class NonTranslatedStrategy implements TranslationStrategyInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      *
      * Remove the (untranslated) fields listed in $metadata->translatableFields
      */
@@ -98,7 +100,7 @@ class NonTranslatedStrategy implements TranslationStrategyInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      *
      * This will remove all fields that are now declared as translated
      */
@@ -108,7 +110,7 @@ class NonTranslatedStrategy implements TranslationStrategyInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getLocalesFor($document, NodeInterface $node, ClassMetadata $metadata)
     {
@@ -116,15 +118,15 @@ class NonTranslatedStrategy implements TranslationStrategyInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getTranslatedPropertyPath($alias, $propertyName, $locale)
     {
-        return array($alias, $propertyName);
+        return [$alias, $propertyName];
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function alterQueryForTranslation(
         QueryObjectModelFactoryInterface $qomf,

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/TranslationNodesWarmer.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/TranslationNodesWarmer.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\ODM\PHPCR\Translation\TranslationStrategy;
 
 use PHPCR\NodeInterface;
@@ -20,9 +19,10 @@ interface TranslationNodesWarmer
      * but the main purpose of it is to warm up all translation
      * nodes in one request to PHPCR.
      *
-     * @param NodeInterface[] $nodes
-     * @param array $locales
+     * @param NodeInterface[]  $nodes
+     * @param array            $locales
      * @param SessionInterface $session
+     *
      * @return mixed
      */
     public function getTranslationsForNodes($nodes, $locales, SessionInterface $session);

--- a/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/TranslationStrategyInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/TranslationStrategyInterface.php
@@ -34,7 +34,7 @@ use PHPCR\Query\QOM\SourceInterface;
 interface TranslationStrategyInterface
 {
     /**
-     * Save the translatable fields of a node
+     * Save the translatable fields of a node.
      *
      * @param array         $data     Data to save (field name => value to persist)
      * @param NodeInterface $node     The physical node in the content repository
@@ -54,7 +54,7 @@ interface TranslationStrategyInterface
      * @param ClassMetadata $metadata The Doctrine metadata of the document
      * @param string        $locale   The language to load the translations from
      *
-     * @return boolean true if the translation was completely loaded, false otherwise
+     * @return bool true if the translation was completely loaded, false otherwise
      */
     public function loadTranslation($document, NodeInterface $node, ClassMetadata $metadata, $locale);
 
@@ -69,7 +69,7 @@ interface TranslationStrategyInterface
     public function removeAllTranslations($document, NodeInterface $node, ClassMetadata $metadata);
 
     /**
-     * Remove the translated fields of a node in a given language
+     * Remove the translated fields of a node in a given language.
      *
      * The document object is not altered by this operation.
      *
@@ -81,7 +81,7 @@ interface TranslationStrategyInterface
     public function removeTranslation($document, NodeInterface $node, ClassMetadata $metadata, $locale);
 
     /**
-     * Get the list of locales persisted for this node
+     * Get the list of locales persisted for this node.
      *
      * @param object        $document The document that must be checked
      * @param NodeInterface $node     The Physical node in the content repository
@@ -90,6 +90,7 @@ interface TranslationStrategyInterface
      * @return array with the locales strings
      */
     public function getLocalesFor($document, NodeInterface $node, ClassMetadata $metadata);
+
     /**
      * Get the location of the property for the base property name in a given
      * language.
@@ -113,7 +114,7 @@ interface TranslationStrategyInterface
      * generate a different query.
      *
      * @param QueryObjectModelFactoryInterface $qomf       The PHPCR query factory.
-     * @param SourceInterface                $selector   The current selector.
+     * @param SourceInterface                  $selector   The current selector.
      * @param ConstraintInterface|null         $constraint The current constraint, may be empty.
      * @param string                           $alias      The selector alias of the main node.
      * @param string                           $locale     The language to use.

--- a/lib/Doctrine/ODM/PHPCR/Version.php
+++ b/lib/Doctrine/ODM/PHPCR/Version.php
@@ -20,12 +20,12 @@
 namespace Doctrine\ODM\PHPCR;
 
 /**
- * Class to mark the current version of the PHPCR ODM
+ * Class to mark the current version of the PHPCR ODM.
  */
 class Version
 {
     /**
-     * Current version of PHPCR ODM
+     * Current version of PHPCR ODM.
      */
     const VERSION = '2.0-dev';
 }

--- a/tests/Doctrine/Tests/Models/Blog/Comment.php
+++ b/tests/Doctrine/Tests/Models/Blog/Comment.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\Models\Blog;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * Comment will be a child of the Post in the test scenario
+ * Comment will be a child of the Post in the test scenario.
  *
  * Used for Join tests
  *

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -4,9 +4,9 @@ namespace Documents;
 
 namespace Doctrine\Tests\Models\CMS;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsAddressRepository", referenceable=true)
@@ -70,9 +70,10 @@ class CmsAddress
 class CmsAddressRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/Models/CMS/CmsArticleFolder.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsArticleFolder.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\Models\CMS;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**

--- a/tests/Doctrine/Tests/Models/CMS/CmsArticlePerson.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsArticlePerson.php
@@ -3,9 +3,9 @@
 namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsArticlePersonRepository", referenceable=true)
@@ -76,9 +76,10 @@ class CmsArticlePerson
 class CmsArticlePersonRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/Models/CMS/CmsBlogFolder.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsBlogFolder.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\Models\CMS;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**

--- a/tests/Doctrine/Tests/Models/CMS/CmsBlogInvalidChild.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsBlogInvalidChild.php
@@ -5,8 +5,6 @@ namespace Documents;
 namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
-use Doctrine\ODM\PHPCR\DocumentRepository;
-use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 
 /**
  * @PHPCRODM\Document()

--- a/tests/Doctrine/Tests/Models/CMS/CmsBlogPost.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsBlogPost.php
@@ -5,8 +5,6 @@ namespace Documents;
 namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
-use Doctrine\ODM\PHPCR\DocumentRepository;
-use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 
 /**
  * @PHPCRODM\Document(isLeaf=true)

--- a/tests/Doctrine/Tests/Models/CMS/CmsItem.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsItem.php
@@ -2,10 +2,9 @@
 
 namespace Doctrine\Tests\Models\CMS;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsItemRepository", referenceable=true)
@@ -21,7 +20,6 @@ class CmsItem
     /** @PHPCRODM\ReferenceOne(strategy="hard", cascade="persist") */
     public $documentTarget;
 
-
     public function getId()
     {
         return $this->id;
@@ -30,6 +28,7 @@ class CmsItem
     public function setDocumentTarget($documentTarget)
     {
         $this->documentTarget = $documentTarget;
+
         return $this;
     }
 
@@ -41,6 +40,7 @@ class CmsItem
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -53,9 +53,10 @@ class CmsItem
 class CmsItemRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/Models/CMS/CmsPage.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsPage.php
@@ -2,10 +2,9 @@
 
 namespace Doctrine\Tests\Models\CMS;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsPageRepository", referenceable=true)
@@ -21,7 +20,7 @@ class CmsPage
     /** @PHPCRODM\Field(type="string") */
     public $title;
     /** @PHPCRODM\MixedReferrers(referenceType="hard") */
-    public $items = array();
+    public $items = [];
 
     public function getId()
     {
@@ -31,6 +30,7 @@ class CmsPage
     public function setContent($content)
     {
         $this->content = $content;
+
         return $this;
     }
 
@@ -42,6 +42,7 @@ class CmsPage
     public function setTitle($title)
     {
         $this->title = $title;
+
         return $this;
     }
 
@@ -53,6 +54,7 @@ class CmsPage
     public function setItems($items)
     {
         $this->items = $items;
+
         return $this;
     }
 
@@ -79,9 +81,10 @@ class CmsPage
 class CmsPageRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/Models/CMS/CmsPageTranslatable.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsPageTranslatable.php
@@ -2,10 +2,9 @@
 
 namespace Doctrine\Tests\Models\CMS;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsPageTranslatableRepository", referenceable=true, translator="attribute")
@@ -40,7 +39,7 @@ class CmsPageTranslatable
     /**
      * @PHPCRODM\MixedReferrers(referenceType="hard")
      */
-    public $items = array();
+    public $items = [];
 
     public function getId()
     {
@@ -50,6 +49,7 @@ class CmsPageTranslatable
     public function setContent($content)
     {
         $this->content = $content;
+
         return $this;
     }
 
@@ -61,6 +61,7 @@ class CmsPageTranslatable
     public function setTitle($title)
     {
         $this->title = $title;
+
         return $this;
     }
 
@@ -72,6 +73,7 @@ class CmsPageTranslatable
     public function setItems($items)
     {
         $this->items = $items;
+
         return $this;
     }
 
@@ -108,10 +110,11 @@ class CmsPageTranslatable
 class CmsPageTranslatableRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
-     * @param null $parent
+     * @param null   $parent
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/Models/CMS/CmsProfile.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsProfile.php
@@ -62,13 +62,14 @@ class CmsProfile
 class CmsProfileRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)
     {
-        return '/functional/' . $document->user->username . '/' . $document->data;
+        return '/functional/'.$document->user->username.'/'.$document->data;
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsTeamUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsTeamUser.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\Tests\Models\CMS;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsTeamUserRepository")
@@ -30,9 +30,10 @@ class CmsTeamUser extends CmsUser
 class CmsTeamUserRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -3,9 +3,9 @@
 namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsUserRepository", referenceable=true)
@@ -100,9 +100,10 @@ class CmsUser
 class CmsUserRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/Models/CMS/CmsUserTranslatable.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUserTranslatable.php
@@ -3,9 +3,9 @@
 namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\Models\CMS\CmsUserTranslatableRepository", translator="attribute", referenceable=true)
@@ -85,13 +85,13 @@ class CmsUserTranslatable
     }
 }
 
-
 class CmsUserTranslatableRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/Models/ECommerce/ECommerceCart.php
+++ b/tests/Doctrine/Tests/Models/ECommerce/ECommerceCart.php
@@ -12,25 +12,17 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class ECommerceCart
 {
-    /**
-     */
     private $id;
 
-    /**
-     */
     private $payment;
 
-    /**
-     */
     private $customer;
 
-    /**
-     */
     private $products;
 
     public function __construct()
     {
-        $this->products = new ArrayCollection;
+        $this->products = new ArrayCollection();
     }
 
     public function getId()

--- a/tests/Doctrine/Tests/Models/Translation/Article.php
+++ b/tests/Doctrine/Tests/Models/Translation/Article.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Tests\Models\Translation;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(translator="attribute", referenceable=true)
@@ -49,7 +49,7 @@ class Article
     public $child;
 
     /** @PHPCRODM\ReferenceMany() */
-    public $relatedArticles = array();
+    public $relatedArticles = [];
 
     /** @PHPCRODM\Field(type="string", translated=true, nullable=true) */
     public $nullable;
@@ -79,6 +79,7 @@ class Article
     {
         return $this->text;
     }
+
     public function setText($text)
     {
         $this->text = $text;
@@ -93,7 +94,7 @@ class Article
     }
 
     /**
-     * Sets the children
+     * Sets the children.
      *
      * @param $children ArrayCollection
      */
@@ -103,17 +104,17 @@ class Article
     }
 
     /**
-     * Set settings
+     * Set settings.
      *
      * @param array $settings
      */
-    public function setSettings(array $settings = array())
+    public function setSettings(array $settings = [])
     {
         $this->settings = $settings;
     }
 
     /**
-     * Get settings
+     * Get settings.
      *
      * @return array $settings
      */

--- a/tests/Doctrine/Tests/Models/Translation/ChildTranslationArticle.php
+++ b/tests/Doctrine/Tests/Models/Translation/ChildTranslationArticle.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\Models\Translation;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
-use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @PHPCRODM\Document(translator="child", referenceable=true)

--- a/tests/Doctrine/Tests/Models/Translation/DerivedArticle.php
+++ b/tests/Doctrine/Tests/Models/Translation/DerivedArticle.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Doctrine\Tests\Models\Translation;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
-use Doctrine\Tests\Models\Translation\Article;
 
 /**
  * @PHPCRODM\Document

--- a/tests/Doctrine/Tests/Models/Translation/NoLocalePropertyArticle.php
+++ b/tests/Doctrine/Tests/Models/Translation/NoLocalePropertyArticle.php
@@ -11,7 +11,6 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
  *
  * This class is invalid as it uses an invalid key for the @PHPCRODM\Document(translator) annotation.
  * This class is supposed to throw an exception when it is read by the ODM !!!
- *
  */
 
 /**

--- a/tests/Doctrine/Tests/Models/Versioning/ExtendedVersionableArticle.php
+++ b/tests/Doctrine/Tests/Models/Versioning/ExtendedVersionableArticle.php
@@ -22,6 +22,7 @@ class ExtendedVersionableArticle extends FullVersionableArticle
     {
         return $this->text;
     }
+
     public function setText($text)
     {
         $this->text = $text;

--- a/tests/Doctrine/Tests/Models/Versioning/FullVersionableArticle.php
+++ b/tests/Doctrine/Tests/Models/Versioning/FullVersionableArticle.php
@@ -27,11 +27,11 @@ class FullVersionableArticle
     /** @PHPCRODM\VersionCreated */
     public $versionCreated;
 
-
     public function getText()
     {
         return $this->text;
     }
+
     public function setText($text)
     {
         $this->text = $text;

--- a/tests/Doctrine/Tests/Models/Versioning/FullVersionableArticleWithChildren.php
+++ b/tests/Doctrine/Tests/Models/Versioning/FullVersionableArticleWithChildren.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Doctrine\Tests\Models\Versioning;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * @PHPCRODM\Document(versionable="full")

--- a/tests/Doctrine/Tests/Models/Versioning/InconsistentVersionableArticle.php
+++ b/tests/Doctrine/Tests/Models/Versioning/InconsistentVersionableArticle.php
@@ -5,7 +5,8 @@ namespace Doctrine\Tests\Models\Versioning;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * This document has a Version annotated field but it is not marked as versionable
+ * This document has a Version annotated field but it is not marked as versionable.
+ *
  * @PHPCRODM\Document
  */
 class InconsistentVersionableArticle
@@ -29,6 +30,7 @@ class InconsistentVersionableArticle
     {
         return $this->text;
     }
+
     public function setText($text)
     {
         $this->text = $text;

--- a/tests/Doctrine/Tests/Models/Versioning/InvalidVersionableArticle.php
+++ b/tests/Doctrine/Tests/Models/Versioning/InvalidVersionableArticle.php
@@ -25,6 +25,7 @@ class InvalidVersionableArticle
     {
         return $this->text;
     }
+
     public function setText($text)
     {
         $this->text = $text;

--- a/tests/Doctrine/Tests/Models/Versioning/NonVersionableArticle.php
+++ b/tests/Doctrine/Tests/Models/Versioning/NonVersionableArticle.php
@@ -25,6 +25,7 @@ class NonVersionableArticle
     {
         return $this->text;
     }
+
     public function setText($text)
     {
         $this->text = $text;

--- a/tests/Doctrine/Tests/Models/Versioning/VersionableArticle.php
+++ b/tests/Doctrine/Tests/Models/Versioning/VersionableArticle.php
@@ -25,6 +25,7 @@ class VersionableArticle
     {
         return $this->text;
     }
+
     public function setText($text)
     {
         $this->text = $text;

--- a/tests/Doctrine/Tests/ODM/PHPCR/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/ConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Doctrine\Tests\ODM\PHPCR;
 
 use Doctrine\ODM\PHPCR\Configuration;
@@ -23,7 +24,7 @@ class ConfigurationTest extends PHPCRTestCase
 
         $config = new Configuration();
 
-        $config->setDocumentNamespaces(array('foo' => 'Documents\Bar'));
+        $config->setDocumentNamespaces(['foo' => 'Documents\Bar']);
         $this->assertEquals('Documents\Bar', $config->getDocumentNamespace('foo'));
 
         $this->expectException(PHPCRException::class);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Decorator/DocumentManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Decorator/DocumentManagerDecoratorTest.php
@@ -4,8 +4,8 @@ namespace Doctrine\Tests\ODM\PHPCR\Decorator;
 
 use Doctrine\ODM\PHPCR\Decorator\DocumentManagerDecorator;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 
 /**
  * @group unit
@@ -15,15 +15,15 @@ class DocumentManagerDecoratorTest extends PHPCRTestCase
     public function testCheckIfAllPublicMethodsAreDecorated()
     {
         $dmMethods = get_class_methods(DocumentManager::class);
-        $dmMethods = array_diff($dmMethods, array('__construct', 'create'));
+        $dmMethods = array_diff($dmMethods, ['__construct', 'create']);
         sort($dmMethods);
 
         $dmiMethods = get_class_methods(DocumentManagerInterface::class);
-        $dmiMethods = array_diff($dmiMethods, array('__construct'));
+        $dmiMethods = array_diff($dmiMethods, ['__construct']);
         sort($dmiMethods);
 
         $dmdMethods = get_class_methods(OwnDocumentManager::class);
-        $dmdMethods = array_diff($dmdMethods, array('__construct'));
+        $dmdMethods = array_diff($dmdMethods, ['__construct']);
         sort($dmdMethods);
 
         $this->assertEquals($dmMethods, $dmiMethods);

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentClassMapperTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentClassMapperTest.php
@@ -7,12 +7,12 @@ use Doctrine\ODM\PHPCR\DocumentClassMapper;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Exception\ClassMismatchException;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use PHPCR\NodeInterface;
-use PHPCR\PropertyType;
-use PHPUnit\Framework\TestCase;
 use Doctrine\ODM\PHPCR\UnitOfWork;
 use Jackalope\Node;
 use Jackalope\Property;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
+use PHPUnit\Framework\TestCase;
 
 class DocumentClassMapperTest extends Testcase
 {
@@ -87,18 +87,15 @@ class DocumentClassMapperTest extends Testcase
         $property = $this->createMock(Property::class);
         $property->expects($this->once())
             ->method('getString')
-            ->will($this->returnValue($class))
-        ;
+            ->will($this->returnValue($class));
         $this->node->expects($this->once())
             ->method('hasProperty')
             ->with('phpcr:class')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $this->node->expects($this->once())
             ->method('getProperty')
             ->with('phpcr:class')
-            ->will($this->returnValue($property))
-        ;
+            ->will($this->returnValue($property));
     }
 
     public function testGetClassNameNull()
@@ -153,7 +150,7 @@ class DocumentClassMapperTest extends Testcase
 
     public function testWriteMetadata()
     {
-        $parentClasses = array(self::CLASS_TEST_2, self::CLASS_TEST_3);
+        $parentClasses = [self::CLASS_TEST_2, self::CLASS_TEST_3];
 
         $this->node->expects($this->at(0))
             ->method('setProperty')
@@ -191,22 +188,20 @@ class DocumentClassMapperTest extends Testcase
         $uow->expects($this->once())
             ->method('determineDocumentId')
             ->with($generic)
-            ->will($this->returnValue('/id'))
-        ;
+            ->will($this->returnValue('/id'));
         $this->dm->expects($this->once())
             ->method('getUnitOfWork')
-            ->will($this->returnValue($uow))
-        ;
+            ->will($this->returnValue($uow));
         $this->expectException(ClassMismatchException::class);
         $this->mapper->validateClassName($this->dm, $generic, 'Other\Class');
     }
 
     public function provideExpandClassName()
     {
-        return array(
-            array('Foobar/BarFoo/Document/Foobar', 'Foobar/BarFoo/Document/Foobar', false),
-            array('Foobar:Barfoo', 'Foobar\Barfoo', true),
-        );
+        return [
+            ['Foobar/BarFoo/Document/Foobar', 'Foobar/BarFoo/Document/Foobar', false],
+            ['Foobar:Barfoo', 'Foobar\Barfoo', true],
+        ];
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
@@ -4,20 +4,18 @@ namespace Doctrine\Tests\ODM\PHPCR;
 
 use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\ODM\PHPCR\PHPCRException;
-use PHPCR\ItemNotFoundException;
-use PHPCR\SessionInterface;
-use PHPCR\Transaction\UserTransactionInterface;
-use PHPCR\UnsupportedRepositoryOperationException;
-use PHPCR\Util\UUIDHelper;
-use PHPCR\WorkspaceInterface;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\DocumentRepository;
-use PHPCR\Query\QueryManagerInterface;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\PHPCR\PHPCRException;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use PHPCR\ItemNotFoundException;
 use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Query\QueryInterface;
-use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use PHPCR\Query\QueryManagerInterface;
+use PHPCR\SessionInterface;
+use PHPCR\Util\UUIDHelper;
+use PHPCR\WorkspaceInterface;
 
 /**
  * @group unit
@@ -30,7 +28,7 @@ class DocumentManagerTest extends PHPCRTestCase
     public function testFind()
     {
         $fakeUuid = UUIDHelper::generateUUID();
-        $session = $this->getMockForAbstractClass(SessionInterface::class, array('getNodeByIdentifier'));
+        $session = $this->getMockForAbstractClass(SessionInterface::class, ['getNodeByIdentifier']);
         $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
         $config = new Configuration();
 
@@ -47,7 +45,7 @@ class DocumentManagerTest extends PHPCRTestCase
     public function testFindTranslation()
     {
         $fakeUuid = UUIDHelper::generateUUID();
-        $session = $this->getMockForAbstractClass(SessionInterface::class, array('getNodeByIdentifier'));
+        $session = $this->getMockForAbstractClass(SessionInterface::class, ['getNodeByIdentifier']);
         $session->expects($this->once())->method('getNodeByIdentifier')->will($this->throwException(new ItemNotFoundException(sprintf('403: %s', $fakeUuid))));
         $config = new Configuration();
 
@@ -109,7 +107,7 @@ class DocumentManagerTest extends PHPCRTestCase
 
         $dm = DocumentManager::create($session);
 
-        $obj = new \stdClass;
+        $obj = new \stdClass();
         $uow = $dm->getUnitOfWork();
 
         $method = new \ReflectionMethod($uow, 'registerDocument');
@@ -170,7 +168,6 @@ class DocumentManagerTest extends PHPCRTestCase
             ->method('getQOMFactory')
             ->will($this->returnValue($qomf));
 
-
         $dm = DocumentManager::create($session);
         $qb = $dm->createQueryBuilder();
         $this->assertInstanceOf(QueryBuilder::class, $qb);
@@ -182,12 +179,12 @@ class DocumentManagerTest extends PHPCRTestCase
 
         $dm = DocumentManager::create($session);
 
-        $obj = new \stdClass;
+        $obj = new \stdClass();
         $uow = $dm->getUnitOfWork();
 
         $reflectionProperty = new \ReflectionProperty($uow, 'documentIds');
         $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($uow, array(spl_object_hash($obj) => '/foo'));
+        $reflectionProperty->setValue($uow, [spl_object_hash($obj) => '/foo']);
         $reflectionProperty->setAccessible(false);
 
         $this->assertEquals('/foo', $dm->getDocumentId($obj));
@@ -198,7 +195,7 @@ class DocumentManagerTest extends PHPCRTestCase
         /** @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject $session */
         $session = $this->createMock(SessionInterface::class);
         $dm = DocumentManager::create($session);
-        $obj = new \stdClass;
+        $obj = new \stdClass();
         $this->expectException(PHPCRException::class);
         $dm->getDocumentId($obj);
     }
@@ -209,23 +206,25 @@ class DocumentManagerGetClassMetadata extends DocumentManager
     private $callCount = 0;
 
     /**
-     * @param  string $class
+     * @param string $class
+     *
      * @return ClassMetadata
      */
     public function getClassMetadata($class)
     {
-        ++$this->callCount;
+        $this->callCount++;
         $metadata = new ClassMetadata('stdClass');
         switch ($this->callCount) {
             case '1':
                 break;
             case '2':
-                $metadata->customRepositoryClassName = "stdClass";
+                $metadata->customRepositoryClassName = 'stdClass';
                 break;
             default:
                 throw new \Exception('getClassMetadata called more than 2 times');
                 break;
         }
+
         return $metadata;
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Event/MoveEventArgsTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Event/MoveEventArgsTest.php
@@ -10,13 +10,13 @@ class MoveEventArgsTest extends TestCase
 
     private $dm;
 
-    /** @var  MoveEventArgs */
+    /** @var MoveEventArgs */
     private $eventArgs;
 
     public function setUp()
     {
         $this->dm = $this->createMock(DocumentManager::class);
-        $this->object = new \stdClass;
+        $this->object = new \stdClass();
 
         $this->eventArgs = new MoveEventArgs(
             $this->object,

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -3,15 +3,15 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
-use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
-use PHPCR\Util\UUIDHelper;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use PHPCR\Util\NodeHelper;
+use PHPCR\Util\UUIDHelper;
 
 /**
  * @group functional
@@ -24,7 +24,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -37,15 +38,15 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function setUp()
     {
         $this->type = User::class;
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $user = $this->node->addNode('user');
         $user->setProperty('username', 'lsmith');
         $user->setProperty('note', 'test');
-        $user->setProperty('numbers', array(3, 1, 2));
-        $user->setProperty('parameters', array('bar', 'dong'));
-        $user->setProperty('parameterKey', array('foo', 'ding'));
+        $user->setProperty('numbers', [3, 1, 2]);
+        $user->setProperty('parameters', ['bar', 'dong']);
+        $user->setProperty('parameterKey', ['foo', 'ding']);
         $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
     }
@@ -53,8 +54,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testInsert()
     {
         $user = new User();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'test';
+        $user->numbers = [1, 2, 3];
         $user->id = '/functional/test';
 
         $this->dm->persist($user);
@@ -63,7 +64,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
 
         $userNew = $this->dm->find($this->type, '/functional/test');
 
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals($user->username, $userNew->username);
         $this->assertEquals($user->numbers, $userNew->numbers);
     }
@@ -71,16 +72,16 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testInsertTwice()
     {
         $user = new User();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'test';
+        $user->numbers = [1, 2, 3];
         $user->id = '/functional/test';
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
 
         $user = new User();
-        $user->username = "toast";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'toast';
+        $user->numbers = [1, 2, 3];
         $user->id = '/functional/test';
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->persist($user);
@@ -90,7 +91,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     {
         $user = $this->node->addNode('userWithAlias');
         $user->setProperty('username', 'dbu');
-        $user->setProperty('numbers', array(3, 1, 2));
+        $user->setProperty('numbers', [3, 1, 2]);
         $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
 
@@ -141,15 +142,15 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testFindNonFlushed()
     {
         $user = new User();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'test';
+        $user->numbers = [1, 2, 3];
         $user->id = '/functional/test';
 
         $this->dm->persist($user);
 
         $userNew = $this->dm->find($this->type, '/functional/test');
 
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals($user->username, $userNew->username);
     }
 
@@ -209,7 +210,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testInsertWithCustomIdStrategy()
     {
         $user = new User3();
-        $user->username = "test3";
+        $user->username = 'test3';
 
         $this->dm->persist($user);
 
@@ -220,14 +221,14 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
 
         $userNew = $this->dm->find(User3::class, '/functional/test3');
 
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals($user->username, $userNew->username);
     }
 
     public function testMultivaluePropertyWithOnlyOneValueUpdatedToMultiValue()
     {
         $user = new User();
-        $user->numbers = array(1);
+        $user->numbers = [1];
         $user->id = '/functional/test';
         $user->username = 'testuser';
 
@@ -238,7 +239,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $userNew = $this->dm->find($this->type, '/functional/test');
         $this->assertEquals($user->numbers, $userNew->numbers);
 
-        $userNew->numbers = array(1, 2);
+        $userNew->numbers = [1, 2];
         $this->dm->flush();
         $this->dm->clear();
 
@@ -310,7 +311,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $user = new User2();
-        $user->username = "test";
+        $user->username = 'test';
         $user->id = '/functional/user';
         $this->dm->persist($user);
 
@@ -319,7 +320,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
 
         $userNew = $this->dm->find(User2::class, '/functional/user');
 
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals($user->username, $userNew->username);
     }
 
@@ -331,7 +332,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
 
         $this->dm->remove($user);
 
-        $user->username = "test";
+        $user->username = 'test';
         $user->id = '/functional/user';
         $this->dm->persist($user);
 
@@ -340,7 +341,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
 
         $userNew = $this->dm->find($this->type, '/functional/user');
 
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals($user->username, $userNew->username);
     }
 
@@ -353,7 +354,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->remove($user);
 
         $user = new User2();
-        $user->username = "test";
+        $user->username = 'test';
         $user->id = '/functional/user';
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->persist($user);
@@ -362,8 +363,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testUpdate1()
     {
         $user = new User();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'test';
+        $user->numbers = [1, 2, 3];
         $user->id = '/functional/user2';
 
         $this->dm->persist($user);
@@ -371,8 +372,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $userNew = $this->dm->find($this->type, '/functional/user2');
-        $userNew->username = "test2";
-        $userNew->numbers = array(4, 5, 6);
+        $userNew->username = 'test2';
+        $userNew->numbers = [4, 5, 6];
         $userNew->id = '/functional/user2';
 
         $this->dm->persist($userNew);
@@ -393,21 +394,21 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $user = $this->dm->find($this->type, '/functional/user');
-        $this->assertEquals($user->numbers, array());
+        $this->assertEquals($user->numbers, []);
 
-        $user->numbers = array();
+        $user->numbers = [];
 
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->find($this->type, '/functional/user');
-        $this->assertEquals($user->numbers, array());
+        $this->assertEquals($user->numbers, []);
     }
 
     public function testUpdate2()
     {
         $user = $this->dm->find($this->type, '/functional/user');
-        $user->username = "new-name";
+        $user->username = 'new-name';
 
         $this->dm->flush();
         $this->dm->clear();
@@ -419,14 +420,14 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testInsertUpdateMultiple()
     {
         $user1 = $this->dm->find($this->type, '/functional/user');
-        $user1->username = "new-name";
+        $user1->username = 'new-name';
 
         $user2 = new User();
-        $user2->username = "test2";
+        $user2->username = 'test2';
         $user2->id = '/functional/user2222';
 
         $user3 = new User();
-        $user3->username = "test3";
+        $user3->username = 'test3';
         $user3->id = '/functional/user3333';
 
         $this->dm->persist($user2);
@@ -458,14 +459,13 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->assertNull($user2->note);
     }
 
-
     public function testNoIdProperty()
     {
         $functional = $this->dm->find(null, '/functional');
 
         $user = new User5();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'test';
+        $user->numbers = [1, 2, 3];
         $user->nodename = 'test';
         $user->parent = $functional;
 
@@ -475,12 +475,12 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
 
         $userNew = $this->dm->find(User5::class, '/functional/test');
 
-        $userNew->username = "test2";
+        $userNew->username = 'test2';
         $this->dm->flush();
 
         $userNew = $this->dm->find(User5::class, '/functional/test');
 
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals('test2', $userNew->username);
         $this->assertEquals($user->numbers, $userNew->numbers);
     }
@@ -490,8 +490,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $functional = $this->dm->find(null, '/functional');
 
         $user = new User6();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'test';
+        $user->numbers = [1, 2, 3];
         $user->parent = $functional;
 
         $this->dm->persist($user);
@@ -505,8 +505,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testAssocProperty()
     {
         $user = new User();
-        $user->username = "test";
-        $assocArray = array('foo' => 'bar', 'ding' => 'dong', 'dong' => null, 'dang' => null);
+        $user->username = 'test';
+        $assocArray = ['foo' => 'bar', 'ding' => 'dong', 'dong' => null, 'dang' => null];
         $user->parameters = $assocArray;
         $user->id = '/functional/test';
 
@@ -519,7 +519,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->assertNotNull($user);
         $this->assertEquals($user->parameters, $assocArray);
 
-        $assocArray = array('foo' => 'bar', 'hello' => 'world', 'check' => 'out');
+        $assocArray = ['foo' => 'bar', 'hello' => 'world', 'check' => 'out'];
         $user->parameters = $assocArray;
 
         $this->dm->flush();
@@ -549,8 +549,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testAssocNumberProperty()
     {
         $user = new User();
-        $user->username = "test";
-        $assocArray = array('foo' => 1, 'ding' => 2);
+        $user->username = 'test';
+        $assocArray = ['foo' => 1, 'ding' => 2];
         $user->assocNumbers = $assocArray;
         $user->id = '/functional/test';
 
@@ -567,8 +567,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     public function testVersionedDocument()
     {
         $user = new VersionTestObj();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'test';
+        $user->numbers = [1, 2, 3];
         $user->id = '/functional/test';
 
         $this->dm->persist($user);
@@ -576,7 +576,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $userNew = $this->dm->find(null, '/functional/test');
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals($user->username, $userNew->username);
         $this->assertEquals($user->numbers, $userNew->numbers);
     }
@@ -724,9 +724,10 @@ class User6 extends User5
 class User3Repository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadePersistTest.php
@@ -7,9 +7,9 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsArticlePerson;
+use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\Tests\Models\CMS\CmsGroup;
 
 class CascadePersistTest extends PHPCRFunctionalTestCase
 {
@@ -20,7 +20,7 @@ class CascadePersistTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $class = $this->dm->getClassMetadata(CmsUser::class);
@@ -220,7 +220,7 @@ class CascadePersistTest extends PHPCRFunctionalTestCase
         $article->text = 'foo';
         $article->topic = 'bar';
         $article->id = '/functional/article_referrer';
-        $user->articlesReferrers = array($article);
+        $user->articlesReferrers = [$article];
 
         $this->dm->flush();
 
@@ -242,7 +242,7 @@ class CascadePersistTest extends PHPCRFunctionalTestCase
         $article->text = 'foo';
         $article->topic = 'bar';
         $article->id = '/functional/article';
-        $article->user = array();
+        $article->user = [];
 
         $this->expectException(PHPCRException::class);
         $this->expectExceptionMessage('Referenced document is not stored correctly in a reference-one property. Do not use array notation');
@@ -281,7 +281,7 @@ class CascadePersistTest extends PHPCRFunctionalTestCase
         $user->name = 'foo';
         $user->username = 'bar';
         $user->id = '/functional/user';
-        $user->groups = array('this is a bad idea');
+        $user->groups = ['this is a bad idea'];
 
         $this->expectException(PHPCRException::class);
         $this->expectExceptionMessage('A reference field may only contain mapped documents, found <string> in field "groups" of "Doctrine\Tests\Models\CMS\CmsUser');
@@ -289,7 +289,7 @@ class CascadePersistTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Test Referrers ManyToMany cascade Flush
+     * Test Referrers ManyToMany cascade Flush.
      */
     public function testCascadeManagedDocumentReferrerMtoMDuringFlush()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRefreshTest.php
@@ -4,10 +4,10 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
 class CascadeRefreshTest extends PHPCRFunctionalTestCase
 {
@@ -18,7 +18,7 @@ class CascadeRefreshTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $class = $this->dm->getClassMetadata(CmsUser::class);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRemoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/CascadeRemoveTest.php
@@ -4,10 +4,10 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
 class CascadeRemoveTest extends PHPCRFunctionalTestCase
 {
@@ -18,7 +18,7 @@ class CascadeRemoveTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $class = $this->dm->getClassMetadata(CmsUser::class);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChangesetCalculationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChangesetCalculationTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event;
@@ -27,7 +26,7 @@ class ChangesetCalculationTest extends PHPCRFunctionalTestCase
     {
         $this->listener = new ChangesetListener();
         $this->dm = $this->createDocumentManager();
-        $this->dm->setLocaleChooserStrategy(new LocaleChooser(array('en' => array('fr'), 'fr' => array('en')), 'en'));
+        $this->dm->setLocaleChooserStrategy(new LocaleChooser(['en' => ['fr'], 'fr' => ['en']], 'en'));
         $this->node = $this->resetFunctionalNode($this->dm);
     }
 
@@ -36,9 +35,9 @@ class ChangesetCalculationTest extends PHPCRFunctionalTestCase
         $this->dm
             ->getEventManager()
             ->addEventListener(
-                array(
+                [
                     Event::postUpdate,
-                ),
+                ],
                 $this->listener
             );
 
@@ -74,9 +73,9 @@ class ChangesetCalculationTest extends PHPCRFunctionalTestCase
         $this->dm
              ->getEventManager()
              ->addEventListener(
-                array(
+                [
                     Event::postUpdate,
-                ),
+                ],
                 $this->listener
             );
 
@@ -112,9 +111,9 @@ class ChangesetCalculationTest extends PHPCRFunctionalTestCase
         $this->dm
             ->getEventManager()
             ->addEventListener(
-                array(
+                [
                     Event::postUpdate,
-                ),
+                ],
                 $this->listener
             );
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DetachTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DetachTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\ODM\PHPCR\UnitOfWork;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
@@ -17,7 +16,8 @@ class DetachTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -30,12 +30,12 @@ class DetachTest extends PHPCRFunctionalTestCase
     public function setUp()
     {
         $this->type = CmsUser::class;
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $user = $this->node->addNode('lsmith');
         $user->setProperty('username', 'lsmith');
-        $user->setProperty('numbers', array(3, 1, 2));
+        $user->setProperty('numbers', [3, 1, 2]);
         $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentManagerTest.php
@@ -1,13 +1,12 @@
 <?php
 
-
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\Util\UUIDHelper;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 class DocumentManagerTest extends PHPCRFunctionalTestCase
 {
@@ -17,7 +16,8 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -29,7 +29,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
     }
 
@@ -49,7 +49,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->assertNotNull($this->dm->find(get_class($user), $actualUuid));
         $this->assertNull($this->dm->find(get_class($user), $unusedUuid));
 
-        $uuids = array($actualUuid, $unusedUuid);
+        $uuids = [$actualUuid, $unusedUuid];
 
         $documents = $this->dm->findMany(get_class($user), $uuids);
         $this->assertEquals(1, count($documents));
@@ -58,7 +58,6 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
 /**
  * @PHPCRODM\Document(referenceable=true)
- *
  */
 class TestUser
 {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentRepositoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DocumentRepositoryTest.php
@@ -3,13 +3,13 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
+use Doctrine\ODM\PHPCR\Query\Builder\From;
+use Doctrine\ODM\PHPCR\Query\Builder\SourceDocument;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
 use PHPCR\NodeInterface;
-use Doctrine\ODM\PHPCR\Query\Builder\From;
-use Doctrine\ODM\PHPCR\Query\Builder\SourceDocument;
 
 /**
  * @group functional
@@ -21,7 +21,8 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
      */
     private $dm;
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -65,30 +66,30 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
     public function testLoadMany()
     {
         $user1 = new CmsUser();
-        $user1->username = "beberlei";
-        $user1->status = "active";
-        $user1->name = "Benjamin";
+        $user1->username = 'beberlei';
+        $user1->status = 'active';
+        $user1->name = 'Benjamin';
 
         $user2 = new CmsUser();
-        $user2->username = "lsmith";
-        $user2->status = "active";
-        $user2->name = "Lukas";
+        $user2->username = 'lsmith';
+        $user2->status = 'active';
+        $user2->name = 'Lukas';
 
         $this->dm->persist($user1);
         $this->dm->persist($user2);
         $this->dm->flush();
 
-        $users = $this->dm->getRepository(CmsUser::class)->findMany(array($user1->id, $user2->id));
+        $users = $this->dm->getRepository(CmsUser::class)->findMany([$user1->id, $user2->id]);
         $this->assertSame($user1, $users['/functional/beberlei']);
         $this->assertSame($user2, $users['/functional/lsmith']);
 
-        $users = $this->dm->getRepository(CmsUser::class)->findMany(array($user1->node->getIdentifier(), substr($user2->id, 1)));
+        $users = $this->dm->getRepository(CmsUser::class)->findMany([$user1->node->getIdentifier(), substr($user2->id, 1)]);
         $this->assertSame($user1, $users['/functional/beberlei']);
         $this->assertSame($user2, $users['/functional/lsmith']);
 
         $this->dm->clear();
 
-        $users = $this->dm->getRepository(CmsUser::class)->findMany(array($user1->id, $user2->id));
+        $users = $this->dm->getRepository(CmsUser::class)->findMany([$user1->id, $user2->id]);
         $this->assertTrue(isset($users['/functional/beberlei']));
         $this->assertTrue(isset($users['/functional/lsmith']));
         $this->assertInstanceOf(CmsUser::class, $users['/functional/beberlei']);
@@ -100,64 +101,64 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
 
         // read second document into memory
         $this->dm->getRepository(CmsUser::class)->find($user2->id);
-        $users = $this->dm->getRepository(CmsUser::class)->findMany(array($user1->id, $user2->id));
+        $users = $this->dm->getRepository(CmsUser::class)->findMany([$user1->id, $user2->id]);
         $this->assertEquals('/functional/beberlei', $users->key(), 'Documents are not returned in the order they were requested');
     }
 
     public function testFindBy()
     {
         $user1 = new CmsUser();
-        $user1->username = "beberlei";
-        $user1->status = "active";
-        $user1->name = "Benjamin";
+        $user1->username = 'beberlei';
+        $user1->status = 'active';
+        $user1->name = 'Benjamin';
 
         $user2 = new CmsUser();
-        $user2->username = "lsmith";
-        $user2->status = "active";
-        $user2->name = "Lukas";
+        $user2->username = 'lsmith';
+        $user2->status = 'active';
+        $user2->name = 'Lukas';
 
         $this->dm->persist($user1);
         $this->dm->persist($user2);
         $this->dm->flush();
 
-        $users1 = $this->dm->getRepository(CmsUser::class)->findBy(array('username' =>'beberlei'));
+        $users1 = $this->dm->getRepository(CmsUser::class)->findBy(['username' =>'beberlei']);
         $this->assertCount(1, $users1);
         $this->assertEquals($user1->username, $users1['/functional/beberlei']->username);
 
-        $users2 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'));
+        $users2 = $this->dm->getRepository(CmsUser::class)->findBy(['status' =>'active']);
         $this->assertCount(2, $users2);
 
-        $users3 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'), null, 1);
+        $users3 = $this->dm->getRepository(CmsUser::class)->findBy(['status' =>'active'], null, 1);
         $this->assertCount(1, $users3);
 
-        $users4 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'), array('name' => 'asc'), 2, 0);
+        $users4 = $this->dm->getRepository(CmsUser::class)->findBy(['status' =>'active'], ['name' => 'asc'], 2, 0);
         $this->assertEquals('/functional/beberlei', $users4->key());
 
-        $users5 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'), array('name' => 'asc'), 2, 1);
+        $users5 = $this->dm->getRepository(CmsUser::class)->findBy(['status' =>'active'], ['name' => 'asc'], 2, 1);
         $this->assertEquals('/functional/lsmith', $users5->key());
 
         // test descending order
-        $users6 = $this->dm->getRepository(CmsUser::class)->findBy(array('status' =>'active'), array('name' => 'desc'));
+        $users6 = $this->dm->getRepository(CmsUser::class)->findBy(['status' =>'active'], ['name' => 'desc']);
         $this->assertEquals('/functional/lsmith', $users6->key());
     }
 
     public function testFindByOnNodename()
     {
         $parent = new CmsUser();
-        $parent->username = "lsmith";
-        $parent->status = "active";
-        $parent->name = "Lukas";
+        $parent->username = 'lsmith';
+        $parent->status = 'active';
+        $parent->name = 'Lukas';
 
         $user = new CmsTeamUser();
-        $user->username = "beberlei";
-        $user->status = "active";
-        $user->name = "Benjamin";
+        $user->username = 'beberlei';
+        $user->status = 'active';
+        $user->name = 'Benjamin';
         $user->parent = $parent;
 
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $users = $this->dm->getRepository(CmsTeamUser::class)->findBy(array('nodename' => 'beberlei'));
+        $users = $this->dm->getRepository(CmsTeamUser::class)->findBy(['nodename' => 'beberlei']);
         $this->assertCount(1, $users);
         $this->assertEquals($user->username, $users['/functional/lsmith/beberlei']->username);
     }
@@ -165,48 +166,48 @@ class DocumentRepositoryTest extends PHPCRFunctionalTestCase
     public function testFindByOrderNonExistentDirectionString()
     {
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
-        $this->dm->getRepository(CmsTeamUser::class)->findBy(array('nodename' =>'beberlei'), array('username' =>'nowhere'));
+        $this->dm->getRepository(CmsTeamUser::class)->findBy(['nodename' =>'beberlei'], ['username' =>'nowhere']);
     }
 
     public function testFindByOrderNodename()
     {
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
 
-        $this->dm->getRepository(CmsTeamUser::class)->findBy(array('nodename' =>'beberlei'), array('nodename' =>'asc'));
+        $this->dm->getRepository(CmsTeamUser::class)->findBy(['nodename' =>'beberlei'], ['nodename' =>'asc']);
     }
 
     public function testFindByOnAssociation()
     {
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
-        $this->dm->getRepository(CmsTeamUser::class)->findBy(array('parent' =>'/foo'));
+        $this->dm->getRepository(CmsTeamUser::class)->findBy(['parent' =>'/foo']);
     }
 
     public function testFindByOrderAssociation()
     {
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
-        $this->dm->getRepository(CmsTeamUser::class)->findBy(array('username' =>'beberlei'), array('parent' => 'asc'));
+        $this->dm->getRepository(CmsTeamUser::class)->findBy(['username' =>'beberlei'], ['parent' => 'asc']);
     }
 
     public function testFindOneBy()
     {
         $user1 = new CmsUser();
-        $user1->username = "beberlei";
-        $user1->status = "active";
-        $user1->name = "Benjamin";
+        $user1->username = 'beberlei';
+        $user1->status = 'active';
+        $user1->name = 'Benjamin';
 
         $user2 = new CmsUser();
-        $user2->username = "lsmith";
-        $user2->status = "active";
-        $user2->name = "Lukas";
+        $user2->username = 'lsmith';
+        $user2->status = 'active';
+        $user2->name = 'Lukas';
 
         $this->dm->persist($user1);
         $this->dm->persist($user2);
         $this->dm->flush();
 
-        $users1 = $this->dm->getRepository(CmsUser::class)->findOneBy(array('username' =>'beberlei'));
+        $users1 = $this->dm->getRepository(CmsUser::class)->findOneBy(['username' =>'beberlei']);
         $this->assertEquals($user1->username, $users1->username);
 
-        $users2 = $this->dm->getRepository(CmsUser::class)->findOneBy(array('username' =>'obama'));
+        $users2 = $this->dm->getRepository(CmsUser::class)->findOneBy(['username' =>'obama']);
         $this->assertNull($users2);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventComputingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventComputingTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event;
@@ -23,12 +22,12 @@ class EventComputingTest extends PHPCRFunctionalTestCase
      */
     private $dm;
 
-    protected $localePrefs = array(
-        'en' => array('de', 'fr'),
-        'fr' => array('de', 'en'),
-        'de' => array('en'),
-        'it' => array('fr', 'de', 'en'),
-    );
+    protected $localePrefs = [
+        'en' => ['de', 'fr'],
+        'fr' => ['de', 'en'],
+        'de' => ['en'],
+        'it' => ['fr', 'de', 'en'],
+    ];
 
     public function setUp()
     {
@@ -42,14 +41,14 @@ class EventComputingTest extends PHPCRFunctionalTestCase
         $this->dm
              ->getEventManager()
              ->addEventListener(
-                array(
+                [
                     Event::prePersist,
                     Event::postPersist,
                     Event::preUpdate,
                     Event::postUpdate,
                     Event::preMove,
-                    Event::postMove
-                ),
+                    Event::postMove,
+                ],
                 $this->listener
             );
 
@@ -100,7 +99,6 @@ class EventComputingTest extends PHPCRFunctionalTestCase
 
         $this->dm->clear();
 
-
         $user = $this->dm->find(CmsUser::class, $targetPath);
 
         // the document was moved but the only changes applied in preUpdate are persisted,
@@ -118,13 +116,13 @@ class EventComputingTest extends PHPCRFunctionalTestCase
         $this->dm
              ->getEventManager()
              ->addEventListener(
-                array(
+                [
                     Event::preCreateTranslation,
                     Event::preUpdateTranslation,
                     Event::postLoadTranslation,
                     Event::preRemoveTranslation,
                     Event::postRemoveTranslation,
-                ),
+                ],
                 $this->listener
             );
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerResetTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerResetTest.php
@@ -4,11 +4,11 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\Tests\Models\CMS\CmsPage;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
 /**
- * These tests ensure that you can reset a value in a lifecycle event
+ * These tests ensure that you can reset a value in a lifecycle event.
  *
  * A use case is for example a bridge which allows you to store associations to objects in a different database
  * - In the prePersist and preUpdate event you serialize the identifier reference of the object
@@ -31,9 +31,9 @@ class EventManagerResetTest extends PHPCRFunctionalTestCase
         $this->listener = new TestResetListener();
         $this->dm = $this->createDocumentManager();
         $this->node = $this->resetFunctionalNode($this->dm);
-        $this->dm->getEventManager()->addEventListener(array(
+        $this->dm->getEventManager()->addEventListener([
             'prePersist', 'postPersist', 'preUpdate', 'postUpdate',
-        ), $this->listener);
+        ], $this->listener);
     }
 
     public function testResetEvents()
@@ -50,12 +50,11 @@ class EventManagerResetTest extends PHPCRFunctionalTestCase
 
         $this->dm->persist($page);
 
-        $this->assertEquals(serialize(array('id' => $pageContent->id)), $page->content);
+        $this->assertEquals(serialize(['id' => $pageContent->id]), $page->content);
 
         $this->dm->flush();
 
         $this->assertInstanceOf(CmsPageContent::class, $page->content);
-
 
         // This is required as the originalData in the UnitOfWork doesn’t set the node of the Document
         $this->dm->clear();
@@ -69,7 +68,6 @@ class EventManagerResetTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $this->assertEquals('my-page', $pageLoaded->title);
-
 
         $pageLoaded->content = $pageContent;
 
@@ -87,7 +85,7 @@ class TestResetListener
     {
         $document = $e->getObject();
         if ($document instanceof CmsPage && $document->content instanceof CmsPageContent) {
-            $contentReference = array('id' => $document->content->id);
+            $contentReference = ['id' => $document->content->id];
             $document->content = serialize($contentReference);
         }
     }
@@ -117,7 +115,7 @@ class TestResetListener
         }
 
         if ($document instanceof CmsPage && $document->content instanceof CmsPageContent) {
-            $contentReference = array('id' => $document->content->id);
+            $contentReference = ['id' => $document->content->id];
             $document->content = serialize($contentReference);
         }
     }
@@ -139,7 +137,6 @@ class TestResetListener
         }
     }
 }
-
 
 class CmsPageContent
 {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
@@ -5,14 +5,14 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Common\Persistence\Event\ManagerEventArgs;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\Event\PreUpdateEventArgs;
-use Doctrine\ODM\PHPCR\Event\MoveEventArgs;
 use Doctrine\ODM\PHPCR\Event;
+use Doctrine\ODM\PHPCR\Event\MoveEventArgs;
+use Doctrine\ODM\PHPCR\Event\PreUpdateEventArgs;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
+use Doctrine\Tests\Models\CMS\CmsItem;
+use Doctrine\Tests\Models\CMS\CmsPage;
 use Doctrine\Tests\Models\CMS\CmsPageTranslatable;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\Tests\Models\CMS\CmsPage;
-use Doctrine\Tests\Models\CMS\CmsItem;
 
 class EventManagerTest extends PHPCRFunctionalTestCase
 {
@@ -26,13 +26,12 @@ class EventManagerTest extends PHPCRFunctionalTestCase
      */
     private $dm;
 
-
-    protected $localePrefs = array(
-        'en' => array('de', 'fr'),
-        'fr' => array('de', 'en'),
-        'de' => array('en'),
-        'it' => array('fr', 'de', 'en'),
-    );
+    protected $localePrefs = [
+        'en' => ['de', 'fr'],
+        'fr' => ['de', 'en'],
+        'de' => ['en'],
+        'it' => ['fr', 'de', 'en'],
+    ];
 
     public function setUp()
     {
@@ -46,7 +45,7 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $this->dm
             ->getEventManager()
             ->addEventListener(
-                array(
+                [
                     Event::prePersist,
                     Event::postPersist,
                     Event::preUpdate,
@@ -59,7 +58,7 @@ class EventManagerTest extends PHPCRFunctionalTestCase
                     Event::preMove,
                     Event::postMove,
                     Event::endFlush,
-                ),
+                ],
                 $this->listener
             );
 
@@ -93,7 +92,7 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $this->assertFalse($this->listener->itemPreMove);
         $this->assertFalse($this->listener->itemPostMove);
 
-        $this->dm->move($page, '/functional/moved-' . $page->title);
+        $this->dm->move($page, '/functional/moved-'.$page->title);
 
         $this->assertFalse($this->listener->pagePreMove);
         $this->assertFalse($this->listener->pagePostMove);
@@ -153,12 +152,12 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $this->dm
             ->getEventManager()
             ->addEventListener(
-                array(
+                [
                     Event::preCreateTranslation,
                     Event::postLoadTranslation,
                     Event::preRemoveTranslation,
                     Event::postRemoveTranslation,
-                ),
+                ],
                 $this->listener
             );
         $this->dm->setLocaleChooserStrategy(new LocaleChooser($this->localePrefs, 'en'));
@@ -250,7 +249,7 @@ class TestPersistenceListener
     public function preUpdate(PreUpdateEventArgs $e)
     {
         $document = $e->getObject();
-        if (! $document instanceof CmsPage) {
+        if (!$document instanceof CmsPage) {
             return;
         }
         $dm = $e->getObjectManager();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventObjectUpdateTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventObjectUpdateTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event;
@@ -28,23 +27,22 @@ class EventObjectUpdateTest extends PHPCRFunctionalTestCase
         $this->node = $this->resetFunctionalNode($this->dm);
     }
 
-
     public function testComputingBetweenEvents()
     {
         $this->dm
             ->getEventManager()
             ->addEventListener(
-                array(
+                [
                     Event::postLoad,
                     Event::prePersist,
                     Event::preUpdate,
                     Event::postPersist,
                     Event::postUpdate,
-                ),
+                ],
                 $this->listener
             );
 
-        $entity = new SomeEntity;
+        $entity = new SomeEntity();
         $entity->id = '/functional/test';
         $entity->status = new \stdClass();
         $entity->status->value = 'active';
@@ -112,13 +110,13 @@ class TestEventDocumentChanger2
 {
     public function getSubscribedEvents()
     {
-        return array(
+        return [
             'postLoad',
             'prePersist',
             'preUpdate',
             'postPersist',
             'postUpdate',
-        );
+        ];
     }
 
     protected function switchToObject(LifecycleEventArgs $args)

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FileTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FileTest.php
@@ -19,7 +19,8 @@ class FileTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -77,7 +78,7 @@ class FileTest extends PHPCRFunctionalTestCase
         $parent = new FileTestObj();
         $parent->file = new File();
         $parent->id = '/functional/filetest';
-        $parent->file->setFileContentFromFilesystem(dirname(__FILE__) .'/_files/foo.txt');
+        $parent->file->setFileContentFromFilesystem(dirname(__FILE__).'/_files/foo.txt');
 
         $this->dm->persist($parent);
         $this->dm->flush();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
@@ -3,10 +3,10 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * Test the DocumentManager::find method.
@@ -21,7 +21,8 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -34,15 +35,15 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
     public function setUp()
     {
         $this->type = TypeUser::class;
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $user = $this->node->addNode('user');
         $user->setProperty('username', 'lsmith');
         $user->setProperty('note', 'test');
-        $user->setProperty('numbers', array(3, 1, 2));
-        $user->setProperty('parameters', array('bar', 'dong'));
-        $user->setProperty('parameterKey', array('foo', 'ding'));
+        $user->setProperty('numbers', [3, 1, 2]);
+        $user->setProperty('parameters', ['bar', 'dong']);
+        $user->setProperty('parameterKey', ['foo', 'ding']);
         $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
     }
@@ -55,7 +56,7 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
         $this->assertEquals('/functional/user', $user->id);
 
         $this->assertEquals('lsmith', $user->username);
-        $this->assertEquals(array(3, 1, 2), $user->numbers);
+        $this->assertEquals([3, 1, 2], $user->numbers);
 
         // subsequent find must find the same object again
 
@@ -85,13 +86,13 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * TypeUser is a superclass of TypeTeamUser
+     * TypeUser is a superclass of TypeTeamUser.
      */
     public function testInheritance()
     {
         $user = new TypeTeamUser();
-        $user->username = "test";
-        $user->numbers = array(1, 2, 3);
+        $user->username = 'test';
+        $user->numbers = [1, 2, 3];
         $user->id = '/functional/test';
         $user->name = 'inheritance';
 
@@ -101,14 +102,14 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
 
         $userNew = $this->dm->find($this->type, '/functional/test');
 
-        $this->assertNotNull($userNew, "Have to hydrate user object!");
+        $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals($user->username, $userNew->username);
         $this->assertEquals($user->numbers, $userNew->numbers);
         $this->assertEquals($user->name, $userNew->name);
     }
 
     /**
-     * TypeTeamUser is not a superclass of User
+     * TypeTeamUser is not a superclass of User.
      */
     public function testNotInstanceOf()
     {
@@ -130,11 +131,11 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * TypeTeamUser is not a superclass of User
+     * TypeTeamUser is not a superclass of User.
      */
     public function testManyNotInstanceOf()
     {
-        $users = $this->dm->findMany(TypeTeamUser::class, array('/functional/user'));
+        $users = $this->dm->findMany(TypeTeamUser::class, ['/functional/user']);
 
         $this->assertCount(0, $users);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FixPHPCR1Test.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FixPHPCR1Test.php
@@ -19,7 +19,8 @@ class FixPHPCR1Test extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
@@ -3,15 +3,14 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
-use Doctrine\Tests\Models\CMS\CmsGroup;
-use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsTeamUser;
+use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\References\UuidTestObj;
 use Doctrine\Tests\Models\References\UuidTestTwoUuidFieldsObj;
-use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 
@@ -26,7 +25,8 @@ class FlushTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -34,7 +34,7 @@ class FlushTest extends PHPCRFunctionalTestCase
     public function setUp()
     {
         $this->type = CmsUser::class;
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->resetFunctionalNode($this->dm);
     }
 
@@ -158,7 +158,7 @@ class FlushTest extends PHPCRFunctionalTestCase
         $this->dm->persist($userB);
         $this->dm->persist($userC);
 
-        $this->dm->flush(array($userA, $userB, $userC));
+        $this->dm->flush([$userA, $userB, $userC]);
 
         $this->assertNotNull($userA->id);
         $this->assertNotNull($userB->id);
@@ -186,7 +186,7 @@ class FlushTest extends PHPCRFunctionalTestCase
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $otherUser = new CmsUser;
+        $otherUser = new CmsUser();
         $otherUser->name = 'Dominik2';
         $otherUser->username = 'domnikl2';
         $otherUser->status = 'developer';
@@ -196,8 +196,8 @@ class FlushTest extends PHPCRFunctionalTestCase
         $this->dm->persist($otherUser);
         $this->dm->flush($user);
 
-        $this->assertTrue($this->dm->contains($otherUser), "Other user is not contained in DocumentManager");
-        $this->assertTrue($otherUser->id != null, "other user has no id");
+        $this->assertTrue($this->dm->contains($otherUser), 'Other user is not contained in DocumentManager');
+        $this->assertTrue($otherUser->id != null, 'other user has no id');
     }
 
     public function testFlushAndCascadePersist()
@@ -211,16 +211,16 @@ class FlushTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $address = new CmsAddress();
-        $address->city = "Springfield";
-        $address->zip = "12354";
-        $address->country = "Germany";
+        $address->city = 'Springfield';
+        $address->zip = '12354';
+        $address->country = 'Germany';
         $address->user = $user;
         $user->address = $address;
 
         $this->dm->flush($user);
 
-        $this->assertTrue($this->dm->contains($address), "Address is not contained in DocumentManager");
-        $this->assertTrue($address->id != null, "address user has no id");
+        $this->assertTrue($this->dm->contains($address), 'Address is not contained in DocumentManager');
+        $this->assertTrue($address->id != null, 'address user has no id');
     }
 
     public function testProxyIsIgnored()
@@ -236,7 +236,7 @@ class FlushTest extends PHPCRFunctionalTestCase
 
         $user = $this->dm->getReference(get_class($user), $user->id);
 
-        $otherUser = new CmsUser;
+        $otherUser = new CmsUser();
         $otherUser->name = 'Dominik2';
         $otherUser->username = 'domnikl2';
         $otherUser->status = 'developer';
@@ -244,13 +244,13 @@ class FlushTest extends PHPCRFunctionalTestCase
         $this->dm->persist($otherUser);
         $this->dm->flush($user);
 
-        $this->assertTrue($this->dm->contains($otherUser), "Other user is contained in DocumentManager");
-        $this->assertTrue($otherUser->id != null, "other user has no id");
+        $this->assertTrue($this->dm->contains($otherUser), 'Other user is contained in DocumentManager');
+        $this->assertTrue($otherUser->id != null, 'other user has no id');
     }
 
     public function testUuidIsSet()
     {
-        $uuidObj = new UuidTestObj;
+        $uuidObj = new UuidTestObj();
         $uuidObj->id = '/functional/uuidObj';
         $this->dm->persist($uuidObj);
         $this->dm->flush();
@@ -259,7 +259,7 @@ class FlushTest extends PHPCRFunctionalTestCase
 
     public function testUuidFieldOnlySetOnce()
     {
-        $uuidObj = new UuidTestTwoUuidFieldsObj;
+        $uuidObj = new UuidTestTwoUuidFieldsObj();
         $uuidObj->id = '/functional/uuidObj';
 
         $this->expectException(MappingException::class);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildTest.php
@@ -2,13 +2,13 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 
+use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
-use Doctrine\Common\Proxy\Proxy;
 
 /**
  * Test for the Child mapping.
@@ -23,13 +23,15 @@ class ChildTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type = ChildTestObj::class;
 
     /**
-     * Class name of the child document class
+     * Class name of the child document class.
+     *
      * @var string
      */
     private $childType = ChildChildTestObj::class;
@@ -170,7 +172,7 @@ class ChildTest extends PHPCRFunctionalTestCase
         $parent = new ChildTestObj();
         $child = new ChildChildTestObj();
         $parent->name = 'Parent';
-        $parent->child = array($child);
+        $parent->child = [$child];
         $child->name = 'Child';
         $parent->id = '/functional/childtest';
 
@@ -244,14 +246,14 @@ class ChildTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Remove the child, check that parent->child is not set afterwards
+     * Remove the child, check that parent->child is not set afterwards.
      */
     public function testRemove2()
     {
         $parent = new ChildTestObj();
         $child = new ChildChildTestObj();
         $parent->name = 'Parent';
-        $parent->id  = '/functional/childtest';
+        $parent->id = '/functional/childtest';
         $parent->child = $child;
         $child->name = 'Child';
 
@@ -273,7 +275,7 @@ class ChildTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Remove the parent node of multiple child level
+     * Remove the parent node of multiple child level.
      */
     public function testRemove3()
     {
@@ -413,27 +415,27 @@ class ChildTest extends PHPCRFunctionalTestCase
     public function testChildOfReference()
     {
         $referrerTestObj = new ChildReferrerTestObj();
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrerTestObj";
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrerTestObj';
 
         $refererenceableTestObj = new ChildReferenceableTestObj();
-        $refererenceableTestObj->id = "/functional/referenceableTestObj";
-        $refererenceableTestObj->name = "referenceableTestObj";
+        $refererenceableTestObj->id = '/functional/referenceableTestObj';
+        $refererenceableTestObj->name = 'referenceableTestObj';
         $referrerTestObj->reference = $refererenceableTestObj;
 
         $this->dm->persist($referrerTestObj);
 
         $ChildTestObj = new ChildTestObj();
-        $ChildTestObj->id = "/functional/referenceableTestObj/test";
-        $ChildTestObj->name= "childTestObj";
+        $ChildTestObj->id = '/functional/referenceableTestObj/test';
+        $ChildTestObj->name = 'childTestObj';
 
         $this->dm->persist($ChildTestObj);
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find(null, "/functional/referrerTestObj");
+        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
 
-        $this->assertEquals($referrer->reference->aChild->name, "childTestObj");
+        $this->assertEquals($referrer->reference->aChild->name, 'childTestObj');
     }
 }
 
@@ -468,8 +470,8 @@ class ChildTestObj
 }
 
 /**
-  * @PHPCRODM\Document()
-  */
+ * @PHPCRODM\Document()
+ */
 class ChildReferrerTestObj
 {
     /** @PHPCRODM\Id */
@@ -483,8 +485,8 @@ class ChildReferrerTestObj
 }
 
 /**
-  * @PHPCRODM\Document(referenceable=true)
-  */
+ * @PHPCRODM\Document(referenceable=true)
+ */
 class ChildReferenceableTestObj
 {
     /** @PHPCRODM\Id */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildrenTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildrenTest.php
@@ -2,17 +2,17 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ODM\PHPCR\ChildrenCollection;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
 use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\RepositoryInterface;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
 
 /**
  * Test for the Children mapping.
@@ -117,11 +117,11 @@ class ChildrenTest extends PHPCRFunctionalTestCase
 
         $parent = $this->dm->find($this->type, '/functional/parent');
         $collection = $parent->allChildren->slice('Child B', 2);
-        $this->assertEquals(array('Child B', 'Child C'), array_keys($collection));
+        $this->assertEquals(['Child B', 'Child C'], array_keys($collection));
 
         $parent->allChildren->initialize();
         $collection = $parent->allChildren->slice('Child B', 2);
-        $this->assertEquals(array('Child B', 'Child C'), array_keys($collection));
+        $this->assertEquals(['Child B', 'Child C'], array_keys($collection));
     }
 
     public function testNoChildrenInitOnFlush()
@@ -165,28 +165,28 @@ class ChildrenTest extends PHPCRFunctionalTestCase
     public function testChildrenOfReference()
     {
         $referrerTestObj = new ChildrenReferrerTestObj();
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrerTestObj";
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrerTestObj';
 
         $refererenceableTestObj = new ChildrenReferenceableTestObj();
-        $refererenceableTestObj->id = "/functional/referenceableTestObj";
-        $refererenceableTestObj->name = "referenceableTestObj";
+        $refererenceableTestObj->id = '/functional/referenceableTestObj';
+        $refererenceableTestObj->name = 'referenceableTestObj';
         $referrerTestObj->reference = $refererenceableTestObj;
 
         $this->dm->persist($referrerTestObj);
 
         $ChildrenTestObj = new ChildrenTestObj();
-        $ChildrenTestObj->id = "/functional/referenceableTestObj/childrenTestObj";
-        $ChildrenTestObj->name= "childrenTestObj";
+        $ChildrenTestObj->id = '/functional/referenceableTestObj/childrenTestObj';
+        $ChildrenTestObj->name = 'childrenTestObj';
 
         $this->dm->persist($ChildrenTestObj);
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find(null, "/functional/referrerTestObj");
+        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
 
         $this->assertCount(1, $referrer->reference->allChildren);
-        $this->assertEquals("childrenTestObj", $referrer->reference->allChildren->first()->name);
+        $this->assertEquals('childrenTestObj', $referrer->reference->allChildren->first()->name);
     }
 
     /**
@@ -198,7 +198,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $new = new ChildrenTestObj();
         $new->id = '/functional/parent/new';
 
-        $children = array();
+        $children = [];
         $child = new ChildrenTestObj();
         $child->id = '/functional/parent/new/Child Create-1';
         $child->name = 'Child A';
@@ -226,7 +226,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
     {
         $parent = $this->dm->find($this->type, '/functional/parent');
 
-        $children = array();
+        $children = [];
         $child = new ChildrenTestObj();
         $child->id = '/functional/parent/Child Create-1';
         $child->name = 'Child A';
@@ -268,7 +268,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * New parent, insert children with parent and name strategy
+     * New parent, insert children with parent and name strategy.
      */
     public function testInsertNewNamedChild()
     {
@@ -296,7 +296,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
     {
         $parent = $this->dm->find($this->type, '/functional/parent');
 
-        $children = array();
+        $children = [];
         $child = new ChildrenTestObj();
         $child->name = 'ChildA';
         $children[] = $child;
@@ -369,7 +369,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
     {
         $parent = $this->dm->find($this->type, '/functional/parent');
 
-        $parent->allChildren = array('This is not an object');
+        $parent->allChildren = ['This is not an object'];
         $this->dm->persist($parent);
 
         $this->expectException(PHPCRException::class);
@@ -474,7 +474,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
      */
     public function testReorderChildren()
     {
-        if (! $this->dm
+        if (!$this->dm
             ->getPhpcrSession()
             ->getRepository()
             ->getDescriptor(RepositoryInterface::NODE_TYPE_MANAGEMENT_ORDERABLE_CHILD_NODES_SUPPORTED)
@@ -488,10 +488,10 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $parent = $this->dm->find($this->type, '/functional/parent');
         $this->assertCount(2, $parent->allChildren);
 
-        $data = array(
+        $data = [
             'Child G' => $parent->allChildren->last(),
             'Child F' => $parent->allChildren->first(),
-        );
+        ];
 
         $first = $parent->allChildren->first();
         $parent->allChildren->remove('Child F');
@@ -513,13 +513,13 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $child3 = new ChildrenTestObj();
         $child3->name = 'Child J';
 
-        $data = array(
+        $data = [
             'Child I' => $child2,
             'Child H' => $child1,
             'Child F' => $parent->allChildren->last(),
             'Child G' => $parent->allChildren->first(),
-            'Child J' => $child3
-        );
+            'Child J' => $child3,
+        ];
 
         $parent->allChildren = new ArrayCollection($data);
 
@@ -540,13 +540,13 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $keys = array(
+        $keys = [
             'Child I',
             'Child H',
             'Child F',
             'Child J',
             'Child G',
-        );
+        ];
 
         $parent = $this->dm->find($this->type, '/functional/parent');
         $this->assertCount(count($keys), $parent->allChildren);
@@ -555,7 +555,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
 
     public function testReorderChildrenLast()
     {
-        if (! $this->dm
+        if (!$this->dm
             ->getPhpcrSession()
             ->getRepository()
             ->getDescriptor(RepositoryInterface::NODE_TYPE_MANAGEMENT_ORDERABLE_CHILD_NODES_SUPPORTED)
@@ -574,7 +574,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
 
         $childrenCollection->clear();
 
-        $expectedOrder = array('Child A', 'Child D', 'Child C', 'Child B');
+        $expectedOrder = ['Child A', 'Child D', 'Child C', 'Child B'];
 
         foreach ($expectedOrder as $name) {
             $childrenCollection->set($name, $children[$name]);
@@ -592,7 +592,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
 
     /**
      * Reorder the children but reset the order in the preUpdate event
-     * Tests that the previously compute document change set gets overwritten
+     * Tests that the previously compute document change set gets overwritten.
      *
      * @depends testReorderChildren
      */
@@ -601,12 +601,12 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $this->createChildren();
 
         $this->listener = new TestResetReorderingListener();
-        $this->dm->getEventManager()->addEventListener(array('preUpdate'), $this->listener);
+        $this->dm->getEventManager()->addEventListener(['preUpdate'], $this->listener);
 
         /** @var $parent ChildrenTestObj */
         $parent = $this->dm->find($this->type, '/functional/parent');
 
-        $this->assertEquals("Child A", $parent->allChildren->first()->name);
+        $this->assertEquals('Child A', $parent->allChildren->first()->name);
 
         $parent->allChildren->remove('Child A');
 
@@ -620,13 +620,13 @@ class ChildrenTest extends PHPCRFunctionalTestCase
 
         $parent = $this->dm->find($this->type, '/functional/parent');
 
-        $this->assertEquals("Child A", $parent->allChildren->first()->name);
+        $this->assertEquals('Child A', $parent->allChildren->first()->name);
 
-        $this->dm->getEventManager()->removeEventListener(array('preUpdate'), $this->listener);
+        $this->dm->getEventManager()->removeEventListener(['preUpdate'], $this->listener);
     }
 
     /**
-     * Rename the nodename of a child
+     * Rename the nodename of a child.
      */
     public function testRenameChildren()
     {
@@ -652,7 +652,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Move a child out of the children collection
+     * Move a child out of the children collection.
      */
     public function testMoveChildren()
     {
@@ -727,18 +727,19 @@ class ChildrenTestObj
     public $aChildren;
 
     /**
-    * @var ChildrenCollection
-    * @PHPCR\Children(fetchDepth=2, cascade="persist")
-    */
+     * @var ChildrenCollection
+     * @PHPCR\Children(fetchDepth=2, cascade="persist")
+     */
     public $allChildren;
 }
 
 class ChildrenTestObjRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
-     * Generate a document id
+     * Generate a document id.
      *
      * @param object $document
+     *
      * @return string
      */
     public function generateId($document, $parent = null)
@@ -748,6 +749,7 @@ class ChildrenTestObjRepository extends DocumentRepository implements Repository
         }
 
         $parent = $parent ? $parent->id : '/functional';
+
         return $parent.'/'.$document->name;
     }
 }
@@ -786,8 +788,8 @@ class ChildrenParentAndNameTestObj
 }
 
 /**
-  * @PHPCR\Document()
-  */
+ * @PHPCR\Document()
+ */
 class ChildrenReferrerTestObj
 {
     /** @PHPCR\Id */
@@ -801,8 +803,8 @@ class ChildrenReferrerTestObj
 }
 
 /**
-  * @PHPCR\Document(referenceable=true)
-  */
+ * @PHPCR\Document(referenceable=true)
+ */
 class ChildrenReferenceableTestObj
 {
     /** @PHPCR\Id */
@@ -828,11 +830,11 @@ class TestResetReorderingListener
 
             $childrenCollection->clear();
 
-            $expectedOrder = array('Child A', 'Child B', 'Child C', 'Child D');
+            $expectedOrder = ['Child A', 'Child B', 'Child C', 'Child D'];
 
             foreach ($expectedOrder as $name) {
                 if (!isset($children[$name])) {
-                    throw new \PHPUnit_Framework_AssertionFailedError("Missing index '$name' in " . implode(', ', array_keys($children)));
+                    throw new \PHPUnit_Framework_AssertionFailedError("Missing index '$name' in ".implode(', ', array_keys($children)));
                 }
                 $childrenCollection->set($name, $children[$name]);
             }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
@@ -2,16 +2,15 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Hierarchy;
 
+use Doctrine\Common\Proxy\Proxy;
+use Doctrine\ODM\PHPCR\Document\Generic;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
-use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
-use Doctrine\ODM\PHPCR\Document\Generic;
 
 /**
  * Test for the Parent mapping.
@@ -26,7 +25,8 @@ class ParentTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -63,6 +63,7 @@ class ParentTest extends PHPCRFunctionalTestCase
 
         $this->assertTrue($doc->parent instanceof Proxy);
         $this->assertEquals('/functional', $doc->parent->getId());
+
         return $doc;
     }
 
@@ -80,7 +81,7 @@ class ParentTest extends PHPCRFunctionalTestCase
 
         $docNew = $this->dm->find($this->type, '/functional/test');
 
-        $this->assertNotNull($docNew, "Have to hydrate user object!");
+        $this->assertNotNull($docNew, 'Have to hydrate user object!');
         $this->assertEquals($doc->nodename, $docNew->nodename);
     }
 
@@ -149,7 +150,7 @@ class ParentTest extends PHPCRFunctionalTestCase
         $grandchild->parent = $doc;
         $grandchild->nodename = 'grandchild';
 
-        $doc->children = array($grandchild);
+        $doc->children = [$grandchild];
 
         $this->dm->persist($grandchild);
 
@@ -168,7 +169,7 @@ class ParentTest extends PHPCRFunctionalTestCase
         $child->parent = $parent;
         $child->nodename = 'child';
 
-        $parent->children = array($child);
+        $parent->children = [$child];
 
         $this->dm->persist($child);
 
@@ -187,14 +188,14 @@ class ParentTest extends PHPCRFunctionalTestCase
         $child->parent = $parent;
         $child->nodename = 'child';
 
-        $parent->children = array($child);
+        $parent->children = [$child];
 
-        # the grand child document
+        // the grand child document
         $grandchild = new NameDoc();
         $grandchild->parent = $child;
         $grandchild->nodename = 'grandchild';
 
-        $child->children = array($grandchild);
+        $child->children = [$grandchild];
 
         $this->dm->persist($child);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AnnotationMappingTest.php
@@ -4,11 +4,11 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Mapping;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
-use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 
@@ -29,7 +29,7 @@ class AnnotationMappingTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
     }
 
@@ -65,10 +65,10 @@ class AnnotationMappingTest extends PHPCRFunctionalTestCase
 
     public function testSecondLevelOverwrite()
     {
-        $localePrefs = array(
-            'en' => array('en', 'de'),
-            'de' => array('de', 'en'),
-        );
+        $localePrefs = [
+            'en' => ['en', 'de'],
+            'de' => ['de', 'en'],
+        ];
 
         $this->dm->setLocaleChooserStrategy(new LocaleChooser($localePrefs, 'en'));
 
@@ -106,38 +106,38 @@ class AnnotationMappingTest extends PHPCRFunctionalTestCase
 
     public function generatorTypeProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 ParentIdStrategy::class,
                 ClassMetadata::GENERATOR_TYPE_PARENT,
                 'parentId',
-            ),
-            array(
+            ],
+            [
                 ParentIdStrategyDifferentOrder::class,
                 ClassMetadata::GENERATOR_TYPE_PARENT,
                 'parentId2',
-            ),
-            array(
+            ],
+            [
                 AutoNameIdStrategy::class,
                 ClassMetadata::GENERATOR_TYPE_AUTO,
                 'autoname as only has parent but not nodename',
-            ),
-            array(
+            ],
+            [
                 AssignedIdStrategy::class,
                 ClassMetadata::GENERATOR_TYPE_ASSIGNED,
                 'assigned',
-            ),
-            array(
+            ],
+            [
                 RepositoryIdStrategy::class,
                 ClassMetadata::GENERATOR_TYPE_REPOSITORY,
-                'repository'
-            ),
-            array(
+                'repository',
+            ],
+            [
                 StandardCase::class,
                 ClassMetadata::GENERATOR_TYPE_ASSIGNED,
                 'standardcase',
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -153,13 +153,13 @@ class AnnotationMappingTest extends PHPCRFunctionalTestCase
 
     public function invalidIdProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 ParentIdNoParentStrategy::class,
                 AutoNameIdNoParentStrategy::class,
                 NoId::class,
-            )
-        );
+            ],
+        ];
     }
 
     public function testPersistParentId()
@@ -336,7 +336,7 @@ class Repository extends DocumentRepository implements RepositoryIdInterface
 {
     public function generateId($document, $parent = null)
     {
-        return '/functional/' . str_replace(' ', '-', $document->title);
+        return '/functional/'.str_replace(' ', '-', $document->title);
     }
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MergeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MergeTest.php
@@ -3,13 +3,13 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\CMS\CmsGroup;
-use Doctrine\Tests\Models\CMS\CmsArticle;
-use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
-use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\ODM\PHPCR\ReferenceManyCollection;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsTeamUser;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 
 class MergeTest extends PHPCRFunctionalTestCase
@@ -26,7 +26,7 @@ class MergeTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
         $this->dm->getPhpcrSession()->save();
     }
@@ -128,7 +128,7 @@ class MergeTest extends PHPCRFunctionalTestCase
 
         $mergableGroup = new CmsGroup();
         $mergableGroup->id = $user->id;
-        $mergableGroup->name = "doctrine";
+        $mergableGroup->name = 'doctrine';
 
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->merge($mergableGroup);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MixinTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MixinTest.php
@@ -3,9 +3,9 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\ODM\PHPCR\Mapping\Model\MixinMappingObject;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use PHPCR\NodeInterface;
 use PHPCR\NodeType\ConstraintViolationException;
 
@@ -20,7 +20,8 @@ class MixinTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -82,7 +83,6 @@ class MixinTest extends PHPCRFunctionalTestCase
 
         $this->dm->flush();
 
-
         $this->assertEquals($created->getTimestamp(), $this->node->getNode('protected')->getProperty('jcr:created')->getDate()->getTimestamp());
         $this->assertEquals('changed', $this->node->getNode('protected')->getProperty('change_me')->getString());
     }
@@ -125,7 +125,7 @@ class MixinTest extends PHPCRFunctionalTestCase
 }
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document(mixins={"mix:created"})
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveByAssignmentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveByAssignmentTest.php
@@ -3,12 +3,10 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
-use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\CMS\CmsTeamUser;
 
 /**
  * @group functional
@@ -21,7 +19,8 @@ class MoveByAssignmentTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -34,7 +33,7 @@ class MoveByAssignmentTest extends PHPCRFunctionalTestCase
     public function setUp()
     {
         $this->type = CmsTeamUser::class;
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $user = $this->node->addNode('dbu');

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
@@ -3,10 +3,10 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use PHPCR\PropertyType;
 use Doctrine\Tests\Models\CMS\CmsTeamUser;
 use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
+use PHPCR\PropertyType;
 
 /**
  * @group functional
@@ -25,12 +25,12 @@ class MoveTest extends PHPCRFunctionalTestCase
     public function setUp()
     {
         $this->type = CmsUser::class;
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $user = $this->node->addNode('lsmith');
         $user->setProperty('username', 'lsmith');
-        $user->setProperty('numbers', array(3, 1, 2));
+        $user->setProperty('numbers', [3, 1, 2]);
         $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/PropertyNameTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/PropertyNameTest.php
@@ -18,7 +18,8 @@ class PropertyNameTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/PropertyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/PropertyTest.php
@@ -19,7 +19,8 @@ class PropertyTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProtectedPropertyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProtectedPropertyTest.php
@@ -21,7 +21,8 @@ class ProtectedPropertyTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -37,18 +38,18 @@ class ProtectedPropertyTest extends PHPCRFunctionalTestCase
         $this->node = $this->resetFunctionalNode($this->dm);
 
         $session = $this->dm->getPhpcrSession();
-        if (! $session instanceof Session) {
+        if (!$session instanceof Session) {
             $this->markTestSkipped('Not a Jackalope session');
         }
 
-        $cnd = <<<CND
+        $cnd = <<<'CND'
 <test='http://test.fr'>
 [test:protected_property_test] > nt:hierarchyNode
   - reference (REFERENCE)
   - changeme (STRING)
 CND;
 
-        $cnd2 = <<<CND
+        $cnd2 = <<<'CND'
 <test='http://test.fr'>
 [test:protected_property_test2] > nt:hierarchyNode
   - reference (REFERENCE)
@@ -56,6 +57,7 @@ CND;
 CND;
 
         $ntm = $session->getWorkspace()->getNodeTypeManager();
+
         try {
             $ntm->registerNodeTypesCnd($cnd, true);
             $ntm->registerNodeTypesCnd($cnd2, true);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProxyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProxyTest.php
@@ -2,11 +2,11 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\Common\Proxy\Proxy;
 
 /**
  * @group functional
@@ -20,7 +20,7 @@ class ProxyTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->resetFunctionalNode($this->dm);
     }
 
@@ -37,8 +37,8 @@ class ProxyTest extends PHPCRFunctionalTestCase
 
         $user = $this->dm->getReference(get_class($user), $user->id);
 
-        $this->assertTrue(isset($user->name), "User is not set on demand");
-        $this->assertEquals('Dominik', $user->name, "User is not loaded on demand");
+        $this->assertTrue(isset($user->name), 'User is not set on demand');
+        $this->assertEquals('Dominik', $user->name, 'User is not loaded on demand');
     }
 
     /**
@@ -56,7 +56,7 @@ class ProxyTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $user = $this->dm->getReference(get_class($user), $user->id);
-        $this->assertEquals('Dominik', $user->name, "User is not loaded on demand");
+        $this->assertEquals('Dominik', $user->name, 'User is not loaded on demand');
 
         $this->assertSame($this->dm->getReference(get_class($user), $user->id), $user, 'Getting the proxy twice results in a copy');
     }
@@ -76,7 +76,7 @@ class ProxyTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $user = $this->dm->find(null, $user->id);
-        $assistant = $this->dm->find(null, $user->id . '/assistant');
+        $assistant = $this->dm->find(null, $user->id.'/assistant');
 
         $this->assertSame($assistant, $user->child);
     }
@@ -104,7 +104,6 @@ class ProxyTest extends PHPCRFunctionalTestCase
         $this->assertEquals('foo', $doc->nodename);
         $this->assertInstanceOf(ParentDoc::class, $doc->parent);
     }
-
 
     public function testProxyAwakesOnFields()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderJoinTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderJoinTest.php
@@ -2,15 +2,11 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\DocumentRepository;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
-use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsAuditItem;
 use Doctrine\Tests\Models\CMS\CmsProfile;
 use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\CMS\CmsAuditItem;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
 /**
  * @group functional
@@ -27,19 +23,19 @@ class QueryBuilderJoinTest extends PHPCRFunctionalTestCase
         $ntm = $this->dm->getPhpcrSession()->getWorkspace()->getNodeTypeManager();
         $ntm->registerNodeTypesCnd('[phpcr:cms_profile] > nt:unstructured', true);
 
-        $address1 = new CmsAddress;
+        $address1 = new CmsAddress();
         $address1->country = 'France';
         $address1->city = 'Lyon';
         $address1->zip = '65019';
         $this->dm->persist($address1);
 
-        $address2 = new CmsAddress;
+        $address2 = new CmsAddress();
         $address2->country = 'England';
         $address2->city = 'Weymouth';
         $address2->zip = 'AB1DC2';
         $this->dm->persist($address2);
 
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->username = 'dantleech';
         $user->address = $address1;
         $this->dm->persist($user);
@@ -49,17 +45,17 @@ class QueryBuilderJoinTest extends PHPCRFunctionalTestCase
         $user->addProfile($profile);
         $this->dm->persist($profile);
 
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->username = 'winstonsmith';
         $user->address = $address2;
         $this->dm->persist($user);
 
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->username = 'anonymous';
         $this->dm->persist($user);
 
-        foreach (array('dantleech', 'winstonsmith', 'dantleech', null) as $i => $username) {
-            $auditItem = new CmsAuditItem;
+        foreach (['dantleech', 'winstonsmith', 'dantleech', null] as $i => $username) {
+            $auditItem = new CmsAuditItem();
             $auditItem->id = '/functional/audit'.$i;
             $auditItem->message = 'User did something 1';
             $auditItem->username = $username;
@@ -86,96 +82,96 @@ class QueryBuilderJoinTest extends PHPCRFunctionalTestCase
 
     public function provideEquiJoinInner()
     {
-        return array(
-            array(
+        return [
+            [
                 'Inner',
                 'CmsUser', 'CmsAuditItem',
-                array('a.username' => 'dantleech'), array(
-                    array(
+                ['a.username' => 'dantleech'], [
+                    [
                         'a' => '/functional/dantleech',
                         'b' => '/functional/audit0',
-                    ),
-                    array(
+                    ],
+                    [
                         'a' => '/functional/dantleech',
                         'b' => '/functional/audit2',
-                    ),
-                ),
-            ),
-            array(
+                    ],
+                ],
+            ],
+            [
                 'Inner',
                 'CmsUser', 'CmsAuditItem',
-                array('a.username' => 'winstonsmith'), array(
-                    array(
+                ['a.username' => 'winstonsmith'], [
+                    [
                         'a' => '/functional/winstonsmith',
                         'b' => '/functional/audit1',
-                    ),
-                ),
-            ),
-            array(
+                    ],
+                ],
+            ],
+            [
                 'Inner',
                 'CmsUser', 'CmsAuditItem',
-                array('a.username' => 'nobody'), array(
-                ),
-            ),
-            array(
+                ['a.username' => 'nobody'], [
+                ],
+            ],
+            [
                 'Inner',
                 'CmsAuditItem', 'CmsUser',
-                array('a.username' => 'dantleech'), array(
-                    array(
+                ['a.username' => 'dantleech'], [
+                    [
                         'a' => '/functional/audit0',
                         'b' => '/functional/dantleech',
-                    ),
-                    array(
+                    ],
+                    [
                         'a' => '/functional/audit2',
                         'b' => '/functional/dantleech',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
 
-            array(
+            [
                 'LeftOuter',
                 'CmsAuditItem', 'CmsUser',
-                null, array(
-                    array(
+                null, [
+                    [
                         'a' => '/functional/audit0',
                         'b' => '/functional/dantleech',
-                    ),
-                    array(
+                    ],
+                    [
                         'a' => '/functional/audit2',
                         'b' => '/functional/dantleech',
-                    ),
-                    array(
+                    ],
+                    [
                         'a' => '/functional/audit1',
                         'b' => '/functional/winstonsmith',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
 
-            array(
+            [
                 'RightOuter',
                 'CmsUser', 'CmsAuditItem',
-                null, array(
-                    array(
+                null, [
+                    [
                         'a' => '/functional/dantleech',
                         'b' => '/functional/audit0',
-                    ),
-                    array(
+                    ],
+                    [
                         'a' => '/functional/dantleech',
                         'b' => '/functional/audit2',
-                    ),
-                    array(
+                    ],
+                    [
                         'a' => '/functional/winstonsmith',
                         'b' => '/functional/audit1',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
      * @dataProvider provideEquiJoinInner
      */
-    public function testEquiJoinInner($joinType, $leftClass, $rightClass, $criteria = null, $expectedPaths)
+    public function testEquiJoinInner($joinType, $leftClass, $rightClass, $criteria, $expectedPaths)
     {
         $leftFqn = 'Doctrine\Tests\Models\CMS\\'.$leftClass;
         $rightFqn = 'Doctrine\Tests\Models\CMS\\'.$rightClass;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QueryBuilderTest.php
@@ -3,10 +3,10 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\Tests\Models\Blog\User as BlogUser;
-use Doctrine\Tests\Models\Blog\Post;
 use Doctrine\Tests\Models\Blog\Comment;
+use Doctrine\Tests\Models\Blog\Post;
+use Doctrine\Tests\Models\Blog\User as BlogUser;
+use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\Util\NodeHelper;
 
@@ -37,60 +37,60 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
         NodeHelper::createPath($session, '/functional/user');
         NodeHelper::createPath($session, '/functional/post');
 
-        $user = new BlogUser;
+        $user = new BlogUser();
         $user->id = '/functional/user/dtl';
         $user->name = 'daniel';
         $user->username = 'dtl';
         $user->status = 'query_builder';
         $this->dm->persist($user);
 
-        $user = new BlogUser;
+        $user = new BlogUser();
         $user->id = '/functional/user/js';
         $user->username = 'js';
         $user->name = 'johnsmith';
         $user->status = 'query_builder';
         $this->dm->persist($user);
 
-        $user = new BlogUser;
+        $user = new BlogUser();
         $user->id = '/functional/user/js2';
         $user->name = 'johnsmith';
         $user->username = 'js2';
         $user->status = 'another_johnsmith';
         $this->dm->persist($user);
 
-        $post = new Post;
+        $post = new Post();
         $post->id = '/functional/post/post_1';
         $post->title = 'Post 2';
         $post->username = 'dtl';
         $this->dm->persist($post);
 
-        $comment1 = new Comment;
+        $comment1 = new Comment();
         $comment1->id = '/functional/post/post_1/comment_1';
         $comment1->title = 'Comment 1';
         $this->dm->persist($comment1);
 
-        $comment2 = new Comment;
+        $comment2 = new Comment();
         $comment2->id = '/functional/post/post_1/comment_2';
         $comment2->title = 'Comment 1';
         $this->dm->persist($comment2);
 
-        $reply1 = new Comment;
+        $reply1 = new Comment();
         $reply1->id = '/functional/post/post_1/comment_1/reply_1';
         $reply1->title = 'Reply to Comment 1';
         $this->dm->persist($reply1);
 
-        $post = new Post;
+        $post = new Post();
         $post->id = '/functional/post/post_2';
         $post->title = 'Post 2';
         $post->username = 'dtl';
         $this->dm->persist($post);
 
-        $comment3 = new Comment;
+        $comment3 = new Comment();
         $comment3->id = '/functional/post/post_2/comment_3';
         $comment3->title = 'Comment 3';
         $this->dm->persist($comment3);
 
-        $post3 = new Post;
+        $post3 = new Post();
         $post3->id = '/functional/post/post_3';
         $post3->title = 'Post 3';
         $post3->username = 'js';
@@ -102,6 +102,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
     protected function createQb()
     {
         $qb = $this->dm->createQueryBuilder();
+
         return $qb;
     }
 
@@ -290,8 +291,8 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
 
         switch ($qb->getQuery()->getLanguage()) {
         case 'JCR-SQL2':
-                $this->assertEquals(array('a'), $result->getSelectorNames());
-                $this->assertEquals(array('a.username' => 'dtl'), $values);
+                $this->assertEquals(['a'], $result->getSelectorNames());
+                $this->assertEquals(['a.username' => 'dtl'], $values);
                 break;
             case 'sql':
                 $this->markTestIncomplete('Not testing SQL for sql query language');
@@ -309,11 +310,11 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
 
         switch ($qb->getQuery()->getLanguage()) {
             case 'JCR-SQL2':
-                $this->assertEquals(array('a'), $result->getSelectorNames());
-                $this->assertEquals(array(
+                $this->assertEquals(['a'], $result->getSelectorNames());
+                $this->assertEquals([
                     'a.username' => 'dtl',
-                    'a.name' => 'daniel',
-                ), $values);
+                    'a.name'     => 'daniel',
+                ], $values);
                 break;
             case 'sql':
                 $this->markTestIncomplete('Not testing SQL for sql query language');
@@ -330,9 +331,9 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
 
         switch ($qb->getQuery()->getLanguage()) {
             case 'JCR-SQL2':
-                $this->assertEquals(array(
+                $this->assertEquals([
                     'a.status' => 'query_builder',
-                ), $values);
+                ], $values);
                 break;
             case 'sql':
                 $this->markTestIncomplete('Not testing SQL for sql query language');
@@ -347,10 +348,10 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
      */
     public function getTextSearches()
     {
-        return array(
-            array('name', 'johnsmith', 2),
-            array('username', 'dtl', 1),
-        );
+        return [
+            ['name', 'johnsmith', 2],
+            ['username', 'dtl', 1],
+        ];
     }
 
     /**
@@ -408,7 +409,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
 
     public function testConditionWithStaticLiteralOfDifferentType()
     {
-        $user = new BlogUser;
+        $user = new BlogUser();
         $user->id = '/functional/user/old';
         $user->name = 'I am old';
         $user->username = 'old';
@@ -422,7 +423,7 @@ class QueryBuilderTest extends PHPCRFunctionalTestCase
         $qb->where()->eq()
             ->field('a.age')
             ->literal('99') // we pass the age here as a string type
-        ;
+;
         $q = $qb->getQuery();
         $res = $q->execute();
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/QuerySql2Test.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/QuerySql2Test.php
@@ -2,14 +2,13 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Query\Query;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\Query\InvalidQueryException;
-use Doctrine\ODM\PHPCR\Query\Query;
 use PHPCR\Query\QueryInterface;
 
 /**
@@ -23,7 +22,8 @@ class QuerySql2Test extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -35,26 +35,26 @@ class QuerySql2Test extends PHPCRFunctionalTestCase
 
     public function queryStatements()
     {
-        return array(
-            array('SELECT username FROM [nt:unstructured] WHERE ISCHILDNODE("/functional")', 5),
-            array('SELECT username FROM [nt:unstructured] WHERE ISCHILDNODE("/functional") ORDER BY username', 5),
-            array('SELECT username FROM [nt:unstructured] WHERE ISCHILDNODE("/functional") AND username="dbu"', 1),
-            array('SELECT username FROM [nt:unstructured] WHERE ISCHILDNODE("/functional") AND username="notexisting"', 0),
-            array('invalidstatement', -1),
+        return [
+            ['SELECT username FROM [nt:unstructured] WHERE ISCHILDNODE("/functional")', 5],
+            ['SELECT username FROM [nt:unstructured] WHERE ISCHILDNODE("/functional") ORDER BY username', 5],
+            ['SELECT username FROM [nt:unstructured] WHERE ISCHILDNODE("/functional") AND username="dbu"', 1],
+            ['SELECT username FROM [nt:unstructured] WHERE ISCHILDNODE("/functional") AND username="notexisting"', 0],
+            ['invalidstatement', -1],
             // TODO: try a join
-        );
+        ];
     }
 
     public function queryRepositoryStatements()
     {
-        return array(
-            array('SELECT username FROM [nt:unstructured] AS a WHERE ISCHILDNODE(a, "/functional")', 4),
-            array('SELECT username FROM [nt:unstructured] AS a WHERE ISCHILDNODE(a, "/functional") ORDER BY username', 4),
-            array('SELECT username FROM [nt:unstructured] AS a WHERE ISCHILDNODE(a, "/functional") AND username="dbu"', 1),
-            array('SELECT username FROM [nt:unstructured] AS a WHERE ISCHILDNODE(a, "/functional") AND username="notexisting"', 0),
-            array('invalidstatement', -1),
+        return [
+            ['SELECT username FROM [nt:unstructured] AS a WHERE ISCHILDNODE(a, "/functional")', 4],
+            ['SELECT username FROM [nt:unstructured] AS a WHERE ISCHILDNODE(a, "/functional") ORDER BY username', 4],
+            ['SELECT username FROM [nt:unstructured] AS a WHERE ISCHILDNODE(a, "/functional") AND username="dbu"', 1],
+            ['SELECT username FROM [nt:unstructured] AS a WHERE ISCHILDNODE(a, "/functional") AND username="notexisting"', 0],
+            ['invalidstatement', -1],
             // TODO: try a join
-        );
+        ];
     }
 
     public function setUp()
@@ -65,26 +65,26 @@ class QuerySql2Test extends PHPCRFunctionalTestCase
 
         $versionNode = $this->node->addNode('node1', 'nt:unstructured');
         $versionNode->setProperty('username', 'dbu');
-        $versionNode->setProperty('numbers', array(3, 1, 2));
+        $versionNode->setProperty('numbers', [3, 1, 2]);
         $versionNode->setProperty('phpcr:class', $this->type);
 
         $versionNode = $this->node->addNode('node2', 'nt:unstructured');
         $versionNode->setProperty('username', 'johannes');
-        $versionNode->setProperty('numbers', array(3, 1, 2));
+        $versionNode->setProperty('numbers', [3, 1, 2]);
         $versionNode->setProperty('phpcr:class', $this->type);
 
         $versionNode = $this->node->addNode('node3', 'nt:unstructured');
         $versionNode->setProperty('username', 'lsmith');
-        $versionNode->setProperty('numbers', array(3, 1, 2));
+        $versionNode->setProperty('numbers', [3, 1, 2]);
         $versionNode->setProperty('phpcr:class', $this->type);
 
         $versionNode = $this->node->addNode('node4', 'nt:unstructured');
         $versionNode->setProperty('username', 'uwe');
-        $versionNode->setProperty('numbers', array(3, 1, 2));
+        $versionNode->setProperty('numbers', [3, 1, 2]);
         $versionNode->setProperty('phpcr:class', $this->type);
 
         $versionNode = $this->node->addNode('node5', 'nt:unstructured');
-        $versionNode->setProperty('numbers', array(3, 1, 2));
+        $versionNode->setProperty('numbers', [3, 1, 2]);
 
         $this->dm->getPhpcrSession()->save();
         $this->dm = $this->createDocumentManager();
@@ -133,18 +133,18 @@ class QuerySql2Test extends PHPCRFunctionalTestCase
         $query->setLimit(2);
         $result = $this->dm->getDocumentsByPhpcrQuery($query, $this->type);
         $this->assertCount(2, $result);
-        $ids = array();
-        $vals = array();
-        $nums = array();
+        $ids = [];
+        $vals = [];
+        $nums = [];
         foreach ($result as $obj) {
             $this->assertInstanceOf(QuerySql2TestObj::class, $obj);
             $ids[] = $obj->id;
             $vals[] = $obj->username;
             $nums[] = $obj->numbers;
         }
-        $this->assertEquals(array('/functional/node5', '/functional/node1'), $ids);
-        $this->assertEquals(array(null, 'dbu'), $vals);
-        $this->assertEquals(array(array(3, 1, 2), array(3, 1, 2)), $nums);
+        $this->assertEquals(['/functional/node5', '/functional/node1'], $ids);
+        $this->assertEquals([null, 'dbu'], $vals);
+        $this->assertEquals([[3, 1, 2], [3, 1, 2]], $nums);
     }
 }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -3,30 +3,30 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\PHPCRException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\PHPCRException;
+use Doctrine\Tests\Models\References\HardRefTestObj;
+use Doctrine\Tests\Models\References\NonRefTestObj;
+use Doctrine\Tests\Models\References\ParentTestObj;
 use Doctrine\Tests\Models\References\RefCascadeManyTestObj;
 use Doctrine\Tests\Models\References\RefCascadeTestObj;
-use Doctrine\Tests\Models\References\HardRefTestObj;
-use Doctrine\Tests\Models\References\RefManyTestObjPathStrategy;
-use Doctrine\Tests\Models\References\WeakRefTestObj;
-use Doctrine\Tests\Models\References\NonRefTestObj;
-use Doctrine\Tests\Models\References\RefType2TestObj;
-use Doctrine\Tests\Models\References\RefType1TestObj;
 use Doctrine\Tests\Models\References\RefDifTestObj;
-use Doctrine\Tests\Models\References\RefTestObj;
-use Doctrine\Tests\Models\References\RefTestObjByPath;
-use Doctrine\Tests\Models\References\RefRefTestObj;
-use Doctrine\Tests\Models\References\RefTestPrivateObj;
 use Doctrine\Tests\Models\References\RefManyTestObj;
 use Doctrine\Tests\Models\References\RefManyTestObjForCascade;
+use Doctrine\Tests\Models\References\RefManyTestObjPathStrategy;
 use Doctrine\Tests\Models\References\RefManyWithParentTestObjForCascade;
-use Doctrine\Tests\Models\References\ParentTestObj;
+use Doctrine\Tests\Models\References\RefRefTestObj;
+use Doctrine\Tests\Models\References\RefTestObj;
+use Doctrine\Tests\Models\References\RefTestObjByPath;
+use Doctrine\Tests\Models\References\RefTestPrivateObj;
+use Doctrine\Tests\Models\References\RefType1TestObj;
+use Doctrine\Tests\Models\References\RefType2TestObj;
+use Doctrine\Tests\Models\References\WeakRefTestObj;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
+use PHPCR\ReferentialIntegrityException;
 use PHPCR\SessionInterface;
 use PHPCR\Util\UUIDHelper;
-use PHPCR\ReferentialIntegrityException;
 
 /**
  * @group functional
@@ -39,7 +39,8 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var SessionInterface
      */
     private $session;
@@ -70,9 +71,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refTestObj = new RefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->reference = $refRefTestObj;
 
@@ -94,7 +95,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testFindByUUID()
     {
         $refTestObj = new RefRefTestObj();
-        $refTestObj->id = "/functional/refRefTestObj";
+        $refTestObj->id = '/functional/refRefTestObj';
         $refTestObj->name = 'referrer';
 
         $this->dm->persist($refTestObj);
@@ -106,7 +107,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $document = $this->dm->find($this->referencedType, $node->getIdentifier());
         $this->assertInstanceOf($this->referencedType, $document);
 
-        $documents = $this->dm->findMany($this->referencedType, array($node->getIdentifier()));
+        $documents = $this->dm->findMany($this->referencedType, [$node->getIdentifier()]);
         $this->assertInstanceOf($this->referencedType, $documents->first());
     }
 
@@ -115,9 +116,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refTestObj = new RefTestObjByPath();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->reference = $refRefTestObj;
 
@@ -127,11 +128,11 @@ class ReferenceTest extends PHPCRFunctionalTestCase
 
         $this->assertTrue($this->session->getNode('/functional')->hasNode('refRefTestObj'));
         $refRefTestNode = $this->session->getNode('/functional/refRefTestObj');
-        $this->assertEquals($refRefTestNode ->getProperty('name')->getString(), 'referenced');
+        $this->assertEquals($refRefTestNode->getProperty('name')->getString(), 'referenced');
 
         $refTestNode = $this->session->getNode('/functional/refTestObj');
         $this->assertTrue($refTestNode->hasProperty('reference'));
-        $this->assertEquals($refTestNode->getProperty('reference')->getValue(), "/functional/refRefTestObj");
+        $this->assertEquals($refTestNode->getProperty('reference')->getValue(), '/functional/refRefTestObj');
 
         $this->assertEquals($refRefTestNode->getPath(), $refTestNode->getProperty('reference')->getString());
     }
@@ -141,9 +142,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refTestObj = new RefTestPrivateObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->setReference($refRefTestObj);
 
@@ -171,8 +172,8 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refTestObj = new RefTestPrivateObj();
         $refRefTestObj = new NonRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
 
         $refTestObj->setReference($refRefTestObj);
 
@@ -207,7 +208,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refRefTestObj->id = '/functional/refRefTestObj';
         $refRefTestObj->name = 'referenced';
 
-        $refTestObj->reference = array($refRefTestObj);
+        $refTestObj->reference = [$refRefTestObj];
 
         $this->expectException(PHPCRException::class);
         $this->expectExceptionMessage('Referenced document is not stored correctly in a reference-one property.');
@@ -304,9 +305,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refTestObj = new RefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->reference = $refRefTestObj;
 
@@ -329,7 +330,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testUpdateMany()
     {
         $refManyTestObj = new RefManyTestObj();
-        $refManyTestObj->id = "/functional/refManyTestObj";
+        $refManyTestObj->id = '/functional/refManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -347,7 +348,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
 
         $i = 0;
         foreach ($referrer->references as $reference) {
-            $reference->name = "new name ".$i;
+            $reference->name = 'new name '.$i;
             $i++;
         }
 
@@ -359,7 +360,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
 
         $i = 0;
         foreach ($this->session->getNode('/functional/refManyTestObj')->getProperty('myReferences')->getNode() as  $node) {
-            $this->assertEquals($node->getProperty('name')->getValue(), "new name ".$i);
+            $this->assertEquals($node->getProperty('name')->getValue(), 'new name '.$i);
             $i++;
         }
         $this->assertEquals($i, $max);
@@ -368,7 +369,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testUpdateOneInMany()
     {
         $refManyTestObj = new RefManyTestObj();
-        $refManyTestObj->id = "/functional/refManyTestObj";
+        $refManyTestObj->id = '/functional/refManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -386,7 +387,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
 
         $pos = 2;
 
-        $referrer->references[$pos]->name = "new name";
+        $referrer->references[$pos]->name = 'new name';
 
         $this->dm->persist($referrer);
         $this->dm->flush();
@@ -399,7 +400,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
             if ($i != $pos) {
                 $this->assertEquals("refRefTestObj$i", $node->getProperty('name')->getValue());
             } else {
-                $this->assertEquals("new name", $referrer->references[$pos]->name);
+                $this->assertEquals('new name', $referrer->references[$pos]->name);
             }
             $i++;
         }
@@ -411,9 +412,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refManyTestObj = new RefManyTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refManyTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refManyTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refManyTestObj->references[] = $refRefTestObj;
 
@@ -423,18 +424,18 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertEquals(1, count($refManyTestObj->references));
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         unset($refManyTestObj->references[0]);
         $this->assertEquals(0, count($refManyTestObj->references));
         $this->assertNotNull($refManyTestObj->references);
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertNotNull($refManyTestObj->references);
         $this->assertEquals(0, count($refManyTestObj->references));
     }
@@ -445,11 +446,11 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refRefTestObjA = new RefRefTestObj();
         $refRefTestObjB = new RefRefTestObj();
 
-        $refManyTestObj->id = "/functional/refTestObj";
-        $refRefTestObjA->id = "/functional/refRefTestObjA";
-        $refRefTestObjA->name = "referencedA";
-        $refRefTestObjB->id = "/functional/refRefTestObjB";
-        $refRefTestObjB->name = "referencedB";
+        $refManyTestObj->id = '/functional/refTestObj';
+        $refRefTestObjA->id = '/functional/refRefTestObjA';
+        $refRefTestObjA->name = 'referencedA';
+        $refRefTestObjB->id = '/functional/refRefTestObjB';
+        $refRefTestObjB->name = 'referencedB';
 
         $refManyTestObj->references[] = $refRefTestObjA;
         $refManyTestObj->references[] = $refRefTestObjB;
@@ -460,18 +461,18 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertEquals(2, count($refManyTestObj->references));
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         unset($refManyTestObj->references[0]);
         $this->assertNotNull($refManyTestObj->references);
         $this->assertEquals(1, count($refManyTestObj->references));
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertEquals(1, count($refManyTestObj->references));
         unset($refManyTestObj->references[0]);
         $this->assertNotNull($refManyTestObj->references);
@@ -479,7 +480,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertNotNull($refManyTestObj->references);
         $this->assertEquals(0, count($refManyTestObj->references));
     }
@@ -490,11 +491,11 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refRefTestObjA = new RefRefTestObj();
         $refRefTestObjB = new RefRefTestObj();
 
-        $refManyTestObj->id = "/functional/refTestObj";
-        $refRefTestObjA->id = "/functional/refRefTestObjA";
-        $refRefTestObjA->name = "referencedA";
-        $refRefTestObjB->id = "/functional/refRefTestObjB";
-        $refRefTestObjB->name = "referencedB";
+        $refManyTestObj->id = '/functional/refTestObj';
+        $refRefTestObjA->id = '/functional/refRefTestObjA';
+        $refRefTestObjA->name = 'referencedA';
+        $refRefTestObjB->id = '/functional/refRefTestObjB';
+        $refRefTestObjB->name = 'referencedB';
 
         $refManyTestObj->references[] = $refRefTestObjA;
         $refManyTestObj->references[] = $refRefTestObjB;
@@ -505,18 +506,18 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertEquals(2, count($refManyTestObj->references));
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         unset($refManyTestObj->references[0]);
         unset($refManyTestObj->references[1]);
         $this->assertEquals(0, count($refManyTestObj->references));
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertEquals(0, count($refManyTestObj->references));
     }
 
@@ -526,11 +527,11 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refRefTestObjA = new RefRefTestObj();
         $refRefTestObjB = new RefRefTestObj();
 
-        $refManyTestObj->id = "/functional/refTestObj";
-        $refRefTestObjA->id = "/functional/refRefTestObjA";
-        $refRefTestObjA->name = "referencedA";
-        $refRefTestObjB->id = "/functional/refRefTestObjB";
-        $refRefTestObjB->name = "referencedB";
+        $refManyTestObj->id = '/functional/refTestObj';
+        $refRefTestObjA->id = '/functional/refRefTestObjA';
+        $refRefTestObjA->name = 'referencedA';
+        $refRefTestObjB->id = '/functional/refRefTestObjB';
+        $refRefTestObjB->name = 'referencedB';
 
         $this->assertEquals(0, count($refManyTestObj->references));
 
@@ -538,21 +539,21 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertEquals(0, count($refManyTestObj->references));
         $refManyTestObj->references[] = $refRefTestObjA;
         $this->assertEquals(1, count($refManyTestObj->references));
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertEquals(1, count($refManyTestObj->references));
         $refManyTestObj->references[] = $refRefTestObjB;
         $this->assertEquals(2, count($refManyTestObj->references));
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, "/functional/refTestObj");
+        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
         $this->assertEquals(2, count($refManyTestObj->references));
     }
 
@@ -561,9 +562,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refTestObj = new RefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->reference = $refRefTestObj;
 
@@ -587,7 +588,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testRemoveReferrerMany()
     {
         $refManyTestObj = new RefManyTestObj();
-        $refManyTestObj->id = "/functional/refManyTestObj";
+        $refManyTestObj->id = '/functional/refManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -620,16 +621,16 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Remove referrer node, but change referenced node before
+     * Remove referrer node, but change referenced node before.
      */
     public function testRemoveReferrerChangeBefore()
     {
         $refTestObj = new RefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->reference = $refRefTestObj;
 
@@ -653,12 +654,12 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Remove referrer node, but change referenced nodes before
+     * Remove referrer node, but change referenced nodes before.
      */
     public function testRemoveReferrerManyChangeBefore()
     {
         $refManyTestObj = new RefManyTestObj();
-        $refManyTestObj->id = "/functional/refManyTestObj";
+        $refManyTestObj->id = '/functional/refManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -688,7 +689,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->assertNull($testReferrer);
 
         for ($i = 0; $i < $max; $i++) {
-            $this->assertEquals("new name $i", $this->session->getNode("/functional/refRefTestObj$i")->getPropertyValue("name"));
+            $this->assertEquals("new name $i", $this->session->getNode("/functional/refRefTestObj$i")->getPropertyValue('name'));
         }
     }
 
@@ -697,9 +698,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refTestObj = new RefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->reference = $refRefTestObj;
 
@@ -724,9 +725,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $weakRefTestObj = new WeakRefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $weakRefTestObj->id = "/functional/weakRefTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $weakRefTestObj->id = '/functional/weakRefTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $weakRefTestObj->reference = $refRefTestObj;
 
@@ -748,9 +749,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $hardRefTestObj = new HardRefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $hardRefTestObj->id = "/functional/hardRefTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $hardRefTestObj->id = '/functional/hardRefTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $hardRefTestObj->reference = $refRefTestObj;
 
@@ -771,9 +772,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $hardRefTestObj = new HardRefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $hardRefTestObj->id = "/functional/hardRefTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $hardRefTestObj->id = '/functional/hardRefTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $hardRefTestObj->reference = $refRefTestObj;
 
@@ -879,7 +880,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testDeleteOneInMany()
     {
         $refManyTestObj = new RefManyTestObj();
-        $refManyTestObj->id = "/functional/refManyTestObj";
+        $refManyTestObj->id = '/functional/refManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -904,7 +905,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $names = array();
+        $names = [];
         for ($i = 0; $i < $max; $i++) {
             if ($i != $pos) {
                 $names[] = "refRefTestObj$i";
@@ -929,7 +930,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $referenced = new RefRefTestObj();
 
         $referrer->id = '/functional/refTestObj';
-        $referenced->id = "/functional/refRefTestObj";
+        $referenced->id = '/functional/refRefTestObj';
 
         $this->dm->persist($referrer);
         $referrer->name = 'Referrer';
@@ -957,7 +958,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testModificationManyAfterPersist()
     {
         $refManyTestObj = new RefManyTestObj();
-        $refManyTestObj->id = "/functional/refManyTestObj";
+        $refManyTestObj->id = '/functional/refManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -993,44 +994,44 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testCreateCascade()
     {
         $referrer = new RefTestObj();
-        $referrer->id = "/functional/refTestObj";
+        $referrer->id = '/functional/refTestObj';
 
         $refCascadeTestObj = new RefCascadeTestObj();
-        $refCascadeTestObj->id = "/functional/refCascadeTestObj";
-        $refCascadeTestObj->name = "refCascadeTestObj";
+        $refCascadeTestObj->id = '/functional/refCascadeTestObj';
+        $refCascadeTestObj->name = 'refCascadeTestObj';
 
         $referrer->reference = $refCascadeTestObj;
 
         $refRefTestObj = new RefRefTestObj();
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "refRefTestObj";
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'refRefTestObj';
 
         $referrer->reference->reference = $refRefTestObj;
 
         $this->dm->persist($referrer);
         $this->dm->flush();
 
-        $this->assertTrue($this->session->getNode("/functional")->hasNode("refTestObj"));
-        $this->assertTrue($this->session->getNode("/functional")->hasNode("refCascadeTestObj"));
-        $this->assertTrue($this->session->getNode("/functional")->hasNode("refRefTestObj"));
+        $this->assertTrue($this->session->getNode('/functional')->hasNode('refTestObj'));
+        $this->assertTrue($this->session->getNode('/functional')->hasNode('refCascadeTestObj'));
+        $this->assertTrue($this->session->getNode('/functional')->hasNode('refRefTestObj'));
 
-        $this->assertTrue($this->session->getNode("/functional/refTestObj")->hasProperty("myReference"));
-        $this->assertTrue($this->session->getNode("/functional/refCascadeTestObj")->hasProperty("reference"));
+        $this->assertTrue($this->session->getNode('/functional/refTestObj')->hasProperty('myReference'));
+        $this->assertTrue($this->session->getNode('/functional/refCascadeTestObj')->hasProperty('reference'));
 
         $this->assertEquals(
-            $this->session->getNode("/functional/refCascadeTestObj")->getIdentifier(),
-            $this->session->getNode("/functional/refTestObj")->getProperty("myReference")->getString()
+            $this->session->getNode('/functional/refCascadeTestObj')->getIdentifier(),
+            $this->session->getNode('/functional/refTestObj')->getProperty('myReference')->getString()
         );
         $this->assertEquals(
-            $this->session->getNode("/functional/refRefTestObj")->getIdentifier(),
-            $this->session->getNode("/functional/refCascadeTestObj")->getProperty("reference")->getString()
+            $this->session->getNode('/functional/refRefTestObj')->getIdentifier(),
+            $this->session->getNode('/functional/refCascadeTestObj')->getProperty('reference')->getString()
         );
     }
 
     public function testCreateManyCascade()
     {
         $refManyTestObjForCascade = new RefManyTestObjForCascade();
-        $refManyTestObjForCascade->id = "/functional/refManyTestObjForCascade";
+        $refManyTestObjForCascade->id = '/functional/refManyTestObjForCascade';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -1043,7 +1044,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $j = 0;
         foreach ($refManyTestObjForCascade->references as $reference) {
             for ($i = 0; $i < $max; $i++) {
-                $newRefRefTestObj= new RefRefTestObj();
+                $newRefRefTestObj = new RefRefTestObj();
                 $newRefRefTestObj->id = "/functional/refRefTestObj$j$i";
                 $newRefRefTestObj->name = "refRefTestObj$j$i";
                 $reference->references[] = $newRefRefTestObj;
@@ -1055,20 +1056,20 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertTrue($this->session->getNode("/functional")->hasNode("refManyTestObjForCascade"));
+        $this->assertTrue($this->session->getNode('/functional')->hasNode('refManyTestObjForCascade'));
 
-        $refIds = $this->session->getNode("/functional/refManyTestObjForCascade")->getProperty("references")->getString();
+        $refIds = $this->session->getNode('/functional/refManyTestObjForCascade')->getProperty('references')->getString();
         for ($i = 0; $i < $max; $i++) {
-            $this->assertTrue($this->session->getNode("/functional")->hasNode("refCascadeManyTestObj$i"));
+            $this->assertTrue($this->session->getNode('/functional')->hasNode("refCascadeManyTestObj$i"));
             $this->assertTrue($this->session->getNode("/functional/refCascadeManyTestObj$i")->hasProperty('references'));
             $this->assertTrue(in_array($this->session->getNode("/functional/refCascadeManyTestObj$i")->getIdentifier(), $refIds));
         }
 
         for ($j = 0; $j < $max; $j++) {
-            $refIds = $this->session->getNode("/functional/refCascadeManyTestObj$j")->getProperty("references")->getString();
+            $refIds = $this->session->getNode("/functional/refCascadeManyTestObj$j")->getProperty('references')->getString();
             for ($i = 0; $i < $max; $i++) {
-                $this->assertTrue($this->session->getNode("/functional")->hasNode("refRefTestObj$j$i"));
-                $this->assertEquals("refRefTestObj$j$i", $this->session->getNode("/functional/refRefTestObj$j$i")->getPropertyValue("name"));
+                $this->assertTrue($this->session->getNode('/functional')->hasNode("refRefTestObj$j$i"));
+                $this->assertEquals("refRefTestObj$j$i", $this->session->getNode("/functional/refRefTestObj$j$i")->getPropertyValue('name'));
                 $this->assertTrue(in_array($this->session->getNode("/functional/refRefTestObj$j$i")->getIdentifier(), $refIds));
             }
         }
@@ -1077,7 +1078,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testManyCascadeChangeOne()
     {
         $refManyTestObjForCascade = new RefManyTestObjForCascade();
-        $refManyTestObjForCascade->id = "/functional/refManyTestObjForCascade";
+        $refManyTestObjForCascade->id = '/functional/refManyTestObjForCascade';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -1090,7 +1091,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $j = 0;
         foreach ($refManyTestObjForCascade->references as $reference) {
             for ($i = 0; $i < $max; $i++) {
-                $newRefRefTestObj= new RefRefTestObj();
+                $newRefRefTestObj = new RefRefTestObj();
                 $newRefRefTestObj->id = "/functional/refRefTestObj$j$i";
                 $newRefRefTestObj->name = "refRefTestObj$j$i";
                 $reference->references[] = $newRefRefTestObj;
@@ -1107,17 +1108,17 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $pos1 = 1;
         $pos2 = 2;
 
-        $referrer->references[$pos1]->references[$pos2]->name = "new name";
+        $referrer->references[$pos1]->references[$pos2]->name = 'new name';
 
         $this->dm->flush();
 
-        $this->assertEquals("new name", $this->session->getNode("/functional/refRefTestObj$pos1$pos2")->getPropertyValue("name"));
+        $this->assertEquals('new name', $this->session->getNode("/functional/refRefTestObj$pos1$pos2")->getPropertyValue('name'));
     }
 
     public function testManyCascadeDeleteOne()
     {
         $refManyTestObjForCascade = new RefManyTestObjForCascade();
-        $refManyTestObjForCascade->id = "/functional/refManyTestObjForCascade";
+        $refManyTestObjForCascade->id = '/functional/refManyTestObjForCascade';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -1130,7 +1131,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $j = 0;
         foreach ($refManyTestObjForCascade->references as $reference) {
             for ($i = 0; $i < $max; $i++) {
-                $newRefRefTestObj= new RefRefTestObj();
+                $newRefRefTestObj = new RefRefTestObj();
                 $newRefRefTestObj->id = "/functional/refRefTestObj$j$i";
                 $newRefRefTestObj->name = "refRefTestObj$j$i";
                 $reference->references[] = $newRefRefTestObj;
@@ -1151,66 +1152,66 @@ class ReferenceTest extends PHPCRFunctionalTestCase
 
         $this->dm->flush();
 
-        $this->assertFalse($this->session->getNode("/functional")->hasNode("refRefTestObj$pos1$pos2"));
-        $this->assertTrue($this->session->getNode("/functional/refCascadeManyTestObj$pos1")->hasProperty("references"));
-        $this->assertCount($max, $this->session->getNode("/functional/refCascadeManyTestObj$pos1")->getProperty("references")->getString());
+        $this->assertFalse($this->session->getNode('/functional')->hasNode("refRefTestObj$pos1$pos2"));
+        $this->assertTrue($this->session->getNode("/functional/refCascadeManyTestObj$pos1")->hasProperty('references'));
+        $this->assertCount($max, $this->session->getNode("/functional/refCascadeManyTestObj$pos1")->getProperty('references')->getString());
     }
 
     public function testRefDifTypes()
     {
         $refDifTestObj = new RefDifTestObj();
-        $refDifTestObj->id = "/functional/refDifTestObj";
+        $refDifTestObj->id = '/functional/refDifTestObj';
 
         $referenceType1 = new RefType1TestObj();
-        $referenceType1->id = "/functional/refType1TestObj";
-        $referenceType1->name = "type1";
+        $referenceType1->id = '/functional/refType1TestObj';
+        $referenceType1->name = 'type1';
         $refDifTestObj->referenceType1 = $referenceType1;
 
         $referenceType2 = new RefType2TestObj();
-        $referenceType2->id  = "/functional/refType2TestObj";
-        $referenceType2->name = "type2";
+        $referenceType2->id = '/functional/refType2TestObj';
+        $referenceType2->name = 'type2';
         $refDifTestObj->referenceType2 = $referenceType2;
 
         $this->dm->persist($refDifTestObj);
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find($this->referrerDifType, "/functional/refDifTestObj");
+        $referrer = $this->dm->find($this->referrerDifType, '/functional/refDifTestObj');
 
         $this->assertTrue(($referrer->referenceType1 instanceof RefType1TestObj));
         $this->assertTrue(($referrer->referenceType2 instanceof RefType2TestObj));
 
-        $this->assertEquals("type1", $referrer->referenceType1->name);
-        $this->assertEquals("type2", $referrer->referenceType2->name);
+        $this->assertEquals('type1', $referrer->referenceType1->name);
+        $this->assertEquals('type2', $referrer->referenceType2->name);
     }
 
     public function testRefDifTypesChangeBoth()
     {
         $refDifTestObj = new RefDifTestObj();
-        $refDifTestObj->id = "/functional/refDifTestObj";
+        $refDifTestObj->id = '/functional/refDifTestObj';
 
         $referenceType1 = new RefType1TestObj();
-        $referenceType1->id = "/functional/refType1TestObj";
-        $referenceType1->name = "type1";
+        $referenceType1->id = '/functional/refType1TestObj';
+        $referenceType1->name = 'type1';
         $refDifTestObj->referenceType1 = $referenceType1;
 
         $referenceType2 = new RefType2TestObj();
-        $referenceType2->id  = "/functional/refType2TestObj";
-        $referenceType2->name = "type2";
+        $referenceType2->id = '/functional/refType2TestObj';
+        $referenceType2->name = 'type2';
         $refDifTestObj->referenceType2 = $referenceType2;
 
         $this->dm->persist($refDifTestObj);
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find($this->referrerDifType, "/functional/refDifTestObj");
+        $referrer = $this->dm->find($this->referrerDifType, '/functional/refDifTestObj');
 
-        $referrer->referenceType1->name = "new name 1";
-        $referrer->referenceType2->name = "new name 2";
+        $referrer->referenceType1->name = 'new name 1';
+        $referrer->referenceType2->name = 'new name 2';
         $this->dm->flush();
 
-        $this->assertEquals("new name 1", $this->session->getNode("/functional/refType1TestObj")->getPropertyValue('name'));
-        $this->assertEquals("new name 2", $this->session->getNode("/functional/refType2TestObj")->getPropertyValue('name'));
+        $this->assertEquals('new name 1', $this->session->getNode('/functional/refType1TestObj')->getPropertyValue('name'));
+        $this->assertEquals('new name 2', $this->session->getNode('/functional/refType2TestObj')->getPropertyValue('name'));
     }
 
     public function testTwoDifferentObjectrefs()
@@ -1218,9 +1219,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $refTestObj = new RefTestObj();
         $refRefTestObj = new RefRefTestObj();
 
-        $refTestObj->id = "/functional/refTestObj";
-        $refRefTestObj->id = "/functional/refRefTestObj";
-        $refRefTestObj->name = "referenced";
+        $refTestObj->id = '/functional/refTestObj';
+        $refRefTestObj->id = '/functional/refRefTestObj';
+        $refRefTestObj->name = 'referenced';
 
         $refTestObj->reference = $refRefTestObj;
 
@@ -1228,20 +1229,20 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $ins0 = $this->dm->find($this->referencedType, "/functional/refRefTestObj");
-        $ins0->name = "0 new name";
-        $ins1 = $this->dm->find($this->referrerType, "/functional/refTestObj");
-        $ins1->reference->name = "1 new name";
+        $ins0 = $this->dm->find($this->referencedType, '/functional/refRefTestObj');
+        $ins0->name = '0 new name';
+        $ins1 = $this->dm->find($this->referrerType, '/functional/refTestObj');
+        $ins1->reference->name = '1 new name';
 
         $this->dm->flush();
-        $this->assertEquals("1 new name", $ins0->name);
+        $this->assertEquals('1 new name', $ins0->name);
         $this->assertEquals(spl_object_hash($ins1->reference), spl_object_hash($ins0));
     }
 
     public function testManyTwoDifferentObjectrefs()
     {
         $refManyTestObj = new RefManyTestObj();
-        $refManyTestObj->id = "/functional/refManyTestObj";
+        $refManyTestObj->id = '/functional/refManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -1255,8 +1256,8 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $documents = array();
-        $hashs = array();
+        $documents = [];
+        $hashs = [];
         for ($i = 0; $i < $max; $i++) {
             $doc = $this->dm->find($this->referencedType, "/functional/refRefTestObj$i");
             $documents[] = $doc;
@@ -1265,9 +1266,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
 
         asort($hashs);
 
-        $refDocuments = array();
-        $refHashs = array();
-        $refDocuments = $this->dm->find($this->referrerManyType, "/functional/refManyTestObj")->references;
+        $refDocuments = [];
+        $refHashs = [];
+        $refDocuments = $this->dm->find($this->referrerManyType, '/functional/refManyTestObj')->references;
 
         foreach ($refDocuments as $refDoc) {
             $refHashs[] = spl_object_hash($refDoc);
@@ -1297,9 +1298,9 @@ class ReferenceTest extends PHPCRFunctionalTestCase
     public function testManyCascadeWithParentDelete()
     {
         $refManyTestObjForCascade = new RefManyWithParentTestObjForCascade();
-        $refManyTestObjForCascade->id = "/functional/refManyWithParentTestObjForCascade";
+        $refManyTestObjForCascade->id = '/functional/refManyWithParentTestObjForCascade';
 
-        $references = array();
+        $references = [];
         for ($i = 0; $i < 3; $i++) {
             $newRefCascadeManyTestObj = new ParentTestObj();
             $newRefCascadeManyTestObj->nodename = "ref$i";
@@ -1312,10 +1313,10 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertTrue($this->session->getNode("/functional")->hasNode("refManyWithParentTestObjForCascade"));
+        $this->assertTrue($this->session->getNode('/functional')->hasNode('refManyWithParentTestObjForCascade'));
 
         for ($i = 0; $i < 3; $i++) {
-            $this->assertTrue($this->session->getNode("/functional/refManyWithParentTestObjForCascade")->hasNode("ref$i"));
+            $this->assertTrue($this->session->getNode('/functional/refManyWithParentTestObjForCascade')->hasNode("ref$i"));
         }
 
         $referrer = $this->dm->find($this->referrerManyWithParentForCascadeType, '/functional/refManyWithParentTestObjForCascade');
@@ -1323,14 +1324,14 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->remove($referrer);
         $this->dm->flush();
 
-        $this->assertFalse($this->session->getNode("/functional")->hasNode("refManyWithParentTestObjForCascade"));
+        $this->assertFalse($this->session->getNode('/functional')->hasNode('refManyWithParentTestObjForCascade'));
     }
 
     public function testCascadeRemoveByCollection()
     {
         $referrerRefManyTestObj = new ReferenceTestObj();
-        $referrerRefManyTestObj->id = "/functional/referenceTestObj";
-        $referrerRefManyTestObj->reference = array();
+        $referrerRefManyTestObj->id = '/functional/referenceTestObj';
+        $referrerRefManyTestObj->reference = [];
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -1344,7 +1345,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrered = $this->dm->find(null, "/functional/referenceTestObj");
+        $referrered = $this->dm->find(null, '/functional/referenceTestObj');
         $this->assertCount($max, $referrered->reference);
         $referrered->reference->remove(0);
         $referrered->reference->remove(3);
@@ -1353,7 +1354,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrered = $this->dm->find(null, "/functional/referenceTestObj");
+        $referrered = $this->dm->find(null, '/functional/referenceTestObj');
         $this->assertCount($max - 2, $referrered->reference);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
@@ -12,7 +12,7 @@ use PHPCR\SessionInterface;
 
 /**
  * These tests test if referrers are correctly read. For cascading
- * referrers, see CascadePersistTest
+ * referrers, see CascadePersistTest.
  *
  * @group functional
  */
@@ -33,10 +33,10 @@ class ReferrerTest extends PHPCRFunctionalTestCase
      */
     private $node;
 
-    protected $localePrefs = array(
-        'en' => array('en', 'fr'),
-        'fr' => array('fr', 'en'),
-    );
+    protected $localePrefs = [
+        'en' => ['en', 'fr'],
+        'fr' => ['fr', 'en'],
+    ];
 
     public function setUp()
     {
@@ -50,10 +50,10 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $referrerTestObj = new ReferrerTestObj();
         $referrerRefTestObj = new ReferrerRefTestObj();
 
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrer";
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
-        $referrerRefTestObj->name = "referenced";
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrer';
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
+        $referrerRefTestObj->name = 'referenced';
 
         $referrerTestObj->reference = $referrerRefTestObj;
 
@@ -61,10 +61,10 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         $this->assertCount(1, $reference->referrers);
-        $this->assertEquals("/functional/referrerTestObj", $reference->referrers->first()->id);
+        $this->assertEquals('/functional/referrerTestObj', $reference->referrers->first()->id);
     }
 
     public function testJIRA41DonotPersistReferrersCollection()
@@ -72,10 +72,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $referrerTestObj = new ReferrerTestObj();
         $referrerRefTestObj = new ReferrerRefTestObj();
 
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrer";
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
-
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrer';
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
         $referrerTestObj->reference = $referrerRefTestObj;
 
@@ -83,11 +82,10 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
+        $tmpReferrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $tmpReferrer->name = 'new referrer name';
 
-        $tmpReferrer = $this->dm->find(null, "/functional/referrerTestObj");
-        $tmpReferrer->name = "new referrer name";
-
-        $tmpReference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $tmpReference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         // persist referenced document again
         $this->dm->persist($tmpReference);
@@ -95,9 +93,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
-        $this->assertEquals("new referrer name", $reference->referrers->first()->name);
+        $this->assertEquals('new referrer name', $reference->referrers->first()->name);
     }
 
     public function testCreateWithoutRef()
@@ -119,9 +117,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $max = 5;
 
         $referrerRefTestObj = new ReferrerRefTestObj();
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
-        $ids = array();
+        $ids = [];
         for ($i = 0; $i < $max; $i++) {
             $referrerTestObj = new ReferrerTestObj();
             $referrerTestObj->id = "/functional/referrerTestObj$i";
@@ -135,11 +133,11 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         /** @var $reference ReferrerRefTestObj */
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         $this->assertCount($max, $reference->referrers);
 
-        $tmpIds = array();
+        $tmpIds = [];
         foreach ($reference->referrers as $referrer) {
             $this->assertInstanceOf(ReferrerTestObj::class, $referrer);
             $tmpIds[] = $referrer->id;
@@ -155,9 +153,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $max = 5;
 
         $referrerRefTestObj = new ReferrerRefTestObj();
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
-        $ids = array();
+        $ids = [];
         for ($i = 0; $i < $max; $i++) {
             $referrerTestObj = new ReferrerTestObj();
             $referrerTestObj->id = "/functional/referrerTestObj$i";
@@ -170,7 +168,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
         $this->dm->flush();
 
         $this->assertFalse($reference->referrers->isInitialized());
@@ -181,9 +179,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $referrerTestObj = new ReferrerTestObj();
         $referrerRefTestObj = new ReferrerRefTestObj();
 
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrer";
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrer';
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
         $referrerTestObj->reference = $referrerRefTestObj;
 
@@ -191,14 +189,14 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
-        $reference->referrers->first()->name = "referrer changed";
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference->referrers->first()->name = 'referrer changed';
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find(null, "/functional/referrerTestObj");
-        $this->assertEquals("referrer changed", $referrer->name);
+        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $this->assertEquals('referrer changed', $referrer->name);
     }
 
     public function testUpdateMany()
@@ -206,9 +204,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $max = 5;
 
         $referrerRefTestObj = new ReferrerRefTestObj();
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
-        $ids = array();
+        $ids = [];
         for ($i = 0; $i < $max; $i++) {
             $referrerTestObj = new ReferrerTestObj();
             $referrerTestObj->id = "/functional/referrerTestObj$i";
@@ -221,12 +219,12 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         $i = 0;
-        $names = array();
+        $names = [];
         foreach ($reference->referrers as $referrer) {
-            $newName = "new name ".$i;
+            $newName = 'new name '.$i;
             $names[] = $newName;
             $referrer->name = $newName;
             $i++;
@@ -235,7 +233,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $tmpNames = array();
+        $tmpNames = [];
         for ($i = 0; $i < $max; $i++) {
             $tmpNames[] = $this->dm->find(null, "/functional/referrerTestObj$i")->name;
         }
@@ -250,9 +248,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $max = 5;
 
         $referrerRefTestObj = new ReferrerRefTestObj();
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
-        $ids = array();
+        $ids = [];
         for ($i = 0; $i < $max; $i++) {
             $referrerTestObj = new ReferrerTestObj();
             $referrerTestObj->id = "/functional/referrerTestObj$i";
@@ -265,15 +263,15 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         $i = 0;
-        $names = array();
+        $names = [];
         foreach ($reference->referrers as $referrer) {
             if ($i !== 2) {
                 $names[] = $referrer->name;
             } else {
-                $newName = "new name ".$i;
+                $newName = 'new name '.$i;
                 $referrer->name = $newName;
                 $names[] = $newName;
             }
@@ -283,7 +281,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $tmpNames = array();
+        $tmpNames = [];
         for ($i = 0; $i < $max; $i++) {
             $tmpNames[] = $this->dm->find(null, "/functional/referrerTestObj$i")->name;
         }
@@ -298,9 +296,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $referrerTestObj = new ReferrerTestObj();
         $referrerRefTestObj = new ReferrerRefTestObj();
 
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrer";
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrer';
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
         $referrerTestObj->reference = $referrerRefTestObj;
 
@@ -308,20 +306,20 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         $this->assertCount(1, $reference->referrers);
-        $this->assertEquals("/functional/referrerTestObj", $reference->referrers->first()->id);
+        $this->assertEquals('/functional/referrerTestObj', $reference->referrers->first()->id);
 
-        $referrer = $this->dm->find(null, "/functional/referrerTestObj");
+        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
         $this->dm->remove($referrer);
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertNull($this->dm->find(null, "/functional/referrerTestObj"));
+        $this->assertNull($this->dm->find(null, '/functional/referrerTestObj'));
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         $this->assertCount(0, $reference->referrers);
         $this->assertFalse($reference->referrers->first());
@@ -332,9 +330,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $max = 5;
 
         $referrerRefTestObj = new ReferrerRefTestObj();
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
-        $ids = array();
+        $ids = [];
         for ($i = 0; $i < $max; $i++) {
             $referrerTestObj = new ReferrerTestObj();
             $referrerTestObj->id = "/functional/referrerTestObj$i";
@@ -355,11 +353,11 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
-        $this->assertCount($max -1, $reference->referrers);
+        $this->assertCount($max - 1, $reference->referrers);
 
-        $tmpIds = array();
+        $tmpIds = [];
         foreach ($reference->referrers as $referrer) {
             $tmpIds[] = $referrer->id;
         }
@@ -370,16 +368,16 @@ class ReferrerTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Remove referenced node, but change referrer node before
+     * Remove referenced node, but change referrer node before.
      */
     public function testRemoveReferrerChangeBefore()
     {
         $referrerTestObj = new ReferrerTestObj();
         $referrerRefTestObj = new ReferrerRefTestObj();
 
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrer";
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrer';
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
         $referrerTestObj->reference = $referrerRefTestObj;
 
@@ -387,30 +385,30 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
-        $reference->referrers[0]->name = "referenced changed";
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference->referrers[0]->name = 'referenced changed';
 
-        $referrer = $this->dm->find(null, "/functional/referrerTestObj");
+        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
         $referrer->reference = null;
 
         $this->dm->remove($reference);
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
         $this->assertNull($reference);
 
-        $referrer = $this->dm->find(null, "/functional/referrerTestObj");
-        $this->assertEquals("referenced changed", $referrer->name);
+        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $this->assertEquals('referenced changed', $referrer->name);
     }
 
     /**
-     * Remove referenced node, but change referrer nodes before
+     * Remove referenced node, but change referrer nodes before.
      */
     public function testRemoveReferrerManyChangeBefore()
     {
         $referrerRefManyTestObj = new ReferrerRefTestObj();
-        $referrerRefManyTestObj->id = "/functional/referrerRefManyTestObj";
+        $referrerRefManyTestObj->id = '/functional/referrerRefManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -425,9 +423,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefManyTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefManyTestObj');
 
-        $names = array();
+        $names = [];
         $i = 0;
         foreach ($reference->referrers as $referrer) {
             $name = "new name $i";
@@ -446,7 +444,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refNames = array();
+        $refNames = [];
         for ($i = 0; $i < $max; $i++) {
             $referrer = $this->dm->find(null, "/functional/referrerTestObj$i");
             $refNames[] = $referrer->name;
@@ -463,9 +461,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $referrerTestObj = new ReferrerTestObj();
         $referrerRefTestObj = new ReferrerRefTestObj();
 
-        $referrerTestObj->id = "/functional/referrerTestObj";
+        $referrerTestObj->id = '/functional/referrerTestObj';
         $referrerTestObj->name = 'referrer';
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
         $referrerTestObj->reference = $referrerRefTestObj;
 
@@ -473,37 +471,35 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         $this->dm->remove($reference->referrers[0]);
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertCount(0, $this->dm->find(null, "/functional/referrerRefTestObj")->referrers);
-        $this->assertFalse($this->session->getNode("/functional")->hasNode("referrerTestObj"));
+        $this->assertCount(0, $this->dm->find(null, '/functional/referrerRefTestObj')->referrers);
+        $this->assertFalse($this->session->getNode('/functional')->hasNode('referrerTestObj'));
     }
 
     public function testWeakHardRef()
     {
         $weakReferrerTestObj = new WeakReferrerTestObj();
-        $weakReferrerTestObj->id = "/functional/weakReferrerTestObj";
-        $weakReferrerTestObj->name = "weakReferrerTestObj";
+        $weakReferrerTestObj->id = '/functional/weakReferrerTestObj';
+        $weakReferrerTestObj->name = 'weakReferrerTestObj';
 
         $hardReferrerTestObj = new HardReferrerTestObj();
-        $hardReferrerTestObj->id = "/functional/hardReferrerTestObj";
-        $hardReferrerTestObj->name = "hardReferrerTestObj";
-
+        $hardReferrerTestObj->id = '/functional/hardReferrerTestObj';
+        $hardReferrerTestObj->name = 'hardReferrerTestObj';
 
         $weakReferrerRefTestObj = new WeakReferrerRefTestObj();
-        $weakReferrerRefTestObj->id = "/functional/weakReferrerRefTestObj";
+        $weakReferrerRefTestObj->id = '/functional/weakReferrerRefTestObj';
 
         $hardReferrerRefTestObj = new HardReferrerRefTestObj();
-        $hardReferrerRefTestObj->id = "/functional/hardReferrerRefTestObj";
+        $hardReferrerRefTestObj->id = '/functional/hardReferrerRefTestObj';
 
         $allReferrerRefTestObj = new AllReferrerRefTestObj();
-        $allReferrerRefTestObj->id = "/functional/allReferrerRefTestObj";
-
+        $allReferrerRefTestObj->id = '/functional/allReferrerRefTestObj';
 
         $weakReferrerTestObj->referenceToWeak = $weakReferrerRefTestObj;
         $weakReferrerTestObj->referenceToHard = $hardReferrerRefTestObj;
@@ -518,23 +514,23 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $weakReferrerRefTestObj = $this->dm->find(null, "/functional/weakReferrerRefTestObj");
+        $weakReferrerRefTestObj = $this->dm->find(null, '/functional/weakReferrerRefTestObj');
         $this->assertCount(1, $weakReferrerRefTestObj->referrers);
-        $this->assertEquals("weakReferrerTestObj", $weakReferrerRefTestObj->referrers[0]->name);
+        $this->assertEquals('weakReferrerTestObj', $weakReferrerRefTestObj->referrers[0]->name);
 
-        $hardReferrerRefTestObj = $this->dm->find(null, "/functional/hardReferrerRefTestObj");
+        $hardReferrerRefTestObj = $this->dm->find(null, '/functional/hardReferrerRefTestObj');
         $this->assertCount(1, $hardReferrerRefTestObj->referrers);
-        $this->assertEquals("hardReferrerTestObj", $hardReferrerRefTestObj->referrers[0]->name);
+        $this->assertEquals('hardReferrerTestObj', $hardReferrerRefTestObj->referrers[0]->name);
 
-        $allReferrerRefTestObj = $this->dm->find(null, "/functional/allReferrerRefTestObj");
+        $allReferrerRefTestObj = $this->dm->find(null, '/functional/allReferrerRefTestObj');
         $this->assertCount(2, $allReferrerRefTestObj->referrers);
 
-        $tmpNames = array();
+        $tmpNames = [];
         foreach ($allReferrerRefTestObj->referrers as $referrer) {
             $tmpNames[] = $referrer->name;
         }
 
-        $names = array("weakReferrerTestObj", "hardReferrerTestObj");
+        $names = ['weakReferrerTestObj', 'hardReferrerTestObj'];
         foreach ($names as $name) {
             $this->assertTrue(in_array($name, $tmpNames));
         }
@@ -547,13 +543,13 @@ class ReferrerTest extends PHPCRFunctionalTestCase
 
         $allReferrerRefNamedPropTestObj = new AllReferrerRefNamedPropTestObj();
 
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrerTestObj";
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrerTestObj';
 
-        $referrerNamedPropTestObj->id = "/functional/referrerNamedPropTestObj";
-        $referrerNamedPropTestObj->name = "referrerNamedPropTestObj";
+        $referrerNamedPropTestObj->id = '/functional/referrerNamedPropTestObj';
+        $referrerNamedPropTestObj->name = 'referrerNamedPropTestObj';
 
-        $allReferrerRefNamedPropTestObj->id = "/functional/allReferrerRefNamedPropTestObj";
+        $allReferrerRefNamedPropTestObj->id = '/functional/allReferrerRefNamedPropTestObj';
 
         $referrerTestObj->reference = $allReferrerRefNamedPropTestObj;
         $referrerNamedPropTestObj->namedReference = $allReferrerRefNamedPropTestObj;
@@ -563,10 +559,10 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referenced = $this->dm->find(null, "/functional/allReferrerRefNamedPropTestObj");
+        $referenced = $this->dm->find(null, '/functional/allReferrerRefNamedPropTestObj');
 
         $this->assertCount(1, $referenced->referrers);
-        $this->assertEquals("referrerNamedPropTestObj", $referenced->referrers[0]->name);
+        $this->assertEquals('referrerNamedPropTestObj', $referenced->referrers[0]->name);
 
         $otherRef = new OtherReferrerTestObj();
         $otherRef->id = '/functional/otherObj';
@@ -577,18 +573,18 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referenced = $this->dm->find(null, "/functional/allReferrerRefNamedPropTestObj");
+        $referenced = $this->dm->find(null, '/functional/allReferrerRefNamedPropTestObj');
 
         // the other ref is a different class and should get filtered out
         $this->assertCount(1, $referenced->referrers);
-        $this->assertEquals("referrerNamedPropTestObj", $referenced->referrers[0]->name);
+        $this->assertEquals('referrerNamedPropTestObj', $referenced->referrers[0]->name);
 
         $allReferrers = $this->dm->getReferrers($referenced, null, 'named-reference');
         $this->assertCount(2, $allReferrers);
     }
 
     /**
-     * There was a bug that documents translated fields where overwritten when they are re-created
+     * There was a bug that documents translated fields where overwritten when they are re-created.
      *
      * depends testCreate
      */
@@ -600,9 +596,9 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $referrerTestObj = new ReferrerTestObjMultilang();
         $referrerRefTestObj = new ReferrerRefTestObj();
 
-        $referrerTestObj->id = "/functional/referrerTestObj";
-        $referrerTestObj->name = "referrer";
-        $referrerRefTestObj->id = "/functional/referrerRefTestObj";
+        $referrerTestObj->id = '/functional/referrerTestObj';
+        $referrerTestObj->name = 'referrer';
+        $referrerRefTestObj->id = '/functional/referrerRefTestObj';
 
         $referrerTestObj->reference = $referrerRefTestObj;
 
@@ -611,7 +607,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $referrer = $this->dm->find(null, '/functional/referrerTestObj');
-        $referenced = $this->dm->find(null, "/functional/referrerRefTestObj");
+        $referenced = $this->dm->find(null, '/functional/referrerRefTestObj');
 
         $referrer->name = 'changed';
         $this->assertEquals('changed', $referrer->name);
@@ -624,7 +620,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
     public function testCascadeRemoveByCollection()
     {
         $referrerRefManyTestObj = new ReferrerRefTestObj2();
-        $referrerRefManyTestObj->id = "/functional/referrerRefManyTestObj";
+        $referrerRefManyTestObj->id = '/functional/referrerRefManyTestObj';
 
         $max = 5;
         for ($i = 0; $i < $max; $i++) {
@@ -639,7 +635,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referenced = $this->dm->find(null, "/functional/referrerRefManyTestObj");
+        $referenced = $this->dm->find(null, '/functional/referrerRefManyTestObj');
         $this->assertCount($max, $referenced->referrers);
         $referenced->referrers->remove(0);
         $referenced->referrers->remove(3);
@@ -648,7 +644,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referenced = $this->dm->find(null, "/functional/referrerRefManyTestObj");
+        $referenced = $this->dm->find(null, '/functional/referrerRefManyTestObj');
         $this->assertCount($max - 2, $referenced->referrers);
     }
 }
@@ -678,7 +674,8 @@ class WeakReferrerTestObj
     /** @PHPCRODM\Id */
     public $id;
     /**
-     * Should implicitly default to strategy="weak"
+     * Should implicitly default to strategy="weak".
+     *
      * @PHPCRODM\ReferenceOne(targetDocument="WeakReferrerRefTestObj", cascade="persist")
      */
     public $referenceToWeak;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/RefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/RefreshTest.php
@@ -2,12 +2,12 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\References\ParentTestObj;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\Common\Proxy\Proxy;
 
 class RefreshTest extends PHPCRFunctionalTestCase
 {
@@ -18,14 +18,14 @@ class RefreshTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $this->node = $this->resetFunctionalNode($this->dm);
         $this->dm->getPhpcrSession()->save();
     }
 
     public function testBasicRefresh()
     {
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->id = '/functional/Guilherme';
         $user->username = 'gblanco';
 
@@ -41,18 +41,18 @@ class RefreshTest extends PHPCRFunctionalTestCase
 
     public function testRefreshResetsCollection()
     {
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->id = '/functional/Guilherme';
         $user->username = 'gblanco';
 
         // Add a group
-        $group1 = new CmsGroup;
+        $group1 = new CmsGroup();
         $group1->name = '12345';
         $group1->id = '/functional/group1';
         $user->addGroup($group1);
 
         // Add a group
-        $group2 = new CmsGroup;
+        $group2 = new CmsGroup();
         $group2->name = '54321';
         $group2->id = '/functional/group2';
 
@@ -93,7 +93,7 @@ class RefreshTest extends PHPCRFunctionalTestCase
 
     public function testRefreshDetached()
     {
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->id = '/functional/Guilherme';
         $user->username = 'gblanco';
 
@@ -103,19 +103,19 @@ class RefreshTest extends PHPCRFunctionalTestCase
 
     public function testRefreshCollection()
     {
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->id = '/functional/Guilherme';
         $user->username = 'gblanco';
 
         // Add a group
-        $group1 = new CmsGroup;
-        $group1->name = "12345";
+        $group1 = new CmsGroup();
+        $group1->name = '12345';
         $group1->id = '/functional/group1';
         $user->addGroup($group1);
 
         // Add a group
-        $group2 = new CmsGroup;
-        $group2->name = "54321";
+        $group2 = new CmsGroup();
+        $group2->name = '54321';
         $group2->id = '/functional/group2';
 
         $this->dm->persist($user);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
@@ -2,11 +2,11 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
-use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Document\Generic;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
-use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 
 /**
  * @group functional
@@ -30,7 +30,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
 
     public function setUp()
     {
-        $this->dm = $this->createDocumentManager(array(__DIR__));
+        $this->dm = $this->createDocumentManager([__DIR__]);
         $repository = $this->dm->getPhpcrSession()->getRepository();
         if (!$repository->getDescriptor('node.type.management.orderable.child.nodes.supported')) {
             $this->markTestSkipped('PHPCR repository doesn\'t support orderable child nodes');
@@ -43,7 +43,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $node1->setNodename('source');
         $this->dm->persist($node1);
 
-        $this->childrenNames = array('first', 'second', 'third', 'fourth');
+        $this->childrenNames = ['first', 'second', 'third', 'fourth'];
         foreach ($this->childrenNames as $childName) {
             $child = new Generic();
             $child->setNodename($childName);
@@ -73,7 +73,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $parent = $this->dm->find(null, '/functional/source');
-        $this->assertSame(array('second', 'first', 'third', 'fourth'), $this->getChildrenNames($parent->getChildren()));
+        $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderMultiple()
@@ -88,7 +88,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $parent = $this->dm->find(null, '/functional/source');
-        $this->assertSame(array('second', 'first', 'fourth', 'third'), $this->getChildrenNames($parent->getChildren()));
+        $this->assertSame(['second', 'first', 'fourth', 'third'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderNoop()
@@ -120,7 +120,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $parent = $this->dm->find(null, '/functional/source');
-        $this->assertSame(array('second', 'first', 'third', 'fourth'), $this->getChildrenNames($parent->getChildren()));
+        $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderAfterLast()
@@ -134,7 +134,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $parent = $this->dm->find(null, '/functional/source');
-        $this->assertSame(array('second', 'third', 'fourth', 'first'), $this->getChildrenNames($parent->getChildren()));
+        $this->assertSame(['second', 'third', 'fourth', 'first'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderUpdatesChildren()
@@ -148,7 +148,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
 
         $this->dm->clear();
         $parent = $this->dm->find(null, '/functional/source');
-        $this->assertSame(array('second', 'first', 'third', 'fourth'), $this->getChildrenNames($parent->getChildren()));
+        $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderBeforeMove()
@@ -159,7 +159,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $parent = $this->dm->find(null, '/functional/target/new');
-        $this->assertSame(array('second', 'first', 'third', 'fourth'), $this->getChildrenNames($parent->getChildren()));
+        $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderAfterMove()
@@ -170,7 +170,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $parent = $this->dm->find(null, '/functional/target/new');
-        $this->assertSame(array('second', 'first', 'third', 'fourth'), $this->getChildrenNames($parent->getChildren()));
+        $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testRemoveAfterReorder()
@@ -198,15 +198,16 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $parent = $first->getParentDocument();
         $this->dm->reorder($parent, 'first', 'second', false);
         $this->dm->flush();
-        $this->assertSame(array('second', 'first', 'third', 'fourth'), $this->getChildrenNames($parent->getChildren()));
+        $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     private function getChildrenNames($children)
     {
-        $result = array();
+        $result = [];
         foreach ($children as $name => $child) {
             $result[] = $name;
         }
+
         return $result;
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/TargetDocumentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/TargetDocumentTest.php
@@ -4,8 +4,8 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
-use Doctrine\Tests\Models\References\RefType2TestObj;
 use Doctrine\Tests\Models\References\RefType1TestObj;
+use Doctrine\Tests\Models\References\RefType2TestObj;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
@@ -6,15 +6,15 @@ use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\ODM\PHPCR\Tools\Helper\TranslationConverter;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
+use Doctrine\Tests\Models\Blog\Comment;
 use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\Tests\Models\Translation\ChildTranslationArticle;
+use Doctrine\Tests\Models\Translation\ChildTranslationComment;
+use Doctrine\Tests\Models\Translation\Comment as TranslatedComment;
 use Doctrine\Tests\ODM\PHPCR\Functional\Translation\AttributeTranslationStrategyTest;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
-use Doctrine\Tests\Models\Blog\Comment;
-use Doctrine\Tests\Models\Translation\Comment as TranslatedComment;
-use Doctrine\Tests\Models\Translation\ChildTranslationComment;
 
 class TranslationConverterTest extends PHPCRFunctionalTestCase
 {
@@ -38,10 +38,10 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
      */
     private $converter;
 
-    private $localePrefs = array(
-        'en' => array('de'),
-        'de' => array('en'),
-    );
+    private $localePrefs = [
+        'en' => ['de'],
+        'de' => ['en'],
+    ];
 
     public function setUp()
     {
@@ -70,11 +70,11 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $comment->setProperty('phpcr:class', $class);
         $this->session->save();
 
-        $this->assertTrue($this->converter->convert($class, array('en')));
+        $this->assertTrue($this->converter->convert($class, ['en']));
         $this->session->save();
-        $this->assertTrue($this->converter->convert($class, array('en')));
+        $this->assertTrue($this->converter->convert($class, ['en']));
         $this->session->save();
-        $this->assertFalse($this->converter->convert($class, array('en')));
+        $this->assertFalse($this->converter->convert($class, ['en']));
         $this->session->save();
 
         $this->assertTrue(
@@ -97,7 +97,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Test when a document already had translated fields
+     * Test when a document already had translated fields.
      */
     public function testPartialTranslateAttribute()
     {
@@ -115,7 +115,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $comment->setProperty($field, 'Move to translated');
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($class, array('en'), array($field)));
+        $this->assertFalse($this->converter->convert($class, ['en'], [$field]));
         $this->session->save();
         $this->dm->clear();
 
@@ -159,7 +159,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $comment->setProperty($field, 'Move to translated');
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($class, array('en')));
+        $this->assertFalse($this->converter->convert($class, ['en']));
         $this->session->save();
         $this->dm->clear();
 
@@ -192,10 +192,10 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $comment = $this->node->addNode('convert');
         $comment->setProperty($field, 'Lorem ipsum...');
         $comment->setProperty('phpcr:class', $class);
-        $comment->setProperty('phpcr:classparents', array($parentClass));
+        $comment->setProperty('phpcr:classparents', [$parentClass]);
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($class, array('en')));
+        $this->assertFalse($this->converter->convert($class, ['en']));
 
         $this->session->save();
 
@@ -228,7 +228,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $comment->setProperty('phpcr:classparents', $parentClass);
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($class, array('en'), array(), AttributeTranslationStrategy::NAME));
+        $this->assertFalse($this->converter->convert($class, ['en'], [], AttributeTranslationStrategy::NAME));
 
         $this->session->save();
 
@@ -264,7 +264,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $comment->setProperty('phpcr:class', $class);
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($class, array('en'), array($field), 'attribute'));
+        $this->assertFalse($this->converter->convert($class, ['en'], [$field], 'attribute'));
 
         $this->session->save();
         $this->assertTrue(
@@ -291,7 +291,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Just make one field of a document untranslated again
+     * Just make one field of a document untranslated again.
      */
     public function testPartialUntranslateAttribute()
     {
@@ -312,7 +312,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         );
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($class, array('en'), array($field)));
+        $this->assertFalse($this->converter->convert($class, ['en'], [$field]));
         $this->session->save();
         $this->dm->clear();
 
@@ -353,7 +353,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $translation->setProperty($field, 'Lorem ipsum...');
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($class, array(), array($field), 'child'));
+        $this->assertFalse($this->converter->convert($class, [], [$field], 'child'));
 
         $this->session->save();
 
@@ -379,7 +379,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Just make one field of a document untranslated again
+     * Just make one field of a document untranslated again.
      */
     public function testPartialUntranslateChild()
     {
@@ -397,7 +397,7 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $node->getNode('phpcr_locale:en')->setProperty($field, 'Move to untranslated');
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($class, array('en'), array($field)));
+        $this->assertFalse($this->converter->convert($class, ['en'], [$field]));
         $this->session->save();
         $this->dm->clear();
 
@@ -443,10 +443,10 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $comment = $this->node->addNode('convert');
         $comment->setProperty($field, 'Lorem ipsum...');
         $comment->setProperty('phpcr:class', $class);
-        $comment->setProperty('phpcr:classparents', array($parentClass));
+        $comment->setProperty('phpcr:classparents', [$parentClass]);
         $this->session->save();
 
-        $this->assertFalse($this->converter->convert($parentClass, array('en')));
+        $this->assertFalse($this->converter->convert($parentClass, ['en']));
         $notices = $this->converter->getLastNotices();
         $this->assertCount(1, $notices);
         $this->assertArrayHasKey('/functional/convert', $notices);
@@ -458,14 +458,14 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
     {
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('To untranslate a document, you need to specify the previous translation strategy');
-        $this->converter->convert(Comment::class, array('en'));
+        $this->converter->convert(Comment::class, ['en']);
     }
 
     public function testUntranslateMissingFields()
     {
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('need to specify the fields that where previously translated');
-        $this->converter->convert(Comment::class, array(), array(), 'attribute');
+        $this->converter->convert(Comment::class, [], [], 'attribute');
     }
 
     /**
@@ -477,6 +477,6 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
 
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('locales must be specified');
-        $this->converter->convert(TranslatedComment::class, array());
+        $this->converter->convert(TranslatedComment::class, []);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/AttributeTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/AttributeTranslationStrategyTest.php
@@ -4,9 +4,9 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\Translation\Translation;
 use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
-use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\SessionInterface;
@@ -56,9 +56,9 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
     public function testSaveTranslation()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
-        $data['text'] ='Lorem ipsum...';
+        $data['text'] = 'Lorem ipsum...';
 
         $node = $this->getTestNode();
 
@@ -73,7 +73,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         // Then test we have what we expect in the content repository
-        $node = $this->session->getNode('/' . $this->testNodeName);
+        $node = $this->session->getNode('/'.$this->testNodeName);
 
         $this->assertTrue($node->hasProperty(self::propertyNameForLocale('en', 'topic')));
         $this->assertTrue($node->hasProperty(self::propertyNameForLocale('fr', 'topic')));
@@ -111,22 +111,22 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertEquals('English topic', $doc->topic);
         $this->assertEquals('English text', $doc->getText());
         $this->assertEquals('Custom property name', $doc->customPropertyName);
-        $this->assertEquals(array(), $doc->getSettings()); // nullable
+        $this->assertEquals([], $doc->getSettings()); // nullable
 
         // Load another language and test the document has been updated
         $strategy->loadTranslation($doc, $node, $this->metadata, 'fr');
 
         $this->assertEquals('Sujet français', $doc->topic);
         $this->assertEquals('Texte français', $doc->getText());
-        $this->assertEquals(array(), $doc->getSettings());
+        $this->assertEquals([], $doc->getSettings());
     }
 
     public function testSubRegionSaveTranslation()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
-        $data['text'] ='Lorem ipsum...';
+        $data['text'] = 'Lorem ipsum...';
 
         $node = $this->getTestNode();
 
@@ -141,7 +141,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         // Then test we have what we expect in the content repository
-        $node = $this->session->getNode('/' . $this->testNodeName);
+        $node = $this->session->getNode('/'.$this->testNodeName);
 
         $this->assertTrue($node->hasProperty(self::propertyNameForLocale('en', 'topic')));
         $this->assertTrue($node->hasProperty(self::propertyNameForLocale('en_US', 'topic')));
@@ -158,7 +158,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         // make sure getLocalesFor works as well.
         $doc = new Article();
         $locales = $strategy->getLocalesFor($doc, $node, $this->metadata);
-        $this->assertEquals(array('en', 'en_US'), $locales);
+        $this->assertEquals(['en', 'en_US'], $locales);
     }
 
     public function testSubRegionLoadTranslation()
@@ -184,14 +184,14 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertEquals('English topic', $doc->topic);
         $this->assertEquals('English text', $doc->getText());
         $this->assertEquals('Custom property name', $doc->customPropertyName);
-        $this->assertEquals(array(), $doc->getSettings()); // nullable
+        $this->assertEquals([], $doc->getSettings()); // nullable
 
         // Load another language and test the document has been updated
         $strategy->loadTranslation($doc, $node, $this->metadata, 'en_US');
 
         $this->assertEquals('American topic', $doc->topic);
         $this->assertEquals('American text', $doc->getText());
-        $this->assertEquals(array(), $doc->getSettings());
+        $this->assertEquals([], $doc->getSettings());
     }
 
     public function testLoadTranslationNotNullable()
@@ -217,12 +217,12 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
     public function testTranslationNullProperties()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
         $data['nullable'] = 'not null';
         $data['customPropertyName'] = 'Custom property name';
-        $data['settings'] = array('key' => 'value');
+        $data['settings'] = ['key' => 'value'];
 
         $node = $this->getTestNode();
         $node->setProperty('author', 'John Doe');
@@ -231,7 +231,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $strategy->saveTranslation($data, $node, $this->metadata, 'en');
 
         // Save translation in another language
-        $data = array();
+        $data = [];
         $data['topic'] = 'Un sujet intéressant';
         $data['text'] = 'Lorem français';
         $data['customPropertyName'] = null;
@@ -239,7 +239,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $strategy->saveTranslation($data, $node, $this->metadata, 'fr');
         $this->dm->flush();
 
-        $doc = new Article;
+        $doc = new Article();
         $doc->author = 'John Doe';
         $doc->topic = $data['topic'];
         $doc->setText($data['text']);
@@ -248,28 +248,28 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertEquals('Lorem ipsum...', $doc->getText());
         $this->assertEquals('not null', $doc->nullable);
         $this->assertEquals('Custom property name', $doc->customPropertyName);
-        $this->assertEquals(array('key' => 'value'), $doc->getSettings());
+        $this->assertEquals(['key' => 'value'], $doc->getSettings());
 
         $strategy->loadTranslation($doc, $node, $this->metadata, 'fr');
         $this->assertEquals('Un sujet intéressant', $doc->topic);
         $this->assertEquals('Lorem français', $doc->getText());
         $this->assertNull($doc->nullable);
         $this->assertNull($doc->customPropertyName);
-        $this->assertEquals(array(), $doc->getSettings());
+        $this->assertEquals([], $doc->getSettings());
 
-        $nullFields = $node->getProperty('phpcr_locale:fr' . AttributeTranslationStrategy::NULLFIELDS)->getValue();
-        $this->assertEquals(array(
+        $nullFields = $node->getProperty('phpcr_locale:fr'.AttributeTranslationStrategy::NULLFIELDS)->getValue();
+        $this->assertEquals([
             'custom-property-name',
-        ), $nullFields);
+        ], $nullFields);
     }
 
     public function testRemoveTranslation()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
-        $data['settings'] = array('setting-1' => 'one-setting');
+        $data['settings'] = ['setting-1' => 'one-setting'];
 
         $node = $this->getTestNode();
         $node->setProperty('author', 'John Doe');
@@ -286,7 +286,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertTrue($node->hasProperty('phpcr_locale:frnullfields'));
 
         // Then remove the french translation
-        $doc = new Article;
+        $doc = new Article();
         $doc->author = 'John Doe';
         $doc->topic = $data['topic'];
         $doc->setText($data['text']);
@@ -305,10 +305,10 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
     public function testRemoveTranslationSubLocale()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
-        $data['settings'] = array('setting-1' => 'one-setting');
+        $data['settings'] = ['setting-1' => 'one-setting'];
 
         $node = $this->getTestNode();
         $node->setProperty('author', 'John Doe');
@@ -325,7 +325,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertTrue($node->hasProperty('phpcr_locale:fr_CAnullfields'));
 
         // Then remove the french translation
-        $doc = new Article;
+        $doc = new Article();
         $doc->author = 'John Doe';
         $doc->topic = $data['topic'];
         $doc->setText($data['text']);
@@ -368,6 +368,7 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->session->save();
 
         $this->dm->clear();
+
         return $node;
     }
 
@@ -385,28 +386,28 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
 
     public static function propertyNameForLocale($locale, $property)
     {
-        return Translation::LOCALE_NAMESPACE . ':' . $locale . '-' . $property;
+        return Translation::LOCALE_NAMESPACE.':'.$locale.'-'.$property;
     }
 
     /**
      * Caution : Jackalope\Property guess the property type on the first element
      * So if it's an boolean, all your array will be set to true
-     * The Array has to be an array of string
+     * The Array has to be an array of string.
      */
     public function testTranslationArrayProperties()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
-        $data['settings'] = array(
+        $data['settings'] = [
             'is-active' => 'true',
-            'url'       => 'great-article-in-english.html'
-        );
-        $data['customNameSettings'] = array(
+            'url'       => 'great-article-in-english.html',
+        ];
+        $data['customNameSettings'] = [
             'is-active' => 'true',
-            'url'       => 'great-article-in-english.html'
-        );
+            'url'       => 'great-article-in-english.html',
+        ];
 
         $node = $this->getTestNode();
         $node->setProperty('author', 'John Doe');
@@ -417,60 +418,60 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         // Save translation in another language
 
         $data['topic'] = 'Un sujet intéressant';
-        $data['settings'] = array(
+        $data['settings'] = [
             'is-active' => 'true',
-            'url'       => 'super-article-en-francais.html'
-        );
-        $data['customNameSettings'] = array(
+            'url'       => 'super-article-en-francais.html',
+        ];
+        $data['customNameSettings'] = [
             'is-active' => 'true',
-            'url'       => 'super-article-en-francais.html'
-        );
+            'url'       => 'super-article-en-francais.html',
+        ];
 
         $strategy->saveTranslation($data, $node, $this->metadata, 'fr');
         $this->dm->flush();
 
-        $doc = new Article;
+        $doc = new Article();
         $doc->author = 'John Doe';
         $doc->topic = $data['topic'];
         $doc->setText($data['text']);
         $strategy->loadTranslation($doc, $node, $this->metadata, 'en');
 
-        $this->assertEquals(array('is-active', 'url'), array_keys($doc->getSettings()));
-        $this->assertEquals(array(
+        $this->assertEquals(['is-active', 'url'], array_keys($doc->getSettings()));
+        $this->assertEquals([
             'is-active' => 'true',
-            'url'       => 'great-article-in-english.html'
-        ), $doc->getSettings());
-        $this->assertEquals(array(
+            'url'       => 'great-article-in-english.html',
+        ], $doc->getSettings());
+        $this->assertEquals([
             'is-active' => 'true',
-            'url'       => 'great-article-in-english.html'
-        ), $doc->customNameSettings);
+            'url'       => 'great-article-in-english.html',
+        ], $doc->customNameSettings);
 
         $strategy->loadTranslation($doc, $node, $this->metadata, 'fr');
-        $this->assertEquals(array('is-active', 'url'), array_keys($doc->getSettings()));
-        $this->assertEquals(array(
+        $this->assertEquals(['is-active', 'url'], array_keys($doc->getSettings()));
+        $this->assertEquals([
             'is-active' => 'true',
-            'url'       => 'super-article-en-francais.html'
-        ), $doc->getSettings());
-        $this->assertEquals(array(
+            'url'       => 'super-article-en-francais.html',
+        ], $doc->getSettings());
+        $this->assertEquals([
             'is-active' => 'true',
-            'url'       => 'super-article-en-francais.html'
-        ), $doc->customNameSettings);
+            'url'       => 'super-article-en-francais.html',
+        ], $doc->customNameSettings);
     }
 
     public function testQueryBuilder()
     {
         $strategy = new AttributeTranslationStrategy($this->dm);
         $this->dm->setTranslationStrategy('attribute', $strategy);
-        $this->dm->setLocaleChooserStrategy(new LocaleChooser(array('en' => array('fr'), 'fr' => array('en')), 'en'));
+        $this->dm->setLocaleChooserStrategy(new LocaleChooser(['en' => ['fr'], 'fr' => ['en']], 'en'));
 
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
-        $data['settings'] = array(
+        $data['settings'] = [
             'is-active' => 'true',
-            'url'       => 'great-article-in-english.html'
-        );
+            'url'       => 'great-article-in-english.html',
+        ];
 
         $node = $this->getTestNode();
         $node->setProperty('author', 'John Doe');
@@ -481,10 +482,10 @@ class AttributeTranslationStrategyTest extends PHPCRFunctionalTestCase
         // Save translation in another language
 
         $data['topic'] = 'Un sujet intéressant';
-        $data['settings'] = array(
+        $data['settings'] = [
             'is-active' => 'true',
-            'url'       => 'super-article-en-francais.html'
-        );
+            'url'       => 'super-article-en-francais.html',
+        ];
 
         $strategy->saveTranslation($data, $node, $this->metadata, 'fr');
         $this->dm->getPhpcrSession()->save();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/ChildTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/ChildTranslationStrategyTest.php
@@ -4,14 +4,14 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\ChildTranslationStrategy;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
-use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\ODM\PHPCR\Translation\Translation;
+use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\ChildTranslationStrategy;
+use Doctrine\Tests\Models\Translation\Article;
+use Doctrine\Tests\Models\Translation\ChildTranslationArticle;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\SessionInterface;
 use PHPCR\WorkspaceInterface;
-use Doctrine\Tests\Models\Translation\ChildTranslationArticle;
 
 class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
 {
@@ -53,7 +53,7 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
     public function testSaveTranslation()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
 
@@ -89,12 +89,12 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
     public function testLoadTranslation()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['author'] = 'John Doe';
         $data['topic'] = 'English topic';
         $data['text'] = 'English text';
         $data['nullable'] = 'not null';
-        $data['settings'] = array('key' => 'value');
+        $data['settings'] = ['key' => 'value'];
 
         $node = $this->getTestNode();
 
@@ -102,7 +102,7 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         $strategy->saveTranslation($data, $node, $this->metadata, 'en');
 
         // Save translation in another language
-        $data = array();
+        $data = [];
         $data['author'] = 'John Doe';
         $data['topic'] = 'Sujet français';
         $data['text'] = 'Texte français';
@@ -110,7 +110,7 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         $strategy->saveTranslation($data, $node, $this->metadata, 'fr');
         $this->dm->flush();
 
-        $doc = new Article;
+        $doc = new Article();
         $doc->author = $data['author'];
         $doc->topic = $data['topic'];
         $doc->setText($data['text']);
@@ -120,7 +120,7 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertEquals('English topic', $doc->topic);
         $this->assertEquals('English text', $doc->getText());
         $this->assertEquals('not null', $doc->nullable);
-        $this->assertEquals(array('key' => 'value'), $doc->getSettings());
+        $this->assertEquals(['key' => 'value'], $doc->getSettings());
 
         // Load another language and test the document has been updated
         $strategy->loadTranslation($doc, $node, $this->metadata, 'fr');
@@ -128,7 +128,7 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->assertEquals('Sujet français', $doc->topic);
         $this->assertEquals('Texte français', $doc->text);
         $this->assertNull($doc->nullable);
-        $this->assertEquals(array(), $doc->getSettings());
+        $this->assertEquals([], $doc->getSettings());
     }
 
     public function testTranslationNullProperties()
@@ -158,8 +158,8 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         $node = $this->fillTranslations();
         $doc = new Article();
 
-        $subNode_en = $node->getNode(Translation::LOCALE_NAMESPACE . ":en");
-        $subNode_fr = $node->getNode(Translation::LOCALE_NAMESPACE . ":fr");
+        $subNode_en = $node->getNode(Translation::LOCALE_NAMESPACE.':en');
+        $subNode_fr = $node->getNode(Translation::LOCALE_NAMESPACE.':fr');
 
         $strategy = new ChildTranslationStrategy($this->dm);
 
@@ -175,9 +175,9 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         $node = $this->fillTranslations();
         $doc = new Article();
 
-        $subNode_en = $node->getNode(Translation::LOCALE_NAMESPACE . ":en");
-        $subNode_fr = $node->getNode(Translation::LOCALE_NAMESPACE . ":fr");
-        $subNode_de = $node->getNode(Translation::LOCALE_NAMESPACE . ":de");
+        $subNode_en = $node->getNode(Translation::LOCALE_NAMESPACE.':en');
+        $subNode_fr = $node->getNode(Translation::LOCALE_NAMESPACE.':fr');
+        $subNode_de = $node->getNode(Translation::LOCALE_NAMESPACE.':de');
 
         $strategy = new ChildTranslationStrategy($this->dm);
 
@@ -232,7 +232,7 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
     {
         $node = $this->fillTranslations();
 
-        $node->getNode(Translation::LOCALE_NAMESPACE . ':en')->remove();
+        $node->getNode(Translation::LOCALE_NAMESPACE.':en')->remove();
         $this->session->save();
 
         $doc = new Article();
@@ -248,18 +248,18 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         $subNode = $this->getTranslationNode($node, 'en');
         $subNode->setProperty('topic', 'English topic');
         $subNode->setProperty('text', 'English text');
-        $subNode->setProperty('settings', array());
+        $subNode->setProperty('settings', []);
         $subNode->setProperty('nullable', 'English is not null');
 
         $subNode = $this->getTranslationNode($node, 'fr');
         $subNode->setProperty('topic', 'Sujet français');
         $subNode->setProperty('text', 'Texte français');
-        $subNode->setProperty('settings', array());
+        $subNode->setProperty('settings', []);
 
         $subNode = $this->getTranslationNode($node, 'de');
         $subNode->setProperty('topic', 'Deutscher Betreff');
         $subNode->setProperty('text', 'Deutscher Text');
-        $subNode->setProperty('settings', array());
+        $subNode->setProperty('settings', []);
         $this->session->save();
 
         return $node;
@@ -272,15 +272,17 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         $this->session->save();
 
         $this->dm->clear();
+
         return $node;
     }
 
     protected function getTranslationNode($parentNode, $locale)
     {
-        $subNode = $parentNode->addNode(Translation::LOCALE_NAMESPACE . ":$locale");
+        $subNode = $parentNode->addNode(Translation::LOCALE_NAMESPACE.":$locale");
         $this->session->save();
 
         $this->dm->clear();
+
         return $subNode;
     }
 
@@ -295,30 +297,30 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
 
     public static function propertyNameForLocale($locale, $property)
     {
-        return Translation::LOCALE_NAMESPACE . '-' . $locale . '-' . $property;
+        return Translation::LOCALE_NAMESPACE.'-'.$locale.'-'.$property;
     }
 
     protected function nodeNameForLocale($locale)
     {
-        return '/' . $this->testNodeName . '/' . Translation::LOCALE_NAMESPACE . ":$locale";
+        return '/'.$this->testNodeName.'/'.Translation::LOCALE_NAMESPACE.":$locale";
     }
 
     /**
      * Caution : Jackalope\Property guess the property type on the first element
      * So if it's an boolean, all your array will be set to true
-     * The Array has to be an array of string
+     * The Array has to be an array of string.
      */
     public function testTranslationArrayProperties()
     {
         // First save some translations
-        $data = array();
+        $data = [];
         $data['author'] = 'John Doe';
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
-        $data['settings'] = array(
+        $data['settings'] = [
             'is-active' => 'true',
-            'url'       => 'great-article-in-english.html'
-        );
+            'url'       => 'great-article-in-english.html',
+        ];
 
         $node = $this->getTestNode();
 
@@ -327,46 +329,46 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
 
         // Save translation in another language
         $data['topic'] = 'Un sujet intéressant';
-        $data['settings'] = array(
+        $data['settings'] = [
             'is-active' => 'true',
-            'url'       => 'super-article-en-francais.html'
-        );
+            'url'       => 'super-article-en-francais.html',
+        ];
 
         $strategy->saveTranslation($data, $node, $this->metadata, 'fr');
         $this->dm->flush();
 
-        $doc = new Article;
+        $doc = new Article();
         $doc->author = $data['author'];
         $doc->topic = $data['topic'];
         $doc->setText($data['text']);
         $strategy->loadTranslation($doc, $node, $this->metadata, 'en');
-        $this->assertEquals(array('is-active', 'url'), array_keys($doc->getSettings()));
-        $this->assertEquals(array(
+        $this->assertEquals(['is-active', 'url'], array_keys($doc->getSettings()));
+        $this->assertEquals([
             'is-active' => 'true',
-            'url'       => 'great-article-in-english.html'
-        ), $doc->getSettings());
+            'url'       => 'great-article-in-english.html',
+        ], $doc->getSettings());
 
         $strategy->loadTranslation($doc, $node, $this->metadata, 'fr');
-        $this->assertEquals(array('is-active', 'url'), array_keys($doc->getSettings()));
-        $this->assertEquals(array(
+        $this->assertEquals(['is-active', 'url'], array_keys($doc->getSettings()));
+        $this->assertEquals([
             'is-active' => 'true',
-            'url'       => 'super-article-en-francais.html'
-        ), $doc->getSettings());
+            'url'       => 'super-article-en-francais.html',
+        ], $doc->getSettings());
     }
 
     public function testQueryBuilder()
     {
         $strategy = $this->dm->getTranslationStrategy('child');
-        $this->dm->setLocaleChooserStrategy(new LocaleChooser(array('en' => array('fr'), 'fr' => array('en')), 'en'));
+        $this->dm->setLocaleChooserStrategy(new LocaleChooser(['en' => ['fr'], 'fr' => ['en']], 'en'));
 
         // First save some translations
-        $data = array();
+        $data = [];
         $data['topic'] = 'Some interesting subject';
         $data['text'] = 'Lorem ipsum...';
-        $data['settings'] = array(
+        $data['settings'] = [
             'is-active' => 'true',
-            'url'       => 'great-article-in-english.html'
-        );
+            'url'       => 'great-article-in-english.html',
+        ];
 
         $node = $this->getTestNode();
         $node->setProperty('author', 'John Doe');
@@ -377,10 +379,10 @@ class ChildTranslationStrategyTest extends PHPCRFunctionalTestCase
         // Save translation in another language
 
         $data['topic'] = 'Un sujet intéressant';
-        $data['settings'] = array(
+        $data['settings'] = [
             'is-active' => 'true',
-            'url'       => 'super-article-en-francais.html'
-        );
+            'url'       => 'super-article-en-francais.html',
+        ];
 
         $strategy->saveTranslation($data, $node, $this->metadata, 'fr');
         $this->dm->getPhpcrSession()->save();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
@@ -2,20 +2,20 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
+use Doctrine\ODM\PHPCR\Document\Generic;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\PHPCRException;
+use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
+use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
+use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\Tests\Models\Translation\Comment;
-use Doctrine\Tests\Models\Translation\InvalidMapping;
 use Doctrine\Tests\Models\Translation\DerivedArticle;
-use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\Translation\InvalidMapping;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
-use Doctrine\ODM\PHPCR\PHPCRException;
-use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
-use Doctrine\ODM\PHPCR\Document\Generic;
 
 class DocumentManagerTest extends PHPCRFunctionalTestCase
 {
@@ -56,12 +56,12 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
      */
     private $childrenClass = Comment::class;
 
-    private $localePrefs = array(
-        'en' => array('de', 'fr'),
-        'fr' => array('de', 'en'),
-        'de' => array('en'),
-        'it' => array('fr', 'de', 'en'),
-    );
+    private $localePrefs = [
+        'en' => ['de', 'fr'],
+        'fr' => ['de', 'en'],
+        'de' => ['en'],
+        'it' => ['fr', 'de', 'en'],
+    ];
 
     public function setUp()
     {
@@ -74,12 +74,12 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->metadata = $this->dm->getClassMetadata($this->class);
 
         $this->doc = new Article();
-        $this->doc->id = '/functional/' . $this->testNodeName;
+        $this->doc->id = '/functional/'.$this->testNodeName;
         $this->doc->author = 'John Doe';
         $this->doc->topic = 'Some interesting subject';
         $this->doc->setText('Lorem ipsum...');
-        $this->doc->setSettings(array());
-        $this->doc->assoc = array('key' => 'value');
+        $this->doc->setSettings([]);
+        $this->doc->assoc = ['key' => 'value'];
     }
 
     private function getTestNode()
@@ -140,7 +140,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->bindTranslation($this->doc, 'en');
         $this->dm->flush();
 
-        $this->assertEquals(array('en'), $this->dm->getLocalesFor($this->doc));
+        $this->assertEquals(['en'], $this->dm->getLocalesFor($this->doc));
 
         $this->doc->topic = 'Un sujet intéressant';
         $this->dm->bindTranslation($this->doc, 'fr');
@@ -149,23 +149,23 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
         $this->doc = $this->dm->findTranslation(null, $this->doc->id, 'fr');
 
-        $this->assertEquals(array('en', 'fr'), $this->dm->getLocalesFor($this->doc));
+        $this->assertEquals(['en', 'fr'], $this->dm->getLocalesFor($this->doc));
 
         $this->dm->removeTranslation($this->doc, 'en');
-        $this->assertEquals(array('fr'), $this->dm->getLocalesFor($this->doc));
+        $this->assertEquals(['fr'], $this->dm->getLocalesFor($this->doc));
         $this->dm->clear();
 
         $this->doc = $this->dm->findTranslation(null, $this->doc->id, 'fr');
-        $this->assertEquals(array('en', 'fr'), $this->dm->getLocalesFor($this->doc));
+        $this->assertEquals(['en', 'fr'], $this->dm->getLocalesFor($this->doc));
         $this->dm->removeTranslation($this->doc, 'en');
 
         $this->dm->flush();
-        $this->assertEquals(array('fr'), $this->dm->getLocalesFor($this->doc));
+        $this->assertEquals(['fr'], $this->dm->getLocalesFor($this->doc));
 
         $this->dm->clear();
         $this->doc = $this->dm->find(null, $this->doc->id);
 
-        $this->assertEquals(array('fr'), $this->dm->getLocalesFor($this->doc));
+        $this->assertEquals(['fr'], $this->dm->getLocalesFor($this->doc));
 
         try {
             $this->dm->removeTranslation($this->doc, 'fr');
@@ -175,7 +175,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * find translation in non-default language and then save it back has to keep language
+     * find translation in non-default language and then save it back has to keep language.
      */
     public function testFindTranslationAndUpdate()
     {
@@ -193,7 +193,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
         $this->assertEquals('Un intéressant', $node->getPropertyValue(AttributeTranslationStrategyTest::propertyNameForLocale('fr', 'topic')));
 
-        $this->doc = $this->dm->findTranslation(null, '/functional/' . $this->testNodeName, 'fr');
+        $this->doc = $this->dm->findTranslation(null, '/functional/'.$this->testNodeName, 'fr');
         $this->doc->topic = 'Un sujet intéressant';
         $this->dm->flush();
 
@@ -201,7 +201,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * changing the locale and flushing should pick up changes automatically
+     * changing the locale and flushing should pick up changes automatically.
      */
     public function testUpdateLocaleAndFlush()
     {
@@ -216,7 +216,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->assertDocumentStored();
 
         // Get de translation via fallback en
-        $this->doc = $this->dm->findTranslation(null, '/functional/' . $this->testNodeName, 'de');
+        $this->doc = $this->dm->findTranslation(null, '/functional/'.$this->testNodeName, 'de');
         $this->doc->topic = 'Ein interessantes Thema';
 
         //set locale explicitly
@@ -255,7 +255,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->persist($this->doc);
         $this->dm->flush();
 
-        $this->doc = $this->dm->find($this->class, '/functional/' . $this->testNodeName);
+        $this->doc = $this->dm->find($this->class, '/functional/'.$this->testNodeName);
 
         $this->assertNotNull($this->doc);
         $this->assertEquals('en', $this->doc->locale);
@@ -273,7 +273,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->persist($this->doc);
         $this->dm->flush();
 
-        $this->doc = $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'fr');
+        $this->doc = $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'fr');
 
         $this->assertNotNull($this->doc);
         $this->assertEquals('fr', $this->doc->locale);
@@ -281,7 +281,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Test that children are retrieved in the parent locale
+     * Test that children are retrieved in the parent locale.
      */
     public function testFindTranslationWithChildren()
     {
@@ -301,7 +301,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
         $this->dm->clear();
 
-        $this->doc = $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'fr');
+        $this->doc = $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'fr');
         $this->assertEquals('en', $this->doc->locale);
         $children = $this->doc->getChildren();
 
@@ -314,7 +314,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->bindTranslation($this->doc, 'fr');
         $this->dm->flush();
 
-        $this->doc = $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'fr');
+        $this->doc = $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'fr');
         $this->assertEquals('fr', $this->doc->locale);
         $children = $this->doc->getChildren();
         $this->assertCount(1, $children);
@@ -331,7 +331,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
         $this->metadata->mappings['children']['cascade'] = ClassMetadata::CASCADE_TRANSLATION;
 
-        $this->doc = $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'en');
+        $this->doc = $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'en');
         $this->assertEquals('en', $this->doc->locale);
         $children = $this->doc->getChildren();
         $this->assertCount(1, $children);
@@ -348,7 +348,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Test that children are retrieved in the parent locale
+     * Test that children are retrieved in the parent locale.
      */
     public function testFindTranslationWithUntranslatedChildren()
     {
@@ -365,7 +365,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
         $this->dm->clear();
 
-        $this->doc = $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'fr');
+        $this->doc = $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'fr');
         $this->assertEquals('fr', $this->doc->locale);
         $children = $this->doc->getChildren();
         $this->assertCount(1, $children);
@@ -376,7 +376,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
         $this->dm->clear();
 
-        $this->doc = $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'en');
+        $this->doc = $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'en');
         $children = $this->dm->getChildren($this->doc);
         $this->assertCount(1, $children);
         foreach ($children as $comment) {
@@ -402,7 +402,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
     /**
      * Italian translation does not exist so as defined in $this->localePrefs we
-     * will get french as it has higher priority than english
+     * will get french as it has higher priority than english.
      */
     public function testFindWithLanguageFallback()
     {
@@ -412,7 +412,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->doc->locale = 'fr';
         $this->dm->flush();
         $this->dm->getLocaleChooserStrategy()->setLocale('it');
-        $this->doc = $this->dm->find($this->class, '/functional/' . $this->testNodeName);
+        $this->doc = $this->dm->find($this->class, '/functional/'.$this->testNodeName);
 
         $this->assertNotNull($this->doc);
         $this->assertEquals('fr', $this->doc->locale);
@@ -443,7 +443,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
     /**
      * Italian translation does not exist so as defined in $this->localePrefs we
-     * will get french as it has higher priority than english
+     * will get french as it has higher priority than english.
      */
     public function testFindTranslationWithLanguageFallback()
     {
@@ -452,7 +452,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->doc->locale = 'fr';
         $this->dm->flush();
 
-        $this->doc = $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'it');
+        $this->doc = $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'it');
 
         $this->assertNotNull($this->doc);
         $this->assertEquals('fr', $this->doc->locale);
@@ -465,12 +465,12 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $this->expectException(MissingTranslationException::class);
-        $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'es');
+        $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'es');
     }
 
     /**
      * Italian translation does not exist so as defined in $this->localePrefs we
-     * will get french as it has higher priority than english
+     * will get french as it has higher priority than english.
      */
     public function testFindTranslationNoFallback()
     {
@@ -484,7 +484,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->assertEquals('en', $doc->locale);
 
         $this->expectException(MissingTranslationException::class);
-        $this->dm->findTranslation($this->class, '/functional/' . $this->testNodeName, 'it', false);
+        $this->dm->findTranslation($this->class, '/functional/'.$this->testNodeName, 'it', false);
     }
 
     /**
@@ -492,7 +492,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
      */
     public function testTranslationOnlyNullProperties()
     {
-        $path = $this->node->getPath() . '/only-null';
+        $path = $this->node->getPath().'/only-null';
         $doc = new Comment();
         $doc->id = $path;
         $this->dm->persist($doc);
@@ -582,7 +582,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $locales = $this->dm->getLocalesFor($this->doc);
-        $this->assertEquals(array('en'), $locales);
+        $this->assertEquals(['en'], $locales);
 
         // A second language is persisted
         $this->dm->bindTranslation($this->doc, 'fr');
@@ -620,11 +620,11 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->doc = $this->dm->find($this->class, '/functional/' . $this->testNodeName);
+        $this->doc = $this->dm->find($this->class, '/functional/'.$this->testNodeName);
         $this->assertNull($this->doc, 'Document must be null after deletion');
 
         $this->doc = new Article();
-        $this->doc->id = '/functional/' . $this->testNodeName;
+        $this->doc->id = '/functional/'.$this->testNodeName;
         $this->doc->author = 'John Doe';
         $this->doc->topic = 'Some interesting subject';
         $this->doc->setText('Lorem ipsum...');
@@ -633,13 +633,13 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $locales = $this->dm->getLocalesFor($this->doc);
-        $this->assertEquals(array('en'), $locales, 'Removing a document must remove all translations');
+        $this->assertEquals(['en'], $locales, 'Removing a document must remove all translations');
     }
 
     public function testInvalidTranslationStrategy()
     {
         $this->doc = new InvalidMapping();
-        $this->doc->id = '/functional/' . $this->testNodeName;
+        $this->doc->id = '/functional/'.$this->testNodeName;
         $this->doc->topic = 'foo';
         $this->dm->persist($this->doc);
         $this->dm->bindTranslation($this->doc, 'en');
@@ -648,23 +648,23 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * bindTranslation with a document that is not persisted should fail
+     * bindTranslation with a document that is not persisted should fail.
      */
     public function testBindTranslationWithoutPersist()
     {
         $this->doc = new CmsArticle();
-        $this->doc->id = '/functional/' . $this->testNodeName;
+        $this->doc->id = '/functional/'.$this->testNodeName;
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\InvalidArgumentException::class);
         $this->dm->bindTranslation($this->doc, 'en');
     }
 
     /**
-     * bindTranslation with a document that is not translatable should fail
+     * bindTranslation with a document that is not translatable should fail.
      */
     public function testBindTranslationNonTranslatable()
     {
         $this->doc = new CmsArticle();
-        $this->doc->id = '/functional/' . $this->testNodeName;
+        $this->doc->id = '/functional/'.$this->testNodeName;
         $this->dm->persist($this->doc);
         $this->expectException(PHPCRException::class);
         $this->dm->bindTranslation($this->doc, 'en');
@@ -672,12 +672,12 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
     /**
      * bindTranslation with a document inheriting from a translatable document
-     * should not fail
+     * should not fail.
      */
     public function testBindTranslationInherited()
     {
         $this->doc = new DerivedArticle();
-        $this->doc->id = '/functional/' . $this->testNodeName;
+        $this->doc->id = '/functional/'.$this->testNodeName;
         $this->dm->persist($this->doc);
         $this->dm->bindTranslation($this->doc, 'en');
         $this->assertEquals('en', $this->doc->locale);
@@ -686,26 +686,26 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     public function testFindTranslationNonPersisted()
     {
         $a = new Article();
-        $a->id = '/functional/' . $this->testNodeName;
+        $a->id = '/functional/'.$this->testNodeName;
         $a->title = 'Hello';
         $this->dm->persist($a);
 
-        $translations = array(
-            'en' => array('topic' => 'Welcome', 'assoc_value' => 'in en'),
-            'fr' => array('topic' => 'Bienvenue', 'assoc_value' => 'in fr'),
-            'de' => array('topic' => 'Wilkommen',  'assoc_value' => 'in de'),
-        );
+        $translations = [
+            'en' => ['topic' => 'Welcome', 'assoc_value' => 'in en'],
+            'fr' => ['topic' => 'Bienvenue', 'assoc_value' => 'in fr'],
+            'de' => ['topic' => 'Wilkommen',  'assoc_value' => 'in de'],
+        ];
 
         foreach ($translations as $locale => $values) {
             $a->topic = $values['topic'];
-            $a->assoc = array('key' => $values['assoc_value']);
+            $a->assoc = ['key' => $values['assoc_value']];
             $this->dm->bindTranslation($a, $locale);
         }
 
         foreach ($translations as $locale => $values) {
             $trans = $this->dm->findTranslation(
                 Article::class,
-                '/functional/' . $this->testNodeName,
+                '/functional/'.$this->testNodeName,
                 $locale
             );
 
@@ -717,7 +717,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         }
 
         $locales = $this->dm->getLocalesFor($a);
-        $this->assertEquals(array('en', 'fr', 'de'), $locales);
+        $this->assertEquals(['en', 'fr', 'de'], $locales);
     }
 
     /**
@@ -727,7 +727,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     public function testFindTranslationNonPersistedFallback()
     {
         $a = new Article();
-        $a->id = '/functional/' . $this->testNodeName;
+        $a->id = '/functional/'.$this->testNodeName;
         $a->topic = 'Hello';
         $a->text = 'Some text';
         $this->dm->persist($a);
@@ -739,7 +739,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         // find the italian translation
         $trans = $this->dm->findTranslation(
             null,
-            '/functional/' . $this->testNodeName,
+            '/functional/'.$this->testNodeName,
             'it'
         );
 
@@ -766,7 +766,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     public function testBindTranslationMemoryOverwrite()
     {
         $a = new Article();
-        $a->id = '/functional/' . $this->testNodeName;
+        $a->id = '/functional/'.$this->testNodeName;
         $a->topic = 'Hello';
         $a->text = 'This is an article in English';
         $this->dm->persist($a);
@@ -777,7 +777,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->persist($a);
         $this->dm->bindTranslation($a, 'de');
 
-        $a = $this->dm->findTranslation(null, '/functional/' . $this->testNodeName, 'en');
+        $a = $this->dm->findTranslation(null, '/functional/'.$this->testNodeName, 'en');
         $a->topic = 'Hallo';
         // this would kill the $a->text and set it back to the english text
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\RuntimeException::class);
@@ -791,7 +791,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
     public function testBindTranslationFlushedOverwrite()
     {
         $a = new Article();
-        $a->id = '/functional/' . $this->testNodeName;
+        $a->id = '/functional/'.$this->testNodeName;
         $a->topic = 'Hello';
         $a->text = 'This is an article in English';
         $this->dm->persist($a);
@@ -805,19 +805,19 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->bindTranslation($a, 'de');
         $this->dm->flush();
 
-        $a = $this->dm->findTranslation(null, '/functional/' . $this->testNodeName, 'en');
+        $a = $this->dm->findTranslation(null, '/functional/'.$this->testNodeName, 'en');
         $a->topic = 'Hallo';
         // this would kill the $a->text and set it back to the english text
         $this->dm->bindTranslation($a, 'de');
     }
 
     /**
-     * The locale is not even currently loaded
+     * The locale is not even currently loaded.
      */
     public function testBindTranslationOverwrite()
     {
         $a = new Article();
-        $a->id = '/functional/' . $this->testNodeName;
+        $a->id = '/functional/'.$this->testNodeName;
         $a->topic = 'Hello';
         $a->text = 'This is an article in English';
         $this->dm->persist($a);
@@ -830,7 +830,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $a = $this->dm->find(null, '/functional/' . $this->testNodeName);
+        $a = $this->dm->find(null, '/functional/'.$this->testNodeName);
         $a->topic = 'Hallo';
         // this would kill the $a->text and set it back to the english text
         $this->expectException(\Doctrine\ODM\PHPCR\Exception\RuntimeException::class);
@@ -840,10 +840,10 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
     public function testAssocWithNulls()
     {
-        $assoc = array('foo' => 'bar', 'test' => null, 2 => 'huhu');
+        $assoc = ['foo' => 'bar', 'test' => null, 2 => 'huhu'];
 
         $a = new Article();
-        $a->id = '/functional/' . $this->testNodeName;
+        $a->id = '/functional/'.$this->testNodeName;
         $a->topic = 'Hello';
         $a->text = 'This is an article in English';
         $a->assoc = $assoc;
@@ -852,14 +852,14 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $a = $this->dm->find(null, '/functional/' . $this->testNodeName);
+        $a = $this->dm->find(null, '/functional/'.$this->testNodeName);
         $this->assertEquals($assoc, $a->assoc);
     }
 
     public function testAdditionalFindCallsDoNotRefresh()
     {
         $a = new Article();
-        $a->id = '/functional/' . $this->testNodeName;
+        $a->id = '/functional/'.$this->testNodeName;
         $a->topic = 'Hello';
         $a->text = 'Some text';
         $this->dm->persist($a);
@@ -869,7 +869,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
         $trans = $this->dm->findTranslation(
             null,
-            '/functional/' . $this->testNodeName,
+            '/functional/'.$this->testNodeName,
             'en'
         );
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationHierarchyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationHierarchyTest.php
@@ -2,13 +2,13 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
+use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
-use Doctrine\Common\Proxy\Proxy;
 use PHPCR\PropertyType;
 
 /**
@@ -22,7 +22,8 @@ class TranslationHierarchyTest extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * Class name of the document class
+     * Class name of the document class.
+     *
      * @var string
      */
     private $type;
@@ -36,16 +37,16 @@ class TranslationHierarchyTest extends PHPCRFunctionalTestCase
     {
         $this->type = Article::class;
         $this->dm = $this->createDocumentManager();
-        $this->dm->setLocaleChooserStrategy(new LocaleChooser(array('en' => array('fr'), 'fr' => array('en')), 'en'));
+        $this->dm->setLocaleChooserStrategy(new LocaleChooser(['en' => ['fr'], 'fr' => ['en']], 'en'));
         $this->node = $this->resetFunctionalNode($this->dm);
         $user = $this->node->addNode('thename');
         $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $user->setProperty('phpcr_locale:fr-topic', 'french', PropertyType::STRING);
         $user->setProperty('phpcr_locale:fr-text', 'french text', PropertyType::STRING);
-        $user->setProperty('phpcr_locale:frnullfields', array('nullable'), PropertyType::STRING);
+        $user->setProperty('phpcr_locale:frnullfields', ['nullable'], PropertyType::STRING);
         $user->setProperty('phpcr_locale:en-topic', 'english', PropertyType::STRING);
         $user->setProperty('phpcr_locale:en-text', 'english text', PropertyType::STRING);
-        $user->setProperty('phpcr_locale:ennullfields', array('nullable'), PropertyType::STRING);
+        $user->setProperty('phpcr_locale:ennullfields', ['nullable'], PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
     }
 
@@ -59,6 +60,7 @@ class TranslationHierarchyTest extends PHPCRFunctionalTestCase
 
         $this->assertNotNull($doc->parent);
         $this->assertEquals('/functional', $doc->parent->getId());
+
         return $doc;
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationTest.php
@@ -3,14 +3,14 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Translation;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\ODM\PHPCR\Translation\Translation;
+use Doctrine\Tests\Models\Translation\Article;
 use Doctrine\Tests\Models\Translation\NoLocalePropertyArticle;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\WorkspaceInterface;
-use Doctrine\Tests\Models\Translation\Article;
 
 class TranslationTest extends PHPCRFunctionalTestCase
 {
@@ -74,10 +74,10 @@ class TranslationTest extends PHPCRFunctionalTestCase
      * Assertion shortcut:
      * Check the given $metadata contain a field mapping for $field that contains the $key and having the value $expectedValue.
      *
-     * @param string $expectedValue The expected value
-     * @param ClassMetadata $metadata The class metadata to test
-     * @param string $field The name of the field's mapping to test
-     * @param string $key The key expected to be in the field mapping
+     * @param string        $expectedValue The expected value
+     * @param ClassMetadata $metadata      The class metadata to test
+     * @param string        $field         The name of the field's mapping to test
+     * @param string        $key           The key expected to be in the field mapping
      */
     private function assertFieldMetadataEquals($expectedValue, ClassMetadata $metadata, $field, $key)
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
@@ -2,21 +2,21 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
 use Doctrine\ODM\PHPCR\UnitOfWork;
-use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsArticleFolder;
+use Doctrine\Tests\Models\CMS\CmsBlogFolder;
+use Doctrine\Tests\Models\CMS\CmsBlogInvalidChild;
+use Doctrine\Tests\Models\CMS\CmsBlogPost;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\References\ParentNoNodenameTestObj;
 use Doctrine\Tests\Models\References\ParentTestObj;
 use Doctrine\Tests\Models\Translation\Comment;
-use Doctrine\Tests\Models\CMS\CmsArticleFolder;
-use Doctrine\Tests\Models\CMS\CmsGroup;
-use Doctrine\Tests\Models\CMS\CmsArticle;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Tests\Models\CMS\CmsBlogPost;
-use Doctrine\Tests\Models\CMS\CmsBlogInvalidChild;
-use Doctrine\Tests\Models\CMS\CmsBlogFolder;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
 /**
@@ -86,7 +86,7 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
         $scheduledMoves = $this->uow->getScheduledMoves();
         $this->assertCount(1, $scheduledMoves);
         $this->assertEquals(32, strlen(key($scheduledMoves)), 'Size of key is 32 chars (oid)');
-        $this->assertEquals(array($user1, '/foobar'), current($scheduledMoves));
+        $this->assertEquals([$user1, '/foobar'], current($scheduledMoves));
     }
 
     public function testMoveParentNoNodeName()
@@ -159,33 +159,33 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
 
     public function testFetchingMultipleHierarchicalObjectsWithChildIdFirst()
     {
-        $parent           = new ParentTestObj();
+        $parent = new ParentTestObj();
         $parent->nodename = 'parent';
-        $parent->name     = 'parent';
-        $parent->parent   = $this->dm->find(null, 'functional');
+        $parent->name = 'parent';
+        $parent->parent = $this->dm->find(null, 'functional');
 
-        $child            = new ParentTestObj();
-        $child->nodename  = 'child';
-        $child->name      = 'child';
-        $child->parent    = $parent;
+        $child = new ParentTestObj();
+        $child->nodename = 'child';
+        $child->name = 'child';
+        $child->parent = $parent;
 
         $this->dm->persist($parent);
         $this->dm->persist($child);
 
         $parentId = $this->uow->getDocumentId($parent);
-        $childId  = $this->uow->getDocumentId($child);
+        $childId = $this->uow->getDocumentId($child);
 
         $this->dm->flush();
         $this->dm->clear();
 
         // this forces the objects to be loaded in an order where the $parent will become a proxy
-        $documents = $this->dm->findMany(ParentTestObj::class, array($childId, $parentId));
+        $documents = $this->dm->findMany(ParentTestObj::class, [$childId, $parentId]);
 
         $this->assertCount(2, $documents);
 
         /* @var $child ParentTestObj */
         /* @var $parent ParentTestObj */
-        $child  = $documents->first();
+        $child = $documents->first();
         $parent = $documents->last();
 
         $this->assertSame($child->parent, $parent);
@@ -251,9 +251,9 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
 
         $postFolder = new CmsBlogFolder();
         $postFolder->id = '/functional/posts';
-        $postFolder->posts = new ArrayCollection(array(
-            $post
-        ));
+        $postFolder->posts = new ArrayCollection([
+            $post,
+        ]);
 
         $this->dm->persist($postFolder);
         $this->dm->flush();
@@ -266,9 +266,9 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
 
         $postFolder = new CmsBlogFolder();
         $postFolder->id = '/functional/posts';
-        $postFolder->posts = new ArrayCollection(array(
-            $post
-        ));
+        $postFolder->posts = new ArrayCollection([
+            $post,
+        ]);
 
         $this->dm->persist($postFolder);
 
@@ -284,9 +284,9 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
 
         $postFolder = new CmsBlogFolder();
         $postFolder->id = '/functional/posts';
-        $postFolder->posts = new ArrayCollection(array(
-            $post
-        ));
+        $postFolder->posts = new ArrayCollection([
+            $post,
+        ]);
 
         $this->dm->persist($postFolder);
         $this->dm->flush();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/AnnotationsTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/AnnotationsTest.php
@@ -4,17 +4,16 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Versioning;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
-use Doctrine\Tests\Models\Versioning\InvalidVersionableArticle;
+use Doctrine\Tests\Models\Versioning\ExtendedVersionableArticle;
+use Doctrine\Tests\Models\Versioning\FullVersionableArticle;
 use Doctrine\Tests\Models\Versioning\InconsistentVersionableArticle;
+use Doctrine\Tests\Models\Versioning\InvalidVersionableArticle;
+use Doctrine\Tests\Models\Versioning\NonVersionableArticle;
+use Doctrine\Tests\Models\Versioning\VersionableArticle;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
-use Doctrine\Tests\Models\Versioning\VersionableArticle;
-use Doctrine\Tests\Models\Versioning\NonVersionableArticle;
-use Doctrine\Tests\Models\Versioning\FullVersionableArticle;
-use Doctrine\Tests\Models\Versioning\ExtendedVersionableArticle;
 
 class AnnotationsTest extends PHPCRFunctionalTestCase
 {
@@ -53,7 +52,7 @@ class AnnotationsTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Test that using an invalid versionable annotation will not work
+     * Test that using an invalid versionable annotation will not work.
      */
     public function testLoadInvalidAnnotation()
     {
@@ -64,7 +63,7 @@ class AnnotationsTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Test that using the Version annotation on non-versionable documents will not work
+     * Test that using the Version annotation on non-versionable documents will not work.
      */
     public function testLoadInconsistentAnnotations()
     {
@@ -75,7 +74,7 @@ class AnnotationsTest extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Check that persisting a node with the versionable type will add the correct mixin to the node
+     * Check that persisting a node with the versionable type will add the correct mixin to the node.
      */
     public function testAnnotationOnPersist()
     {
@@ -105,7 +104,7 @@ class AnnotationsTest extends PHPCRFunctionalTestCase
     /**
      * Create a document, save it, and return the underlying PHPCR node.
      *
-     * @param string $name The name of the new node (will be created under root)
+     * @param string $name  The name of the new node (will be created under root)
      * @param string $class The class name of the document
      *
      * @return NodeInterface
@@ -115,7 +114,7 @@ class AnnotationsTest extends PHPCRFunctionalTestCase
         $this->removeTestNode($name);
 
         $article = new $class();
-        $article->id = '/' . $name;
+        $article->id = '/'.$name;
         $article->author = 'John Doe';
         $article->topic = 'Some subject';
         $article->setText('Lorem ipsum...');
@@ -123,13 +122,13 @@ class AnnotationsTest extends PHPCRFunctionalTestCase
         $this->dm->persist($article);
         $this->dm->flush();
 
-        $node = $this->session->getNode('/' . $name);
+        $node = $this->session->getNode('/'.$name);
 
         return $node;
     }
 
     /**
-     * Remove a PHPCR node under the root node
+     * Remove a PHPCR node under the root node.
      *
      * @param string $name The name of the node to remove
      *

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/FullVersioningTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/FullVersioningTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Versioning;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/SimpleVersioningTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/SimpleVersioningTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Doctrine\Tests\ODM\PHPCR\Functional\Versioning;
 
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/VersioningTestAbstract.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Versioning/VersioningTestAbstract.php
@@ -4,13 +4,13 @@ namespace Doctrine\Tests\ODM\PHPCR\Functional\Versioning;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Tests\Models\Versioning\FullVersionableArticle;
+use Doctrine\Tests\Models\Versioning\FullVersionableArticleWithChildren;
+use Doctrine\Tests\Models\Versioning\NonVersionableArticle;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\ReferentialIntegrityException;
 use PHPCR\Util\PathHelper;
-use Doctrine\Tests\Models\Versioning\FullVersionableArticle;
-use Doctrine\Tests\Models\Versioning\FullVersionableArticleWithChildren;
-use Doctrine\Tests\Models\Versioning\NonVersionableArticle;
 use PHPCR\Version\VersionException;
 
 /**
@@ -24,14 +24,14 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
     private $dm;
 
     /**
-     * class name
+     * class name.
      *
      * @var string
      */
     protected $typeVersion;
 
     /**
-     * class name
+     * class name.
      *
      * @var string
      */
@@ -57,22 +57,22 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
 
         $versionNode = $this->node->addNode('versionTestObj');
         $versionNode->setProperty('username', 'lsmith');
-        $versionNode->setProperty('numbers', array(3, 1, 2));
+        $versionNode->setProperty('numbers', [3, 1, 2]);
         $versionNode->setProperty('phpcr:class', $this->typeVersion);
-        $versionNode->addMixin("mix:versionable");
+        $versionNode->addMixin('mix:versionable');
 
         $referenceNode = $this->node->addNode('referenceTestObj');
         $referenceNode->setProperty('content', 'reference test');
         $referenceNode->setProperty('phpcr:class', $this->typeReference);
-        $referenceNode->addMixin("mix:referenceable");
+        $referenceNode->addMixin('mix:referenceable');
 
         $this->dm->getPhpcrSession()->save();
 
         $versionNodeWithReference = $this->node->addNode('versionTestObjWithReference');
         $versionNodeWithReference->setProperty('username', 'laupifrpar');
-        $versionNodeWithReference->setProperty('numbers', array(6, 4, 5));
+        $versionNodeWithReference->setProperty('numbers', [6, 4, 5]);
         $versionNodeWithReference->setProperty('reference', $referenceNode);
-        $versionNodeWithReference->addMixin("mix:versionable");
+        $versionNodeWithReference->addMixin('mix:versionable');
 
         $this->dm->getPhpcrSession()->save();
         $this->dm = $this->createDocumentManager();
@@ -92,10 +92,10 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
 
     public function testMergeVersionable()
     {
-        $versionableArticle = new FullVersionableArticle;
+        $versionableArticle = new FullVersionableArticle();
         $versionableArticle->setText('very interesting content');
         $versionableArticle->author = 'greg0ire';
-        $versionableArticle->topic  = 'whatever';
+        $versionableArticle->topic = 'whatever';
         $versionableArticle->id = '/functional/whatever';
         $versionableArticle->versionName = 'v1';
 
@@ -176,7 +176,7 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Test it's not possible to get a version of a non-versionable document
+     * Test it's not possible to get a version of a non-versionable document.
      */
     public function testFindVersionByNameNotVersionable()
     {
@@ -190,7 +190,7 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Test that trying to read a non existing version fails
+     * Test that trying to read a non existing version fails.
      */
     public function testFindVersionByNameVersionDoesNotExist()
     {
@@ -210,7 +210,7 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
         $frozenDocument = $this->dm->findVersionByName($this->typeVersion, '/functional/versionTestObj', $lastVersionName);
 
         $this->assertEquals('lsmith', $frozenDocument->username);
-        $this->assertEquals(array(3, 1, 2), $frozenDocument->numbers);
+        $this->assertEquals([3, 1, 2], $frozenDocument->numbers);
 
         $this->assertEquals($lastVersionName, $frozenDocument->versionName);
         $this->assertInstanceOf('DateTime', $frozenDocument->versionCreated);
@@ -276,7 +276,7 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Check we cannot remove the last version of a document (since it's the current version)
+     * Check we cannot remove the last version of a document (since it's the current version).
      */
     public function testRemoveLastVersion()
     {
@@ -295,7 +295,7 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Check we cannot remove the root version of a document
+     * Check we cannot remove the root version of a document.
      */
     public function testRemoveRootVersion()
     {
@@ -338,7 +338,8 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
     }
 
     /**
-     * Check the version we removed in testRemoveVersion does not exist anymore
+     * Check the version we removed in testRemoveVersion does not exist anymore.
+     *
      * @depends testRemoveVersion
      */
     public function testDeletedVersionDoesNotExistAnymore($lastVersionName)
@@ -349,7 +350,7 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
 
     /**
      * Try to access the children of a specific version of a document and assert they
-     * are hydrated properly
+     * are hydrated properly.
      */
     public function testUnversionedChildrenOnParentVersion()
     {
@@ -361,7 +362,7 @@ abstract class VersioningTestAbstract extends PHPCRFunctionalTestCase
         $this->dm->persist($versionableArticle);
 
         $childArticle = new NonVersionableArticle();
-        $childArticle->setText("This is the child");
+        $childArticle->setText('This is the child');
         $childArticle->id = '/functional/children-test/child';
         $childArticle->author = 'mellowplace';
         $childArticle->topic = 'children test - child';

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/AssignedIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/AssignedIdGeneratorTest.php
@@ -14,7 +14,7 @@ class AssignedIdGeneratorTest extends TestCase
     {
         $id = 'moo';
 
-        $generator = new AssignedIdGenerator;
+        $generator = new AssignedIdGenerator();
         $cm = new ClassMetadataProxy($id);
         $dm = $this->createMock(DocumentManager::class);
 
@@ -28,7 +28,7 @@ class AssignedIdGeneratorTest extends TestCase
     {
         $id = '';
 
-        $generator = new AssignedIdGenerator;
+        $generator = new AssignedIdGenerator();
         $cm = new ClassMetadataProxy($id);
         $dm = $this->createMock(DocumentManager::class);
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/IdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/IdGeneratorTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Doctrine\ODM\PHPCR\Id\ParentIdGenerator;
-use Doctrine\ODM\PHPCR\Id\RepositoryIdGenerator;
 use Doctrine\ODM\PHPCR\Id\AssignedIdGenerator;
 use Doctrine\ODM\PHPCR\Id\AutoIdGenerator;
 use Doctrine\ODM\PHPCR\Id\IdGenerator;
+use Doctrine\ODM\PHPCR\Id\ParentIdGenerator;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/ParentIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/ParentIdGeneratorTest.php
@@ -2,12 +2,12 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Id;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Id\IdException;
 use Doctrine\ODM\PHPCR\Id\ParentIdGenerator;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use PHPUnit\Framework\TestCase;
-use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\UnitOfWork;
+use PHPUnit\Framework\TestCase;
 
 class ParentIdGeneratorTest extends TestCase
 {
@@ -18,22 +18,20 @@ class ParentIdGeneratorTest extends TestCase
     {
         $id = '/moo';
 
-        $generator = new ParentIdGenerator;
-        $parent = new ParentDummy;
+        $generator = new ParentIdGenerator();
+        $parent = new ParentDummy();
         $cm = new ParentClassMetadataProxy($parent, 'name', $id, new MockField($parent, '/miau'));
         $uow = $this->createMock(UnitOfWork::class);
         $uow
             ->expects($this->once())
             ->method('getDocumentId')
             ->with($this->equalTo($parent))
-            ->will($this->returnValue('/miau'))
-        ;
+            ->will($this->returnValue('/miau'));
         $dm = $this->createMock(DocumentManager::class);
         $dm
             ->expects($this->once())
             ->method('getUnitOfWork')
-            ->will($this->returnValue($uow))
-        ;
+            ->will($this->returnValue($uow));
         $this->assertEquals('/miau/name', $generator->generate(null, $cm, $dm));
     }
 
@@ -44,7 +42,7 @@ class ParentIdGeneratorTest extends TestCase
     {
         $id = '/moo';
 
-        $generator = new ParentIdGenerator;
+        $generator = new ParentIdGenerator();
         $cm = new ParentClassMetadataProxy(null, 'name', $id);
         $dm = $this->createMock(DocumentManager::class);
 
@@ -58,8 +56,8 @@ class ParentIdGeneratorTest extends TestCase
     {
         $id = '/moo';
 
-        $generator = new ParentIdGenerator;
-        $cm = new ParentClassMetadataProxy(new ParentDummy, '', $id);
+        $generator = new ParentIdGenerator();
+        $cm = new ParentClassMetadataProxy(new ParentDummy(), '', $id);
         $dm = $this->createMock(DocumentManager::class);
 
         $this->assertEquals($id, $generator->generate(null, $cm, $dm));
@@ -67,7 +65,7 @@ class ParentIdGeneratorTest extends TestCase
 
     public function testGenerateNoIdNoParentNoName()
     {
-        $generator = new ParentIdGenerator;
+        $generator = new ParentIdGenerator();
         $cm = new ParentClassMetadataProxy(null, '', '');
         $dm = $this->createMock(DocumentManager::class);
 
@@ -77,7 +75,7 @@ class ParentIdGeneratorTest extends TestCase
 
     public function testGenerateNoIdNoParent()
     {
-        $generator = new ParentIdGenerator;
+        $generator = new ParentIdGenerator();
         $cm = new ParentClassMetadataProxy(null, 'name', '');
         $dm = $this->createMock(DocumentManager::class);
 
@@ -87,8 +85,8 @@ class ParentIdGeneratorTest extends TestCase
 
     public function testGenerateNoIdNoName()
     {
-        $generator = new ParentIdGenerator;
-        $cm = new ParentClassMetadataProxy(new ParentDummy, '', '');
+        $generator = new ParentIdGenerator();
+        $cm = new ParentClassMetadataProxy(new ParentDummy(), '', '');
         $dm = $this->createMock(DocumentManager::class);
 
         $this->expectException(IdException::class);
@@ -97,22 +95,20 @@ class ParentIdGeneratorTest extends TestCase
 
     public function testGenerateNoParentId()
     {
-        $generator = new ParentIdGenerator;
-        $parent = new ParentDummy;
+        $generator = new ParentIdGenerator();
+        $parent = new ParentDummy();
         $cm = new ParentClassMetadataProxy($parent, 'name', '', new MockField($parent, '/miau'));
         $uow = $this->createMock(UnitOfWork::class);
         $uow
             ->expects($this->once())
             ->method('getDocumentId')
             ->with($this->equalTo($parent))
-            ->will($this->returnValue(''))
-        ;
+            ->will($this->returnValue(''));
         $dm = $this->createMock(DocumentManager::class);
         $dm
             ->expects($this->once())
             ->method('getUnitOfWork')
-            ->will($this->returnValue($uow))
-        ;
+            ->will($this->returnValue($uow));
 
         $this->expectException(IdException::class);
         $generator->generate(null, $cm, $dm);
@@ -139,7 +135,7 @@ class ParentClassMetadataProxy extends ClassMetadata
         $this->_nodename = $nodename;
         $this->_identifier = $identifier;
 
-        $this->reflFields = array($this->identifier => $mockField);
+        $this->reflFields = [$this->identifier => $mockField];
     }
 
     public function getFieldValue($document, $field)
@@ -152,8 +148,6 @@ class ParentClassMetadataProxy extends ClassMetadata
             case $this->identifier:
                 return $this->_identifier;
         }
-
-        return null;
     }
 }
 
@@ -170,9 +164,10 @@ class MockField
 
     public function getValue($parent)
     {
-        if (! $this->p == $parent) {
+        if (!$this->p == $parent) {
             throw new \Exception('Wrong parent passed in getValue');
         }
+
         return $this->id;
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Id/RepositoryIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Id/RepositoryIdGeneratorTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdGenerator;
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 
@@ -20,16 +20,14 @@ class RepositoryIdGeneratorTest extends TestCase
             ->expects($this->once())
             ->method('generateId')
             ->with($this->equalTo(null))
-            ->will($this->returnValue('generatedid'))
-        ;
+            ->will($this->returnValue('generatedid'));
         $dm = $this->createMock(DocumentManager::class);
         $dm
             ->expects($this->once())
             ->method('getRepository')
-            ->will($this->returnValue($repository))
-        ;
+            ->will($this->returnValue($repository));
 
-        $generator = new RepositoryIdGenerator;
+        $generator = new RepositoryIdGenerator();
 
         $this->assertEquals('generatedid', $generator->generate(null, $cm, $dm));
     }
@@ -40,22 +38,19 @@ class RepositoryIdGeneratorTest extends TestCase
     public function testGenerateNoIdException()
     {
         $id = 'moo';
-        $generator = new RepositoryIdGenerator;
+        $generator = new RepositoryIdGenerator();
         $cm = new ClassMetadataProxy($id);
         $repository = $this->createMock(RepositoryIdInterface::class);
         $repository
             ->expects($this->once())
             ->method('generateId')
             ->with($this->equalTo(null))
-            ->will($this->throwException(new \Exception))
-        ;
+            ->will($this->throwException(new \Exception()));
         $dm = $this->createMock(DocumentManager::class);
         $dm
             ->expects($this->once())
             ->method('getRepository')
-            ->will($this->returnValue($repository))
-        ;
-
+            ->will($this->returnValue($repository));
 
         try {
             $generator->generate(null, $cm, $dm);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AbstractMappingDriverTest.php
@@ -3,14 +3,14 @@
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
-use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
-use PHPUnit\Framework\TestCase;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
 
 abstract class AbstractMappingDriverTest extends TestCase
 {
@@ -18,6 +18,7 @@ abstract class AbstractMappingDriverTest extends TestCase
      * @return MappingDriver
      */
     abstract protected function loadDriver();
+
     /**
      * @return MappingDriver
      */
@@ -25,7 +26,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     protected function ensureIsLoaded($entityClassName)
     {
-        new $entityClassName;
+        new $entityClassName();
     }
 
     /**
@@ -99,11 +100,13 @@ abstract class AbstractMappingDriverTest extends TestCase
     public function testLoadFieldMapping()
     {
         $className = Model\FieldMappingObject::class;
+
         return $this->loadMetadataForClassName($className);
     }
 
     /**
      * @depends testLoadFieldMapping
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -141,6 +144,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -154,6 +158,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -168,6 +173,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -182,6 +188,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -196,6 +203,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -210,6 +218,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -224,6 +233,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -238,6 +248,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -252,6 +263,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -266,6 +278,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -280,6 +293,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      */
     public function testNameFieldMappings($class)
@@ -292,6 +306,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -306,6 +321,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testFieldMappings
+     *
      * @param ClassMetadata $class
      *
      * @return ClassMetadata
@@ -327,6 +343,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadNodenameMapping
+     *
      * @param ClassMetadata $class
      */
     public function testNodenameMapping($class)
@@ -344,6 +361,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadParentDocumentMapping
+     *
      * @param ClassMetadata $class
      */
     public function testParentDocumentMapping($class)
@@ -355,11 +373,13 @@ abstract class AbstractMappingDriverTest extends TestCase
     public function testLoadDepthMapping()
     {
         $className = Model\DepthMappingObject::class;
+
         return $this->loadMetadataForClassname($className);
     }
 
     /**
      * @depends testLoadDepthMapping
+     *
      * @param ClassMetadata $class
      */
     public function testDepthMapping($class)
@@ -404,6 +424,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadChildMapping
+     *
      * @param ClassMetadata $class
      */
     public function testChildMapping($class)
@@ -425,6 +446,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadChildrenMapping
+     *
      * @param ClassMetadata $class
      */
     public function testChildrenMapping($class)
@@ -434,7 +456,7 @@ abstract class AbstractMappingDriverTest extends TestCase
         $this->assertTrue(isset($class->mappings['all']));
         $this->assertFalse(isset($class->mappings['all']['filter']));
         $this->assertTrue(isset($class->mappings['some']));
-        $this->assertEquals(array('*some*'), $class->mappings['some']['filter']);
+        $this->assertEquals(['*some*'], $class->mappings['some']['filter']);
         $this->assertEquals(2, $class->mappings['some']['fetchDepth']);
         $this->assertEquals(3, $class->mappings['some']['cascade']);
     }
@@ -448,6 +470,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadRepositoryMapping
+     *
      * @param ClassMetadata $class
      */
     public function testRepositoryMapping($class)
@@ -465,6 +488,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadVersionableMapping
+     *
      * @param ClassMetadata $class
      */
     public function testVersionableMapping($class)
@@ -483,6 +507,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadReferenceableMapping
+     *
      * @param ClassMetadata $class
      */
     public function testReferenceableMapping($class)
@@ -499,6 +524,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadUniqueNodeTypeMapping
+     *
      * @param ClassMetadata $class
      */
     public function testUniqueNodeTypeMapping($class)
@@ -515,6 +541,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadNodeTypeMapping
+     *
      * @param ClassMetadata $class
      */
     public function testNodeTypeMapping($class)
@@ -531,21 +558,22 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadMappedSuperclassTypeMapping
+     *
      * @param ClassMetadata $class
      */
     public function testMappedSuperclassTypeMapping($class)
     {
         $this->assertTrue($class->isMappedSuperclass);
-        $this->assertEquals("phpcr:test", $class->nodeType);
+        $this->assertEquals('phpcr:test', $class->nodeType);
         $this->assertEquals(Model\DocumentRepository::class, $class->customRepositoryClassName);
-        $this->assertEquals("children", $class->translator);
-        $this->assertEquals(array('mix:one', 'mix:two'), $class->mixins);
-        $this->assertEquals("simple", $class->versionable);
+        $this->assertEquals('children', $class->translator);
+        $this->assertEquals(['mix:one', 'mix:two'], $class->mixins);
+        $this->assertEquals('simple', $class->versionable);
         $this->assertTrue($class->referenceable);
         $this->assertEquals(
             'id',
             $class->identifier,
-            'A driver should always be able to give mapping for a mapped superclass,' . PHP_EOL.
+            'A driver should always be able to give mapping for a mapped superclass,'.PHP_EOL.
             'and let classes mapped with other drivers inherit this mapping entirely.'
         );
 
@@ -572,6 +600,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadMappedSuperclassChildTypeMapping
+     *
      * @param ClassMetadata $class
      */
     public function testMappedSuperclassChildTypeMapping($class)
@@ -583,7 +612,6 @@ abstract class AbstractMappingDriverTest extends TestCase
         );
     }
 
-
     public function testLoadNodeMapping()
     {
         $className = Model\NodeMappingObject::class;
@@ -593,6 +621,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadNodeMapping
+     *
      * @param ClassMetadata $class
      */
     public function testNodeMapping($class)
@@ -609,6 +638,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadReferenceOneMapping
+     *
      * @param ClassMetadata $class
      */
     public function testReferenceOneMapping($class)
@@ -643,6 +673,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadReferenceManyMapping
+     *
      * @param ClassMetadata $class
      */
     public function testReferenceManyMapping($class)
@@ -678,6 +709,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadReferrersMapping
+     *
      * @param ClassMetadata $class
      */
     public function testReferrersMapping($class)
@@ -690,6 +722,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadReferrersMapping
+     *
      * @param ClassMetadata $class
      */
     public function testMixedReferrersMapping($class)
@@ -719,6 +752,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadTranslatorMapping
+     *
      * @param ClassMetadata $class
      */
     public function testTranslatorMapping($class)
@@ -739,6 +773,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadMixinMapping
+     *
      * @param ClassMetadata $class
      */
     public function testMixinMapping($class)
@@ -756,6 +791,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadReplaceMixinMapping
+     *
      * @param ClassMetadata $class
      */
     public function testReplaceMixinMapping($class)
@@ -773,6 +809,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadLifecycleCallbackMapping
+     *
      * @param ClassMetadata $class
      */
     public function testLifecycleCallbackMapping($class)
@@ -810,6 +847,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadUuidMapping
+     *
      * @param   $class
      */
     public function testUuidMapping($class)
@@ -846,11 +884,12 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadChildClassesMapping
+     *
      * @param ClassMetadata $class
      */
     public function testChildClassesMapping($class)
     {
-        $this->assertEquals(array('stdClass'), $class->getChildClasses());
+        $this->assertEquals(['stdClass'], $class->getChildClasses());
     }
 
     public function testLoadIsLeafMapping()
@@ -862,6 +901,7 @@ abstract class AbstractMappingDriverTest extends TestCase
 
     /**
      * @depends testLoadIsLeafMapping
+     *
      * @param ClassMetadata $class
      */
     public function testIsLeafMapping($class)

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AnnotationDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
 use Doctrine\Common\Annotations\AnnotationReader;
@@ -19,12 +20,13 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     protected function loadDriverForTestMappingDocuments()
     {
         $annotationDriver = $this->loadDriver();
-        $annotationDriver->addPaths(array(__DIR__ . '/Model'));
+        $annotationDriver->addPaths([__DIR__.'/Model']);
+
         return $annotationDriver;
     }
 
     /**
-     * Overwriting private parent properties isn't supported with annotations
+     * Overwriting private parent properties isn't supported with annotations.
      */
     public function testParentWithPrivatePropertyMapping()
     {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataFactoryTest.php
@@ -6,13 +6,13 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Event;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
-use Doctrine\ODM\PHPCR\Event;
 use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
-use PHPUnit\Framework\TestCase;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
 
 class ClassMetadataFactoryTest extends TestCase
 {
@@ -30,7 +30,7 @@ class ClassMetadataFactoryTest extends TestCase
     {
         $reader = new AnnotationReader();
         $annotationDriver = new AnnotationDriver($reader);
-        $annotationDriver->addPaths(array(__DIR__ . '/Model'));
+        $annotationDriver->addPaths([__DIR__.'/Model']);
         $this->dm->getConfiguration()->setMetadataDriverImpl($annotationDriver);
 
         $cmf = new ClassMetadataFactory($this->dm);
@@ -67,7 +67,7 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testGetAllMetadata()
     {
-        $driver = new PHPDriver(array(__DIR__ . '/Model/php'));
+        $driver = new PHPDriver([__DIR__.'/Model/php']);
         $this->dm->getConfiguration()->setMetadataDriverImpl($driver);
 
         $cmf = new ClassMetadataFactory($this->dm);
@@ -107,7 +107,7 @@ class ClassMetadataFactoryTest extends TestCase
         $this->assertTrue($meta->referenceable);
         $this->assertEquals('foo', $meta->translator);
         $this->assertEquals('nt:test', $meta->nodeType);
-        $this->assertEquals(array('mix:foo', 'mix:bar'), $meta->mixins);
+        $this->assertEquals(['mix:foo', 'mix:bar'], $meta->mixins);
         $this->assertEquals('simple', $meta->versionable);
         $this->assertEquals(Model\DocumentRepository::class, $meta->customRepositoryClassName);
     }
@@ -126,7 +126,7 @@ class ClassMetadataFactoryTest extends TestCase
         $this->assertTrue($meta->referenceable);
         $this->assertEquals('bar', $meta->translator);
         $this->assertEquals('nt:test-override', $meta->nodeType);
-        $this->assertEquals(array('mix:baz'), $meta->mixins);
+        $this->assertEquals(['mix:baz'], $meta->mixins);
         $this->assertEquals('full', $meta->versionable);
         $this->assertEquals(Model\BarfooRepository::class, $meta->customRepositoryClassName);
     }
@@ -159,9 +159,9 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testLoadClassMetadataEvent()
     {
-        $listener = new Listener;
+        $listener = new Listener();
         $evm = $this->dm->getEventManager();
-        $evm->addEventListener(array(Event::loadClassMetadata), $listener);
+        $evm->addEventListener([Event::loadClassMetadata], $listener);
 
         $meta = $this->getMetadataFor(Model\DefaultMappingObject::class);
         $this->assertTrue($listener->called);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/ClassMetadataTest.php
@@ -2,19 +2,19 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
-use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
+use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
+use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
-use PHPUnit\Framework\TestCase;
+use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsUserRepository;
-use Doctrine\Tests\Models\CMS\CmsAddress;
 use PHPCR\RepositoryException;
+use PHPUnit\Framework\TestCase;
 
 class ClassMetadataTest extends TestCase
 {
@@ -23,7 +23,7 @@ class ClassMetadataTest extends TestCase
         $cmi = new ClassMetadata(Person::class);
         $cmi->initializeReflection(new RuntimeReflectionService());
         $this->assertNull($cmi->getTypeOfField('some_field'));
-        $cmi->mappings['some_field'] = array('type' => 'some_type');
+        $cmi->mappings['some_field'] = ['type' => 'some_type'];
         $this->assertEquals('some_type', $cmi->getTypeOfField('some_field'));
     }
 
@@ -58,19 +58,19 @@ class ClassMetadataTest extends TestCase
      */
     public function testMapFieldWithId(ClassMetadata $cm)
     {
-        $cm->mapField(array('fieldName' => 'id', 'id' => true, 'strategy' => 'assigned'));
+        $cm->mapField(['fieldName' => 'id', 'id' => true, 'strategy' => 'assigned']);
 
         $this->assertTrue(isset($cm->mappings['id']));
         $this->assertEquals(
-            array(
-                'id' => true,
-                'property' => 'id',
-                'type' => 'string',
-                'fieldName' => 'id',
+            [
+                'id'         => true,
+                'property'   => 'id',
+                'type'       => 'string',
+                'fieldName'  => 'id',
                 'multivalue' => false,
-                'strategy' => 'assigned',
-                'nullable' => false,
-            ), $cm->mappings['id']
+                'strategy'   => 'assigned',
+                'nullable'   => false,
+            ], $cm->mappings['id']
         );
 
         $this->assertEquals('id', $cm->identifier);
@@ -110,30 +110,30 @@ class ClassMetadataTest extends TestCase
      */
     public function testMapField(ClassMetadata $cm)
     {
-        $cm->mapField(array('fieldName' => 'username', 'property' => 'username', 'type' => 'string'));
-        $cm->mapField(array('fieldName' => 'created', 'property' => 'created', 'type' => 'datetime'));
+        $cm->mapField(['fieldName' => 'username', 'property' => 'username', 'type' => 'string']);
+        $cm->mapField(['fieldName' => 'created', 'property' => 'created', 'type' => 'datetime']);
 
         $this->assertTrue(isset($cm->mappings['username']));
         $this->assertTrue(isset($cm->mappings['created']));
 
         $this->assertEquals(
-            array(
-                'property' => 'username',
-                'type' => 'string',
-                'fieldName' => 'username',
+            [
+                'property'   => 'username',
+                'type'       => 'string',
+                'fieldName'  => 'username',
                 'multivalue' => false,
-                'nullable' => false,
-            ),
+                'nullable'   => false,
+            ],
             $cm->mappings['username']
         );
         $this->assertEquals(
-            array(
-                'property' => 'created',
-                'type' => 'datetime',
-                'fieldName' => 'created',
+            [
+                'property'   => 'created',
+                'type'       => 'datetime',
+                'fieldName'  => 'created',
                 'multivalue' => false,
-                'nullable' => false,
-            ),
+                'nullable'   => false,
+            ],
             $cm->mappings['created']
         );
 
@@ -142,6 +142,7 @@ class ClassMetadataTest extends TestCase
 
     /**
      * Mapping should return translated fields.
+     *
      * @depends testMapFieldWithId
      */
     public function testMapFieldWithInheritance(ClassMetadata $cmp)
@@ -156,13 +157,13 @@ class ClassMetadataTest extends TestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
         // Test that the translated field is being inherited.
-        $mapping = array(
-            'property' => 'translatedField',
-            'fieldName' => 'translatedField',
-            'translated' => true
-        );
+        $mapping = [
+            'property'   => 'translatedField',
+            'fieldName'  => 'translatedField',
+            'translated' => true,
+        ];
         $cm->mapField($mapping, $cmp);
-        $this->assertEquals(array('translatedField'), $cm->translatableFields);
+        $this->assertEquals(['translatedField'], $cm->translatableFields);
     }
 
     /**
@@ -171,7 +172,7 @@ class ClassMetadataTest extends TestCase
     public function testMapFieldWithoutNameThrowsException(ClassMetadata $cm)
     {
         $this->expectException(MappingException::class);
-        $cm->mapField(array());
+        $cm->mapField([]);
     }
 
     /**
@@ -180,7 +181,7 @@ class ClassMetadataTest extends TestCase
     public function testMapNonExistingField(ClassMetadata $cm)
     {
         $this->expectException(MappingException::class);
-        $cm->mapField(array('fieldName' => 'notexisting'));
+        $cm->mapField(['fieldName' => 'notexisting']);
     }
 
     public function testMapChildInvalidName()
@@ -189,7 +190,7 @@ class ClassMetadataTest extends TestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->expectException(MappingException::class);
-        $cm->mapChild(array('fieldName' => 'child', 'nodeName' => 'in/valid'));
+        $cm->mapChild(['fieldName' => 'child', 'nodeName' => 'in/valid']);
     }
 
     public function testMapChildrenInvalidFetchDepth()
@@ -198,7 +199,7 @@ class ClassMetadataTest extends TestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->expectException(MappingException::class);
-        $cm->mapChildren(array('fieldName' => 'address', 'fetchDepth' => 'invalid'));
+        $cm->mapChildren(['fieldName' => 'address', 'fetchDepth' => 'invalid']);
     }
 
     /**
@@ -243,7 +244,7 @@ class ClassMetadataTest extends TestCase
 
         $this->assertInstanceOf(ClassMetadata::class, $cm);
 
-        $this->assertEquals(array('callback'), $cm->getLifecycleCallbacks('postLoad'));
+        $this->assertEquals(['callback'], $cm->getLifecycleCallbacks('postLoad'));
         $this->assertTrue($cm->isMappedSuperclass);
         $this->assertTrue($cm->versionable);
         $this->assertTrue($cm->uniqueNodeType);
@@ -257,18 +258,18 @@ class ClassMetadataTest extends TestCase
      */
     public function testMapAssociationManyToOne(ClassMetadata $cm)
     {
-        $cm->mapManyToOne(array('fieldName' => 'address', 'targetDocument' => Address::class));
+        $cm->mapManyToOne(['fieldName' => 'address', 'targetDocument' => Address::class]);
 
         $this->assertTrue(isset($cm->mappings['address']), "No 'address' in associations map.");
-        $this->assertEquals(array(
-            'fieldName' => 'address',
+        $this->assertEquals([
+            'fieldName'      => 'address',
             'targetDocument' => Address::class,
             'sourceDocument' => Person::class,
-            'type' => ClassMetadata::MANY_TO_ONE,
-            'strategy' => 'weak',
-            'cascade' => null,
-            'property' => 'address',
-        ), $cm->mappings['address']);
+            'type'           => ClassMetadata::MANY_TO_ONE,
+            'strategy'       => 'weak',
+            'cascade'        => null,
+            'property'       => 'address',
+        ], $cm->mappings['address']);
 
         return $cm;
     }
@@ -276,33 +277,33 @@ class ClassMetadataTest extends TestCase
     public function testClassMetadataInstanceSerialization()
     {
         $cm = new ClassMetadata(CmsUser::class);
-        $cm->initializeReflection(new RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         // Test initial state
         $this->assertTrue(count($cm->getReflectionProperties()) == 0);
         $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
         $this->assertEquals(CmsUser::class, $cm->name);
-        $this->assertEquals(array(), $cm->parentClasses);
+        $this->assertEquals([], $cm->parentClasses);
         $this->assertEquals(0, count($cm->referenceMappings));
 
         // Customize state
-        $cm->setParentClasses(array('UserParent'));
+        $cm->setParentClasses(['UserParent']);
         $cm->setCustomRepositoryClassName('CmsUserRepository');
         $cm->setNodeType('foo:bar');
-        $cm->mapManyToOne(array('fieldName' => 'address', 'targetDocument' => 'CmsAddress', 'mappedBy' => 'foo'));
+        $cm->mapManyToOne(['fieldName' => 'address', 'targetDocument' => 'CmsAddress', 'mappedBy' => 'foo']);
         $this->assertEquals(1, count($cm->referenceMappings));
 
         $serialized = serialize($cm);
         /** @var ClassMetadata $cm */
         $cm = unserialize($serialized);
-        $cm->wakeupReflection(new RuntimeReflectionService);
+        $cm->wakeupReflection(new RuntimeReflectionService());
 
         // Check state
         $this->assertTrue(count($cm->getReflectionProperties()) > 0);
         $this->assertEquals('Doctrine\Tests\Models\CMS', $cm->namespace);
         $this->assertInstanceOf(\ReflectionClass::class, $cm->reflClass);
         $this->assertEquals(CmsUser::class, $cm->name);
-        $this->assertEquals(array('UserParent'), $cm->parentClasses);
+        $this->assertEquals(['UserParent'], $cm->parentClasses);
         $this->assertEquals(CmsUserRepository::class, $cm->customRepositoryClassName);
         $this->assertEquals('foo:bar', $cm->getNodeType());
         $this->assertEquals(ClassMetadata::MANY_TO_ONE, $cm->getTypeOfField('address'));
@@ -320,7 +321,7 @@ class ClassMetadataTest extends TestCase
         $serialized = serialize($cm);
         /** @var ClassMetadata $cm */
         $cm = unserialize($serialized);
-        $cm->wakeupReflection(new RuntimeReflectionService);
+        $cm->wakeupReflection(new RuntimeReflectionService());
 
         // Check properties needed for translations
         $this->assertEquals('attribute', $cm->translator);
@@ -350,7 +351,7 @@ class ClassMetadataTest extends TestCase
     {
         $cm = new ClassMetadata(Person::class);
         $childCm = new ClassMetadata('stdClass');
-        $cm->setChildClasses(array());
+        $cm->setChildClasses([]);
         $cm->assertValidChildClass($childCm);
     }
 
@@ -360,7 +361,7 @@ class ClassMetadataTest extends TestCase
     public function testAssertValidChildClassesAllowed()
     {
         $cm = new ClassMetadata(Person::class);
-        $cm->setChildClasses(array('stdClass'));
+        $cm->setChildClasses(['stdClass']);
         $childCm = new ClassMetadata('stdClass');
         $childCm->initializeReflection(new RuntimeReflectionService());
         $cm->assertValidChildClass($childCm);
@@ -375,7 +376,7 @@ class ClassMetadataTest extends TestCase
         $cm->initializeReflection(new RuntimeReflectionService());
         $childCm = new ClassMetadata(Customer::class);
         $childCm->initializeReflection(new RuntimeReflectionService());
-        $cm->setChildClasses(array(Person::class));
+        $cm->setChildClasses([Person::class]);
         $result = $cm->assertValidChildClass($childCm);
         $this->assertNull($result);
     }
@@ -389,7 +390,7 @@ class ClassMetadataTest extends TestCase
         $cm->initializeReflection(new RuntimeReflectionService());
         $childCm = new ClassMetadata('ArrayAccess');
         $childCm->initializeReflection(new RuntimeReflectionService());
-        $cm->setChildClasses(array('ArrayAccess'));
+        $cm->setChildClasses(['ArrayAccess']);
         $result = $cm->assertValidChildClass($childCm);
         $this->assertNull($result);
     }
@@ -403,7 +404,7 @@ class ClassMetadataTest extends TestCase
         $cm->initializeReflection(new RuntimeReflectionService());
         $childCm = new ClassMetadata('stdClass');
         $childCm->initializeReflection(new RuntimeReflectionService());
-        $cm->setChildClasses(array(Person::class));
+        $cm->setChildClasses([Person::class]);
 
         $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('does not allow children of type "stdClass"');

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/BarfooRepository.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/BarfooRepository.php
@@ -3,15 +3,14 @@
 namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 
 use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
-use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  */
 class BarfooRepository extends BaseDocumentRepository
 {
     public function generateId($document, $parent = null)
     {
-        return '/functional/' . rand();
+        return '/functional/'.rand();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildClassesAndLeafObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildClassesAndLeafObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document(childClasses={
  *     "stdClass",

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildClassesObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildClassesObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document(childClasses={
  *     "stdClass",

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildrenMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ChildrenMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildMappingObject.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * A class that represents a child class for the purposes
- * of testing class property inheritance
+ * of testing class property inheritance.
  *
  * @PHPCRODM\Document()
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildOverridesMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceChildOverridesMappingObject.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * A class that represents a parent class for the purposes
- * of testing class property inheritance
+ * of testing class property inheritance.
  *
  * @PHPCRODM\Document(
  *   nodeType="nt:test-override",

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceParentMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ClassInheritanceParentMappingObject.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * A class that represents a parent class for the purposes
- * of testing class property inheritance
+ * of testing class property inheritance.
  *
  * @PHPCRODM\Document(
  *   referenceable=true,

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/DefaultMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/DefaultMappingObject.php
@@ -6,6 +6,7 @@ use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
  * A class with no explicitly set properties for testing default values.
+ *
  * @PHPCRODM\Document
  */
 class DefaultMappingObject

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/DepthMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/DepthMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains a mapped parent document via properties
+ * A class that contains a mapped parent document via properties.
  *
  * @PHPCRODM\Document
  */
@@ -13,7 +13,7 @@ class DepthMappingObject
 {
     /** @PHPCRODM\Id */
     public $id;
-    
+
     /** @PHPCRODM\Depth */
     public $depth;
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/DocumentRepository.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/DocumentRepository.php
@@ -6,12 +6,12 @@ use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  */
 class DocumentRepository extends BaseDocumentRepository implements RepositoryIdInterface
 {
     public function generateId($document, $parent = null)
     {
-        return '/functional/' . rand();
+        return '/functional/'.rand();
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/FieldMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/FieldMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped fields via properties
+ * A class that contains mapped fields via properties.
  *
  * @PHPCRODM\Document
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/InheritedMixinMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/InheritedMixinMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document(mixins={"mix:title"})
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/IsLeafObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/IsLeafObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document(isLeaf=true)
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/LifecycleCallbackMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/LifecycleCallbackMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses Lifecycle Callbacks
+ * A class that uses Lifecycle Callbacks.
  *
  * @PHPCRODM\Document
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/MappedSuperclassMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/MappedSuperclassMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses the repository strategy to generate IDs
+ * A class that uses the repository strategy to generate IDs.
  *
  * @PHPCRODM\MappedSuperclass(nodeType="phpcr:test", repositoryClass="Doctrine\Tests\ODM\PHPCR\Mapping\Model\DocumentRepository", translator="children", mixins={"mix:one", "mix:two"}, versionable="simple", referenceable=true)
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/MixinMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/MixinMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document(mixins={"mix:lastModified"})
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/NodeMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/NodeMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses the repository strategy to generate IDs
+ * A class that uses the repository strategy to generate IDs.
  *
  * @PHPCRODM\Document
  */
@@ -13,7 +13,7 @@ class NodeMappingObject
 {
     /** @PHPCRODM\Id */
     public $id;
-    
+
     /** @PHPCRODM\Node */
     public $node;
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/NodeTypeMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/NodeTypeMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses the repository strategy to generate IDs
+ * A class that uses the repository strategy to generate IDs.
  *
  * @PHPCRODM\Document(nodeType="nt:test")
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/NodenameMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/NodenameMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped fields via properties
+ * A class that contains mapped fields via properties.
  *
  * @PHPCRODM\Document
  */
@@ -13,7 +13,7 @@ class NodenameMappingObject
 {
     /** @PHPCRODM\Id */
     public $id;
-    
+
     /** @PHPCRODM\Nodename */
     public $namefield;
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ParentDocumentMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ParentDocumentMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains a mapped parent document via properties
+ * A class that contains a mapped parent document via properties.
  *
  * @PHPCRODM\Document
  */
@@ -13,7 +13,7 @@ class ParentDocumentMappingObject
 {
     /** @PHPCRODM\Id */
     public $id;
-    
+
     /** @PHPCRODM\ParentDocument */
     public $parent;
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ParentPrivatePropertyMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ParentPrivatePropertyMappingObject.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 
 /**
- * A class that contains extends from a parent with mapped private properties
+ * A class that contains extends from a parent with mapped private properties.
  */
 class ParentPrivatePropertyMappingObject extends ParentWithPrivatePropertyObject
 {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ParentWithPrivatePropertyObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ParentWithPrivatePropertyObject.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 
 /**
- * A class that contains a mapped private property
+ * A class that contains a mapped private property.
  */
 class ParentWithPrivatePropertyObject
 {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferenceManyMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferenceManyMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that references many other documents
+ * A class that references many other documents.
  *
  * @PHPCRODM\Document
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferenceOneMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferenceOneMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that references one other document
+ * A class that references one other document.
  *
  * @PHPCRODM\Document
  */
@@ -13,10 +13,10 @@ class ReferenceOneMappingObject
 {
     /** @PHPCRODM\Id */
     public $id;
-    
+
     /** @PHPCRODM\ReferenceOne(targetDocument="myDocument", strategy="weak") */
     public $referenceOneWeak;
-    
+
     /** @PHPCRODM\ReferenceOne(targetDocument="myDocument", strategy="hard") */
     public $referenceOneHard;
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferenceableMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferenceableMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses the repository strategy to generate IDs
+ * A class that uses the repository strategy to generate IDs.
  *
  * @PHPCRODM\Document(referenceable=true)
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferrersMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReferrersMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses referrers
+ * A class that uses referrers.
  *
  * @PHPCRODM\Document(referenceable=true)
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReplaceMixinMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/ReplaceMixinMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains mapped children via properties
+ * A class that contains mapped children via properties.
  *
  * @PHPCRODM\Document(mixins={"mix:lastModified"}, inheritMixins=false)
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/RepositoryMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/RepositoryMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses the repository strategy to generate IDs
+ * A class that uses the repository strategy to generate IDs.
  *
  * @PHPCRODM\Document(repositoryClass="Doctrine\Tests\ODM\PHPCR\Mapping\Model\DocumentRepository")
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/StringExtendedMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/StringExtendedMappingObject.php
@@ -5,14 +5,15 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that extends a class which contains string properties
+ * A class that extends a class which contains string properties.
  *
  * @PHPCRODM\Document(translator="attribute")
  */
 class StringExtendedMappingObject extends StringMappingObject
 {
     /**
-     * The language this document currently is in
+     * The language this document currently is in.
+     *
      * @PHPCRODM\Locale
      */
     private $doclocale;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/StringMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/StringMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that contains string properties
+ * A class that contains string properties.
  *
  * @PHPCRODM\Document
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/TranslatorMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/TranslatorMappingObject.php
@@ -5,38 +5,43 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses translator and translatable
+ * A class that uses translator and translatable.
  *
  * @PHPCRODM\Document(translator="attribute")
  */
 class TranslatorMappingObject
 {
     /**
-     * The path
+     * The path.
+     *
      * @PHPCRODM\Id
      */
     private $id;
 
     /**
-     * The language this document currently is in
+     * The language this document currently is in.
+     *
      * @PHPCRODM\Locale
      */
     private $doclocale;
 
     /**
-     * Untranslated property
+     * Untranslated property.
+     *
      * @PHPCRODM\Field(type="date")
      */
     private $publishDate;
 
     /**
-     * Translated property
+     * Translated property.
+     *
      * @PHPCRODM\Field(type="string", translated=true)
      */
     private $topic;
 
     /**
-     * Language specific image
+     * Language specific image.
+     *
      * @PHPCRODM\Field(type="binary", translated=true)
      */
     private $image;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/TranslatorMappingObjectNoStrategy.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/TranslatorMappingObjectNoStrategy.php
@@ -5,38 +5,43 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * An invalid class with translated fields but no translator
+ * An invalid class with translated fields but no translator.
  *
  * @PHPCRODM\Document()
  */
 class TranslatorMappingObjectNoStrategy
 {
     /**
-     * The path
+     * The path.
+     *
      * @PHPCRODM\Id
      */
     private $id;
 
     /**
-     * The language this document currently is in
+     * The language this document currently is in.
+     *
      * @PHPCRODM\Locale
      */
     private $doclocale;
 
     /**
-     * Untranslated property
+     * Untranslated property.
+     *
      * @PHPCRODM\Field(type="date")
      */
     private $publishDate;
 
     /**
-     * Translated property
+     * Translated property.
+     *
      * @PHPCRODM\Field(type="string", translated=true)
      */
     private $topic;
 
     /**
-     * Language specific image
+     * Language specific image.
+     *
      * @PHPCRODM\Field(type="binary", translated=true)
      */
     private $image;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/VersionableMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/VersionableMappingObject.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ODM\PHPCR\Mapping\Model;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
 
 /**
- * A class that uses the repository strategy to generate IDs
+ * A class that uses the repository strategy to generate IDs.
  *
  * @PHPCRODM\Document(versionable="simple")
  */

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/php/Doctrine.Tests.ODM.PHPCR.Mapping.Model.VersionableMappingObject.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/Model/php/Doctrine.Tests.ODM.PHPCR.Mapping.Model.VersionableMappingObject.php
@@ -1,9 +1,10 @@
 <?php
+
 if (isset($metadata) && $metadata instanceof \Doctrine\ODM\PHPCR\Mapping\ClassMetadata) {
     /* @var $metadata \Doctrine\ODM\PHPCR\Mapping\ClassMetadata */
     $metadata->setVersioned('simple');
-    $metadata->mapId(array(
+    $metadata->mapId([
         'fieldName' => 'id',
-        'id'        => true
-    ));
+        'id'        => true,
+    ]);
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/XmlDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/XmlDriverTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver;
 
 /**
@@ -16,7 +14,7 @@ class XmlDriverTest extends AbstractMappingDriverTest
      */
     protected function loadDriver()
     {
-        $location = __DIR__ . '/Model/xml';
+        $location = __DIR__.'/Model/xml';
 
         return new XmlDriver($location);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/YamlDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/YamlDriverTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver;
 
 /**
@@ -16,7 +14,7 @@ class YamlDriverTest extends AbstractMappingDriverTest
      */
     protected function loadDriver()
     {
-        $location = __DIR__ . '/Model/yml';
+        $location = __DIR__.'/Model/yml';
 
         return new YamlDriver($location);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/PHPCRFunctionalTestCase.php
@@ -5,8 +5,8 @@ namespace Doctrine\Tests\ODM\PHPCR;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ODM\PHPCR\Configuration;
-use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Jackalope\RepositoryFactoryDoctrineDBAL;
 use Jackalope\RepositoryFactoryJackrabbit;
 use PHPCR\RepositoryFactoryInterface;
@@ -19,7 +19,7 @@ abstract class PHPCRFunctionalTestCase extends TestCase
     /**
      * @var SessionInterface[]
      */
-    private $sessions = array();
+    private $sessions = [];
 
     public function createDocumentManager(array $paths = null)
     {
@@ -27,7 +27,7 @@ abstract class PHPCRFunctionalTestCase extends TestCase
         AnnotationReader::addGlobalIgnoredName('group');
 
         if (empty($paths)) {
-            $paths = array(__DIR__ . "/../../Models");
+            $paths = [__DIR__.'/../../Models'];
         }
 
         $metaDriver = new AnnotationDriver($reader, $paths);
@@ -36,7 +36,7 @@ abstract class PHPCRFunctionalTestCase extends TestCase
             ?? RepositoryFactoryJackrabbit::class;
 
         if (ltrim($factoryclass, '\\') === RepositoryFactoryDoctrineDBAL::class) {
-            $params = array();
+            $params = [];
             foreach ($GLOBALS as $key => $value) {
                 if (0 === strpos($key, 'jackalope.doctrine.dbal.')) {
                     $params[substr($key, strlen('jackalope.doctrine.dbal.'))] = $value;
@@ -93,6 +93,6 @@ abstract class PHPCRFunctionalTestCase extends TestCase
         foreach ($this->sessions as $session) {
             $session->logout();
         }
-        $this->sessions = array();
+        $this->sessions = [];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Performance/InsertPerformanceTest.php
@@ -41,9 +41,9 @@ class InsertPerformanceTest extends PHPCRFunctionalTestCase
 
         for ($i = 0; $i < $this->count; $i++) {
             $user = new CmsUser();
-            $user->name = "Benjamin";
-            $user->username = "beberlei";
-            $user->status = "active";
+            $user->name = 'Benjamin';
+            $user->username = 'beberlei';
+            $user->status = 'active';
 
             $this->dm->persist($user);
         }
@@ -51,6 +51,6 @@ class InsertPerformanceTest extends PHPCRFunctionalTestCase
 
         $diff = microtime(true) - $s;
 
-        $this->assertTrue($diff < 1.0, "Inserting " . $this->count . " documents shouldn't take longer than one second, took " . $diff . " seconds.");
+        $this->assertTrue($diff < 1.0, 'Inserting '.$this->count." documents shouldn't take longer than one second, took ".$diff.' seconds.');
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractLeafNodeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractLeafNodeTest.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
+use Doctrine\ODM\PHPCR\Exception\RuntimeException;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
 use PHPUnit\Framework\TestCase;
-use Doctrine\ODM\PHPCR\Exception\RuntimeException;
 
 class AbstractLeafNodeTest extends TestCase
 {
@@ -27,17 +27,17 @@ class AbstractLeafNodeTest extends TestCase
 
     public function provideTestExplodeField()
     {
-        return array(
-            array('foo.bar', false, array('foo', 'bar')),
-            array('foobar', 'Invalid field specification'),
-            array('foobar.foobar.foobar', 'Invalid field specification'),
-        );
+        return [
+            ['foo.bar', false, ['foo', 'bar']],
+            ['foobar', 'Invalid field specification'],
+            ['foobar.foobar.foobar', 'Invalid field specification'],
+        ];
     }
 
     /**
      * @dataProvider provideTestExplodeField
      */
-    public function testExplodeField($fieldSpec, $xpctdExceptionMessage, $xpctdRes = array())
+    public function testExplodeField($fieldSpec, $xpctdExceptionMessage, $xpctdRes = [])
     {
         if ($xpctdExceptionMessage) {
             $this->expectException(RuntimeException::class);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractNodeTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/AbstractNodeTest.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use PHPUnit\Framework\TestCase;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use PHPUnit\Framework\TestCase;
 
 class AbstractNodeTest extends TestCase
 {
@@ -31,12 +31,12 @@ class AbstractNodeTest extends TestCase
 
         $this->node1 = $this->getMockBuilder(AbstractNode::class)
             ->setMockClassName('TestNode')
-            ->setConstructorArgs(array($this->parent))
+            ->setConstructorArgs([$this->parent])
             ->getMockForAbstractClass();
 
         $this->leafNode = $this->getMockBuilder(AbstractLeafNode::class)
             ->setMockClassName('LeafNode')
-            ->setConstructorArgs(array($this->node1))
+            ->setConstructorArgs([$this->node1])
             ->getMockForAbstractClass();
         $this->leafNode->expects($this->any())
             ->method('getNodeType')
@@ -47,7 +47,7 @@ class AbstractNodeTest extends TestCase
     {
         foreach ($data as $className) {
             /** @var AbstractNode|\PHPUnit_Framework_MockObject_MockObject $childNode */
-            $childNode = $this->getMockForAbstractClass(AbstractNode::class, array(), $className);
+            $childNode = $this->getMockForAbstractClass(AbstractNode::class, [], $className);
             $childNode->expects($this->once())
                 ->method('getNodeType')
                 ->will($this->returnValue($className));
@@ -65,76 +65,76 @@ class AbstractNodeTest extends TestCase
 
     public function provideAddChildValidation()
     {
-        return array(
+        return [
             // 1. Foobar bounded 1..1
             // VALID: We fulful criteria
-            array(
-                array(
-                    'FooBar' => array(1, 1),
-                ),
-                array(
+            [
+                [
+                    'FooBar' => [1, 1],
+                ],
+                [
                     'FooBar',
-                ),
-                array(
-                ),
-            ),
+                ],
+                [
+                ],
+            ],
             // 1a.
             // INVALID: Out of bounds
-            array(
-                array(
-                    'FooBar' => array(1, 1),
-                ),
-                array(
+            [
+                [
+                    'FooBar' => [1, 1],
+                ],
+                [
                     'FooBar',
                     'FooBar',
-                ),
-                array(
-                    'exceeds_max' => true
-                ),
-            ),
+                ],
+                [
+                    'exceeds_max' => true,
+                ],
+            ],
             // 1b.
             // INVALID: Wrong child type
-            array(
-                array(
-                    'FooBar' => array(1, 1),
-                ),
-                array(
+            [
+                [
+                    'FooBar' => [1, 1],
+                ],
+                [
                     'BarFoo',
-                ),
-                array(
-                    'invalid_child' => true
-                ),
-            ),
+                ],
+                [
+                    'invalid_child' => true,
+                ],
+            ],
             // 2. FooBar bounded below, unbounded above
-            array(
-                array(
-                    'FooBar' => array(1, null),
-                ),
-                array(
+            [
+                [
+                    'FooBar' => [1, null],
+                ],
+                [
                     'FooBar',
                     'FooBar',
                     'FooBar',
                     'FooBar',
-                ),
-                array(
-                ),
-            ),
+                ],
+                [
+                ],
+            ],
             // 2a.
             // INVALID: third datum is of wrong type
-            array(
-                array(
-                    'FooBar' => array(1, null),
-                ),
-                array(
+            [
+                [
+                    'FooBar' => [1, null],
+                ],
+                [
                     'FooBar',
                     'FooBar',
                     'BarFoo',
-                ),
-                array(
+                ],
+                [
                     'invalid_child' => true,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     /**
@@ -142,10 +142,10 @@ class AbstractNodeTest extends TestCase
      */
     public function testAddChildValidation($cardinalityMap, $data, $options)
     {
-        $options = array_merge(array(
-            'exceeds_max' => false,
+        $options = array_merge([
+            'exceeds_max'   => false,
             'invalid_child' => false,
-        ), $options);
+        ], $options);
 
         $this->node1->expects($this->any())
             ->method('getCardinalityMap')
@@ -169,9 +169,9 @@ class AbstractNodeTest extends TestCase
     {
         $this->node1->expects($this->any())
             ->method('getCardinalityMap')
-            ->will($this->returnValue(array(
-                'LeafNode' => array(1, 1),
-            )));
+            ->will($this->returnValue([
+                'LeafNode' => [1, 1],
+            ]));
 
         $res = $this->node1->addChild($this->leafNode);
         $this->assertSame($this->node1, $res);
@@ -179,42 +179,42 @@ class AbstractNodeTest extends TestCase
 
     public function provideValidate()
     {
-        return array(
+        return [
 
             // 1. Not enough data
             // INVALID
-            array(
-                array(
-                    'FooBar' => array(1, 1),
-                ),
-                array(
-                ), // not data!
-                array(
-                    'expected_exception' => array(
+            [
+                [
+                    'FooBar' => [1, 1],
+                ],
+                [
+                ], // not data!
+                [
+                    'expected_exception' => [
                         'OutOfBoundsException',
-                        '"TestNode" must have at least "1" child nodes of type "FooBar". "0" given'
-                    ),
-                )
-            ),
+                        '"TestNode" must have at least "1" child nodes of type "FooBar". "0" given',
+                    ],
+                ],
+            ],
 
             // 1a.
             // INVALID
-            array(
-                array(
-                    'FooBar' => array(3, 3),
-                ),
-                array(
+            [
+                [
+                    'FooBar' => [3, 3],
+                ],
+                [
                     'FooBar',
                     'FooBar',
-                ),
-                array(
-                    'expected_exception' => array(
+                ],
+                [
+                    'expected_exception' => [
                         'OutOfBoundsException',
-                        '"TestNode" must have at least "3" child nodes of type "FooBar". "2" given'
-                    ),
-                )
-            ),
-        );
+                        '"TestNode" must have at least "3" child nodes of type "FooBar". "2" given',
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -223,10 +223,10 @@ class AbstractNodeTest extends TestCase
      */
     public function testValidate($cardinalityMap, $data, $options)
     {
-        $options = array_merge(array(
-            'invalid_child' => false,
+        $options = array_merge([
+            'invalid_child'      => false,
             'expected_exception' => false,
-        ), $options);
+        ], $options);
 
         if ($options['expected_exception']) {
             list($exceptionType, $exceptionMessage) = $options['expected_exception'];
@@ -246,10 +246,10 @@ class AbstractNodeTest extends TestCase
     {
         $this->parent->expects($this->any())
             ->method('getCardinalityMap')
-            ->will($this->returnValue(array(
-                'foo' => array(1, 2),
-                'bar' => array(1, 2),
-            )));
+            ->will($this->returnValue([
+                'foo' => [1, 2],
+                'bar' => [1, 2],
+            ]));
 
         $this->node1->expects($this->any())
             ->method('getNodeType')
@@ -274,7 +274,7 @@ class AbstractNodeTest extends TestCase
     {
         $this->node1->expects($this->any())
             ->method('getCardinalityMap')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
         $res = $this->node1->end();
         $this->assertSame($this->parent, $res);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConstraintFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConstraintFactoryTest.php
@@ -2,56 +2,55 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Where;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 
 class ConstraintFactoryTest extends NodeTestCase
 {
     public function provideInterface()
     {
-        return array(
-            array('andX', 'ConstraintAndx', array(
-            )),
-            array('orX', 'ConstraintOrx', array(
-            )),
-            array('fieldIsset', 'ConstraintFieldIsset', array(
+        return [
+            ['andX', 'ConstraintAndx', [
+            ]],
+            ['orX', 'ConstraintOrx', [
+            ]],
+            ['fieldIsset', 'ConstraintFieldIsset', [
                 'alias.propery_name',
-            )),
-            array('fullTextSearch', 'ConstraintFullTextSearch', array(
+            ]],
+            ['fullTextSearch', 'ConstraintFullTextSearch', [
                 'alias.field', 'full_text_expression',
-            )),
-            array('same', 'ConstraintSame', array(
+            ]],
+            ['same', 'ConstraintSame', [
                 'path', 'alias',
-            )),
-            array('descendant', 'ConstraintDescendant', array(
+            ]],
+            ['descendant', 'ConstraintDescendant', [
                 'ancestor_path', 'alias',
-            )),
-            array('child', 'ConstraintChild', array(
+            ]],
+            ['child', 'ConstraintChild', [
                 'parent_path', 'alias',
-            )),
-            array('not', 'ConstraintNot', array(
-            )),
-            array('eq', 'ConstraintComparison', array(
-                QOMConstants::JCR_OPERATOR_EQUAL_TO
-            )),
-            array('neq', 'ConstraintComparison', array(
-                QOMConstants::JCR_OPERATOR_NOT_EQUAL_TO
-            )),
-            array('lt', 'ConstraintComparison', array(
-                QOMConstants::JCR_OPERATOR_LESS_THAN
-            )),
-            array('lte', 'ConstraintComparison', array(
-                QOMConstants::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO
-            )),
-            array('gt', 'ConstraintComparison', array(
-                QOMConstants::JCR_OPERATOR_GREATER_THAN
-            )),
-            array('gte', 'ConstraintComparison', array(
-                QOMConstants::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO
-            )),
-            array('like', 'ConstraintComparison', array(
-                QOMConstants::JCR_OPERATOR_LIKE
-            )),
-        );
+            ]],
+            ['not', 'ConstraintNot', [
+            ]],
+            ['eq', 'ConstraintComparison', [
+                QOMConstants::JCR_OPERATOR_EQUAL_TO,
+            ]],
+            ['neq', 'ConstraintComparison', [
+                QOMConstants::JCR_OPERATOR_NOT_EQUAL_TO,
+            ]],
+            ['lt', 'ConstraintComparison', [
+                QOMConstants::JCR_OPERATOR_LESS_THAN,
+            ]],
+            ['lte', 'ConstraintComparison', [
+                QOMConstants::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+            ]],
+            ['gt', 'ConstraintComparison', [
+                QOMConstants::JCR_OPERATOR_GREATER_THAN,
+            ]],
+            ['gte', 'ConstraintComparison', [
+                QOMConstants::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+            ]],
+            ['like', 'ConstraintComparison', [
+                QOMConstants::JCR_OPERATOR_LIKE,
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConverterPhpcrTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/ConverterPhpcrTest.php
@@ -2,32 +2,32 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
-use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
-use Jackalope\Query\QOM\QueryObjectModelFactory;
-use Doctrine\ODM\PHPCR\Query\Builder\ConverterPhpcr;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
-use PHPUnit\Framework\TestCase;
-use Jackalope\FactoryInterface;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use PHPCR\Query\QOM\PropertyExistenceInterface;
-use PHPCR\Query\QOM\JoinInterface;
-use PHPCR\Query\QOM\SelectorInterface;
-use PHPCR\Query\QOM\ColumnInterface;
-use PHPCR\Query\QOM\AndInterface;
-use PHPCR\Query\QOM\OrInterface;
-use PHPCR\Query\QOM\ComparisonInterface;
-use PHPCR\Query\QOM\PropertyValueInterface;
-use PHPCR\Query\QOM\LiteralInterface;
-use PHPCR\Query\QOM\NotInterface;
-use PHPCR\Query\QOM\NodeLocalNameInterface;
-use PHPCR\Query\QOM\SourceInterface;
-use PHPCR\Query\QOM\OrderingInterface;
-use PHPCR\Query\QOM\QueryObjectModelInterface;
-use Doctrine\ODM\PHPCR\Query\Query;
+use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
+use Doctrine\ODM\PHPCR\Query\Builder\ConverterPhpcr;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\ODM\PHPCR\Query\Query;
+use Jackalope\FactoryInterface;
+use Jackalope\Query\QOM\QueryObjectModelFactory;
+use PHPCR\Query\QOM\AndInterface;
+use PHPCR\Query\QOM\ColumnInterface;
+use PHPCR\Query\QOM\ComparisonInterface;
+use PHPCR\Query\QOM\JoinInterface;
+use PHPCR\Query\QOM\LiteralInterface;
+use PHPCR\Query\QOM\NodeLocalNameInterface;
+use PHPCR\Query\QOM\NotInterface;
+use PHPCR\Query\QOM\OrderingInterface;
+use PHPCR\Query\QOM\OrInterface;
+use PHPCR\Query\QOM\PropertyExistenceInterface;
+use PHPCR\Query\QOM\PropertyValueInterface;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
+use PHPCR\Query\QOM\QueryObjectModelInterface;
+use PHPCR\Query\QOM\SelectorInterface;
+use PHPCR\Query\QOM\SourceInterface;
+use PHPUnit\Framework\TestCase;
 
 class ConverterPhpcrTest extends TestCase
 {
@@ -80,11 +80,12 @@ class ConverterPhpcrTest extends TestCase
                 $meta->expects($me->any())
                     ->method('getFieldMapping')
                     ->will($me->returnCallback(function ($name) {
-                        $res = array(
+                        $res = [
                             'fieldName' => $name,
-                            'property' => $name.'_phpcr',
-                            'type' => 'String',
-                        );
+                            'property'  => $name.'_phpcr',
+                            'type'      => 'String',
+                        ];
+
                         return $res;
                     }));
 
@@ -133,7 +134,7 @@ class ConverterPhpcrTest extends TestCase
 
     /**
      * Return a builder with a source, as a alias is required for
-     * all methods
+     * all methods.
      */
     protected function primeBuilder()
     {
@@ -153,11 +154,11 @@ class ConverterPhpcrTest extends TestCase
 
     public function testDispatchFrom()
     {
-        $from = $this->createNode('From', array());
-        $source = $this->createNode('SourceDocument', array(
+        $from = $this->createNode('From', []);
+        $source = $this->createNode('SourceDocument', [
             'foobar',
             'alias',
-        ));
+        ]);
         $from->addChild($source);
 
         $res = $this->converter->dispatch($from);
@@ -169,11 +170,11 @@ class ConverterPhpcrTest extends TestCase
 
     public function testDispatchFromNonMapped()
     {
-        $from = $this->createNode('From', array());
-        $source = $this->createNode('SourceDocument', array(
+        $from = $this->createNode('From', []);
+        $source = $this->createNode('SourceDocument', [
             '_document_not_mapped_',
             'alias',
-        ));
+        ]);
         $from->addChild($source);
 
         $this->expectException(\RuntimeException::class);
@@ -183,12 +184,12 @@ class ConverterPhpcrTest extends TestCase
 
     public function provideDispatchWheres()
     {
-        return array(
-            array('And'),
-            array('Or'),
-            array('And', true),
-            array('Or', true),
-        );
+        return [
+            ['And'],
+            ['Or'],
+            ['And', true],
+            ['Or', true],
+        ];
     }
 
     /**
@@ -200,14 +201,14 @@ class ConverterPhpcrTest extends TestCase
         $this->primeBuilder();
 
         if ($skipOriginalWhere) {
-            $where = $this->createNode('Where'.$logicalOp, array());
+            $where = $this->createNode('Where'.$logicalOp, []);
         } else {
-            $where = $this->createNode('Where', array());
+            $where = $this->createNode('Where', []);
         }
 
-        $constraint = $this->createNode('ConstraintFieldIsset', array(
+        $constraint = $this->createNode('ConstraintFieldIsset', [
             'alias_1.foobar',
-        ));
+        ]);
         $where->addChild($constraint);
 
         $res = $this->converter->dispatch($where);
@@ -217,10 +218,10 @@ class ConverterPhpcrTest extends TestCase
         $this->assertEquals('foobar_phpcr', $res->getPropertyName());
 
         // test add / or where (see dataProvider)
-        $whereCon = $this->createNode('Where'.$logicalOp, array());
-        $constraint = $this->createNode('ConstraintFieldIsset', array(
+        $whereCon = $this->createNode('Where'.$logicalOp, []);
+        $constraint = $this->createNode('ConstraintFieldIsset', [
             'alias_1.barfoo',
-        ));
+        ]);
         $whereCon->addChild($constraint);
 
         $res = $this->converter->dispatch($whereCon);
@@ -232,18 +233,18 @@ class ConverterPhpcrTest extends TestCase
 
     public function provideDispatchFromJoin()
     {
-        return array(
+        return [
             // join types
-            array('joinInner', QOMConstants::JCR_JOIN_TYPE_INNER),
-            array('joinLeftOuter', QOMConstants::JCR_JOIN_TYPE_LEFT_OUTER),
-            array('joinRightOuter', QOMConstants::JCR_JOIN_TYPE_RIGHT_OUTER),
-            array('joinInner', QOMConstants::JCR_JOIN_TYPE_INNER),
+            ['joinInner', QOMConstants::JCR_JOIN_TYPE_INNER],
+            ['joinLeftOuter', QOMConstants::JCR_JOIN_TYPE_LEFT_OUTER],
+            ['joinRightOuter', QOMConstants::JCR_JOIN_TYPE_RIGHT_OUTER],
+            ['joinInner', QOMConstants::JCR_JOIN_TYPE_INNER],
 
             // conditions
-            array('joinInner', QOMConstants::JCR_JOIN_TYPE_INNER, 'child'),
-            array('joinInner', QOMConstants::JCR_JOIN_TYPE_INNER, 'descendant'),
-            array('joinInner', QOMConstants::JCR_JOIN_TYPE_INNER, 'sameDocument'),
-        );
+            ['joinInner', QOMConstants::JCR_JOIN_TYPE_INNER, 'child'],
+            ['joinInner', QOMConstants::JCR_JOIN_TYPE_INNER, 'descendant'],
+            ['joinInner', QOMConstants::JCR_JOIN_TYPE_INNER, 'sameDocument'],
+        ];
     }
 
     /**
@@ -316,14 +317,14 @@ class ConverterPhpcrTest extends TestCase
 
     public function provideDispatchCompositeConstraints()
     {
-        return array(
-            array('andX', PropertyExistenceInterface::class, 1),
-            array('andX', AndInterface::class, 2),
-            array('andX', AndInterface::class, 3),
-            array('orX', PropertyExistenceInterface::class, 1),
-            array('orX', OrInterface::class, 2),
-            array('orX', OrInterface::class, 3),
-        );
+        return [
+            ['andX', PropertyExistenceInterface::class, 1],
+            ['andX', AndInterface::class, 2],
+            ['andX', AndInterface::class, 3],
+            ['orX', PropertyExistenceInterface::class, 1],
+            ['orX', OrInterface::class, 2],
+            ['orX', OrInterface::class, 3],
+        ];
     }
 
     /**
@@ -356,28 +357,28 @@ class ConverterPhpcrTest extends TestCase
 
     public function provideDisaptchConstraintsLeaf()
     {
-        return array(
-            array(
-                'ConstraintFieldIsset', array('alias_1.rop_1'),
-                'PropertyExistenceInterface'
-            ),
-            array(
-                'ConstraintFullTextSearch', array('alias_1.prop_1', 'search_expr'),
-                'FullTextSearchInterface'
-            ),
-            array(
-                'ConstraintSame', array('alias_1', '/path'),
-                'SameNodeInterface'
-            ),
-            array(
-                'ConstraintDescendant', array('alias_1', '/ancestor/path'),
-                'DescendantNodeInterface'
-            ),
-            array(
-                'ConstraintChild', array('alias_1', '/parent/path'),
-                'ChildNodeInterface'
-            ),
-        );
+        return [
+            [
+                'ConstraintFieldIsset', ['alias_1.rop_1'],
+                'PropertyExistenceInterface',
+            ],
+            [
+                'ConstraintFullTextSearch', ['alias_1.prop_1', 'search_expr'],
+                'FullTextSearchInterface',
+            ],
+            [
+                'ConstraintSame', ['alias_1', '/path'],
+                'SameNodeInterface',
+            ],
+            [
+                'ConstraintDescendant', ['alias_1', '/ancestor/path'],
+                'DescendantNodeInterface',
+            ],
+            [
+                'ConstraintChild', ['alias_1', '/parent/path'],
+                'ChildNodeInterface',
+            ],
+        ];
     }
 
     /**
@@ -397,15 +398,15 @@ class ConverterPhpcrTest extends TestCase
 
     public function provideDispatchConstraintsComparison()
     {
-        return array(
-            array('eq', QOMConstants::JCR_OPERATOR_EQUAL_TO),
-            array('neq', QOMConstants::JCR_OPERATOR_NOT_EQUAL_TO),
-            array('gt', QOMConstants::JCR_OPERATOR_GREATER_THAN),
-            array('gte', QOMConstants::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO),
-            array('lt', QOMConstants::JCR_OPERATOR_LESS_THAN),
-            array('lte', QOMConstants::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO),
-            array('like', QOMConstants::JCR_OPERATOR_LIKE),
-        );
+        return [
+            ['eq', QOMConstants::JCR_OPERATOR_EQUAL_TO],
+            ['neq', QOMConstants::JCR_OPERATOR_NOT_EQUAL_TO],
+            ['gt', QOMConstants::JCR_OPERATOR_GREATER_THAN],
+            ['gte', QOMConstants::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO],
+            ['lt', QOMConstants::JCR_OPERATOR_LESS_THAN],
+            ['lte', QOMConstants::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO],
+            ['like', QOMConstants::JCR_OPERATOR_LIKE],
+        ];
     }
 
     /**
@@ -442,27 +443,27 @@ class ConverterPhpcrTest extends TestCase
 
     public function provideTestDispatchOperands()
     {
-        return array(
+        return [
             // leaf
-            array('OperandDynamicLocalName', array('alias_1'), array(
+            ['OperandDynamicLocalName', ['alias_1'], [
                 'assert' => function ($test, $node) {
                     $test->assertEquals('alias_1', $node->getSelectorName());
                 },
                 'phpcr_class' => 'NodeLocalNameInterface',
-            )),
-            array('OperandDynamicName', array('alias_1'), array(
+            ]],
+            ['OperandDynamicName', ['alias_1'], [
                 'assert' => function ($test, $node) {
                     $test->assertEquals('alias_1', $node->getSelectorName());
                 },
                 'phpcr_class' => 'NodeNameInterface',
-            )),
-            array('OperandDynamicFullTextSearchScore', array('alias_1'), array(
+            ]],
+            ['OperandDynamicFullTextSearchScore', ['alias_1'], [
                 'assert' => function ($test, $node) {
                     $test->assertEquals('alias_1', $node->getSelectorName());
                 },
                 'phpcr_class' => 'FullTextSearchScoreInterface',
-            )),
-            array('OperandDynamicLength', array('alias_1.field'), array(
+            ]],
+            ['OperandDynamicLength', ['alias_1.field'], [
                 'assert' => function ($test, $node) {
                     $propertyValue = $node->getPropertyValue();
                     $test->assertInstanceOf(
@@ -473,47 +474,47 @@ class ConverterPhpcrTest extends TestCase
                     $test->assertEquals('field_phpcr', $propertyValue->getPropertyName());
                 },
                 'phpcr_class' => 'LengthInterface',
-            )),
-            array('OperandDynamicField', array('alias_1.field'), array(
+            ]],
+            ['OperandDynamicField', ['alias_1.field'], [
                 'assert' => function ($test, $node) {
                     $test->assertEquals('alias_1', $node->getSelectorName());
                     $test->assertEquals('field_phpcr', $node->getPropertyName());
                 },
                 'phpcr_class' => 'PropertyValueinterface',
-            )),
+            ]],
 
             // non-leaf
-            array('OperandDynamicLowerCase', array('alias_1'), array(
-                'phpcr_class' => 'LowerCaseInterface',
+            ['OperandDynamicLowerCase', ['alias_1'], [
+                'phpcr_class'       => 'LowerCaseInterface',
                 'add_child_operand' => true,
-                'assert' => function ($test, $node) {
+                'assert'            => function ($test, $node) {
                     $op = $node->getOperand();
                     $test->assertInstanceOf(NodeLocalNameInterface::class, $op);
-                }
-            )),
-            array('OperandDynamicUpperCase', array('alias_1'), array(
+                },
+            ]],
+            ['OperandDynamicUpperCase', ['alias_1'], [
                 'assert' => function ($test, $node) {
                     $op = $node->getOperand();
                     $test->assertInstanceOf(NodeLocalNameInterface::class, $op);
                 },
                 'add_child_operand' => true,
-                'phpcr_class' => 'UpperCaseInterface',
-            )),
+                'phpcr_class'       => 'UpperCaseInterface',
+            ]],
 
             // static
-            array('OperandStaticParameter', array('variable_name'), array(
+            ['OperandStaticParameter', ['variable_name'], [
                 'assert' => function ($test, $node) {
                     $test->assertEquals('variable_name', $node->getBindVariableName());
                 },
                 'phpcr_class' => 'BindVariableValueInterface',
-            )),
-            array('OperandStaticLiteral', array('literal_value'), array(
+            ]],
+            ['OperandStaticLiteral', ['literal_value'], [
                 'assert' => function ($test, $node) {
                     $test->assertEquals('literal_value', $node->getLiteralValue());
                 },
                 'phpcr_class' => 'LiteralInterface',
-            )),
-        );
+            ]],
+        ];
     }
 
     /**
@@ -521,11 +522,11 @@ class ConverterPhpcrTest extends TestCase
      */
     public function testDispatchOperands($class, $args, $options)
     {
-        $options = array_merge(array(
-            'assert' => null,
+        $options = array_merge([
+            'assert'            => null,
             'add_child_operand' => false,
-            'phpcr_class' => null,
-        ), $options);
+            'phpcr_class'       => null,
+        ], $options);
 
         $expectedPhpcrClass = '\\PHPCR\\Query\\QOM\\'.$options['phpcr_class'];
 
@@ -535,7 +536,7 @@ class ConverterPhpcrTest extends TestCase
 
         if ($options['add_child_operand']) {
             $operand->addChild(
-                $this->createNode('OperandDynamicLocalName', array('alias_1'))
+                $this->createNode('OperandDynamicLocalName', ['alias_1'])
             );
         }
 
@@ -551,20 +552,20 @@ class ConverterPhpcrTest extends TestCase
     public function testOrderBy()
     {
         $this->primeBuilder();
-        $order1 = $this->createNode('Ordering', array(QOMConstants::JCR_ORDER_ASCENDING));
-        $order2 = $this->createNode('Ordering', array(QOMConstants::JCR_ORDER_ASCENDING));
-        $order3 = $this->createNode('Ordering', array(QOMConstants::JCR_ORDER_DESCENDING));
+        $order1 = $this->createNode('Ordering', [QOMConstants::JCR_ORDER_ASCENDING]);
+        $order2 = $this->createNode('Ordering', [QOMConstants::JCR_ORDER_ASCENDING]);
+        $order3 = $this->createNode('Ordering', [QOMConstants::JCR_ORDER_DESCENDING]);
 
-        $orderBy = $this->createNode('OrderBy', array());
+        $orderBy = $this->createNode('OrderBy', []);
         $orderBy->addChild($order1);
         $orderBy->addChild($order2);
 
-        $op = $this->createNode('OperandDynamicLocalName', array('alias_1'));
+        $op = $this->createNode('OperandDynamicLocalName', ['alias_1']);
         $order1->addChild($op);
         $order2->addChild($op);
         $order3->addChild($op);
 
-        $orderByAdd = $this->createNode('OrderByAdd', array());
+        $orderByAdd = $this->createNode('OrderByAdd', []);
         $orderByAdd->addChild($order3);
 
         // original adds 2 orderings
@@ -582,11 +583,11 @@ class ConverterPhpcrTest extends TestCase
 
     public function provideOrderByDynamicField()
     {
-        return array(
-            array('alias_1.ok_field', null),
-            array('alias_1.nodenameProperty', 'Cannot use nodename property "nodenameProperty" of class "MyClassName" as a dynamic operand use "localname()" instead.'),
-            array('alias_1.associationfield', 'Cannot use association property "associationfield" of class "MyClassName" as a dynamic operand.')
-        );
+        return [
+            ['alias_1.ok_field', null],
+            ['alias_1.nodenameProperty', 'Cannot use nodename property "nodenameProperty" of class "MyClassName" as a dynamic operand use "localname()" instead.'],
+            ['alias_1.associationfield', 'Cannot use association property "associationfield" of class "MyClassName" as a dynamic operand.'],
+        ];
     }
 
     /**
@@ -595,12 +596,12 @@ class ConverterPhpcrTest extends TestCase
     public function testOrderByDynamicField($field, $exception)
     {
         $this->primeBuilder();
-        $order1 = $this->createNode('Ordering', array(QOMConstants::JCR_ORDER_ASCENDING));
+        $order1 = $this->createNode('Ordering', [QOMConstants::JCR_ORDER_ASCENDING]);
 
-        $orderBy = $this->createNode('OrderBy', array());
+        $orderBy = $this->createNode('OrderBy', []);
         $orderBy->addChild($order1);
 
-        $op = $this->createNode('OperandDynamicField', array($field));
+        $op = $this->createNode('OperandDynamicField', [$field]);
         $order1->addChild($op);
 
         if (null !== $exception) {
@@ -664,6 +665,7 @@ class ConverterPhpcrTest extends TestCase
 
                 // return something ..
                 $qom = $me->createMock(QueryObjectModelInterface::class);
+
                 return $qom;
             }));
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/FieldTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/FieldTest.php
@@ -2,18 +2,15 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Builder;
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
-
 class FieldTest extends LeafNodeTestCase
 {
     public function provideNode()
     {
-        return array(
-            array('Field', array('a.FooBar'), array(
+        return [
+            ['Field', ['a.FooBar'], [
                 'getAlias' => 'a',
                 'getField' => 'FooBar',
-            )),
-        );
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/FromTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/FromTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\From;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 
 class FromTest extends NodeTestCase
@@ -10,26 +9,26 @@ class FromTest extends NodeTestCase
     /**
      * @dataProvider provideInterface
      */
-    public function testInterface($method, $type, $args = array())
+    public function testInterface($method, $type, $args = [])
     {
         $this->markTestSkipped('Joins temporarily disabled');
     }
 
     public function provideInterface()
     {
-        return array(
-            array('document', 'SourceDocument', array(
+        return [
+            ['document', 'SourceDocument', [
                 '/Fqn/To/Class', 'a',
-            )),
-            array('joinInner', 'SourceJoin', array(
+            ]],
+            ['joinInner', 'SourceJoin', [
                 QOMConstants::JCR_JOIN_TYPE_INNER,
-            )),
-            array('joinLeftOuter', 'SourceJoin', array(
+            ]],
+            ['joinLeftOuter', 'SourceJoin', [
                 QOMConstants::JCR_JOIN_TYPE_LEFT_OUTER,
-            )),
-            array('joinRightOuter', 'SourceJoin', array(
+            ]],
+            ['joinRightOuter', 'SourceJoin', [
                 QOMConstants::JCR_JOIN_TYPE_RIGHT_OUTER,
-            )),
-        );
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/LeafNodeTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/LeafNodeTestCase.php
@@ -25,7 +25,7 @@ abstract class LeafNodeTestCase extends TestCase
     public function testNode($type, $args, $methods)
     {
         $ns = 'Doctrine\ODM\PHPCR\Query\Builder';
-        $fqn = $ns . '\\' . $type;
+        $fqn = $ns.'\\'.$type;
 
         $values = array_values($args);
         array_unshift($values, $this->parent);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/NodeTestCase.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/NodeTestCase.php
@@ -2,10 +2,9 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Builder;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
-use PHPUnit\Framework\TestCase;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use PHPUnit\Framework\TestCase;
 
 abstract class NodeTestCase extends TestCase
 {
@@ -21,16 +20,16 @@ abstract class NodeTestCase extends TestCase
 
     abstract public function provideInterface();
 
-    protected function getNode($args = array())
+    protected function getNode($args = [])
     {
         $refl = new \ReflectionClass($this);
         preg_match('&^(.*?)Test&', $refl->getShortName(), $matches);
         $nodeClass = $matches[1];
         $fqn = 'Doctrine\\ODM\\PHPCR\Query\\Builder\\'.$nodeClass;
         $nodeRefl = new \ReflectionClass($fqn);
-        $inst = $nodeRefl->newInstanceArgs(array_merge(array(
-            $this->parent
-        ), $args));
+        $inst = $nodeRefl->newInstanceArgs(array_merge([
+            $this->parent,
+        ], $args));
 
         return $inst;
     }
@@ -38,11 +37,11 @@ abstract class NodeTestCase extends TestCase
     /**
      * @dataProvider provideInterface
      */
-    public function testInterface($method, $type, $args = array())
+    public function testInterface($method, $type, $args = [])
     {
         $expectedClass = 'Doctrine\\ODM\\PHPCR\\Query\\Builder\\'.$type;
 
-        $res = call_user_func_array(array($this->node, $method), $args);
+        $res = call_user_func_array([$this->node, $method], $args);
         $refl = new \ReflectionClass($expectedClass);
 
         if ($refl->isSubclassOf(AbstractLeafNode::class)) {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/OperandDynamicFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/OperandDynamicFactoryTest.php
@@ -2,33 +2,30 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Where;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
-
 class OperandDynamicFactoryTest extends NodeTestCase
 {
     public function provideInterface()
     {
-        return array(
-            array('fullTextSearchScore', 'OperandDynamicFullTextSearchScore', array(
+        return [
+            ['fullTextSearchScore', 'OperandDynamicFullTextSearchScore', [
                 'alias',
-            )),
-            array('length', 'OperandDynamicFullTextSearchScore', array(
+            ]],
+            ['length', 'OperandDynamicFullTextSearchScore', [
                 'alias.field',
-            )),
-            array('lowerCase', 'OperandDynamicLowerCase', array(
-            )),
-            array('upperCase', 'OperandDynamicUpperCase', array(
-            )),
-            array('name', 'OperandDynamicName', array(
+            ]],
+            ['lowerCase', 'OperandDynamicLowerCase', [
+            ]],
+            ['upperCase', 'OperandDynamicUpperCase', [
+            ]],
+            ['name', 'OperandDynamicName', [
                 'alias',
-            )),
-            array('localName', 'OperandDynamicLocalName', array(
+            ]],
+            ['localName', 'OperandDynamicLocalName', [
                 'alias',
-            )),
-            array('field', 'OperandDynamicField', array(
+            ]],
+            ['field', 'OperandDynamicField', [
                 'alias.field',
-            )),
-        );
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/OperandStaticFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/OperandStaticFactoryTest.php
@@ -2,20 +2,17 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Where;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
-
 class OperandStaticFactoryTest extends NodeTestCase
 {
     public function provideInterface()
     {
-        return array(
-            array('literal', 'OperandStaticLiteral', array(
+        return [
+            ['literal', 'OperandStaticLiteral', [
                 'value',
-            )),
-            array('parameter', 'OperandStaticParameter', array(
+            ]],
+            ['parameter', 'OperandStaticParameter', [
                 'variable_name',
-            )),
-        );
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/OrderByTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/OrderByTest.php
@@ -2,20 +2,19 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\Where;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 
 class OrderByTest extends NodeTestCase
 {
     public function provideInterface()
     {
-        return array(
-            array('asc', 'Ordering', array(
+        return [
+            ['asc', 'Ordering', [
                 QOMConstants::JCR_ORDER_ASCENDING,
-            )),
-            array('desc', 'Ordering', array(
+            ]],
+            ['desc', 'Ordering', [
                 QOMConstants::JCR_ORDER_DESCENDING,
-            )),
-        );
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
@@ -2,21 +2,21 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Query\Builder\ConverterInterface;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 
 class QueryBuilderTest extends NodeTestCase
 {
     public function provideInterface()
     {
-        return array(
-            array('where', 'Where'),
-            array('andWhere', 'WhereAnd'), // andWhere adds Where if no existing Where
-            array('orWhere', 'WhereOr'), // andWhere adds Where if no existing Where
-            array('from', 'From', array('a')),
-            array('orderBy', 'OrderBy'),
-            array('select', 'Select'),
-        );
+        return [
+            ['where', 'Where'],
+            ['andWhere', 'WhereAnd'], // andWhere adds Where if no existing Where
+            ['orWhere', 'WhereOr'], // andWhere adds Where if no existing Where
+            ['from', 'From', ['a']],
+            ['orderBy', 'OrderBy'],
+            ['select', 'Select'],
+        ];
     }
 
     public function testNonExistantMethod()
@@ -88,8 +88,7 @@ class QueryBuilderTest extends NodeTestCase
             ->end()
             ->addOrderBy()
                 ->asc()->name('c')->end()
-            ->end()
-        ;
+            ->end();
     }
 
     public function testPrimaryAlias()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SelectTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SelectTest.php
@@ -2,17 +2,14 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\From;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
-
 class SelectTest extends NodeTestCase
 {
     public function provideInterface()
     {
-        return array(
-            array('field', 'Field', array(
+        return [
+            ['field', 'Field', [
                 'alias.field',
-            )),
-        );
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceDocumentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceDocumentTest.php
@@ -8,12 +8,12 @@ class SourceDocumentTest extends LeafNodeTestCase
 {
     public function provideNode()
     {
-        return array(
-            array('SourceDocument', array('FooBar', 'a'), array(
+        return [
+            ['SourceDocument', ['FooBar', 'a'], [
                 'getDocumentFqn' => 'FooBar',
-                'getAlias' => 'a',
-            )),
-        );
+                'getAlias'       => 'a',
+            ]],
+        ];
     }
 
     public function testEmptyAlias()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceJoinConditionFactoryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceJoinConditionFactoryTest.php
@@ -2,27 +2,23 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\From;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
-use Doctrine\ODM\PHPCR\Query\Builder\SourceJoin;
-
 class SourceJoinConditionFactoryTest extends NodeTestCase
 {
     public function provideInterface()
     {
-        return array(
-            array('descendant', 'SourceJoinConditionDescendant', array(
+        return [
+            ['descendant', 'SourceJoinConditionDescendant', [
                 'alias_1', 'alias_2',
-            )),
-            array('equi', 'SourceJoinConditionEqui', array(
+            ]],
+            ['equi', 'SourceJoinConditionEqui', [
                 'alias1.property1', 'alias2.property2',
-            )),
-            array('child', 'SourceJoinConditionChildDocument', array(
+            ]],
+            ['child', 'SourceJoinConditionChildDocument', [
                 'child_alias', 'parent_alias',
-            )),
-            array('same', 'SourceJoinConditionSameDocument', array(
+            ]],
+            ['same', 'SourceJoinConditionSameDocument', [
                 'alias_1', 'alias_2', '/path/to/doc',
-            )),
-        );
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceJoinTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/SourceJoinTest.php
@@ -2,28 +2,25 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query\Builder;
 
-use Doctrine\ODM\PHPCR\Query\Builder\From;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
-use Doctrine\ODM\PHPCR\Query\Builder\SourceJoin;
-
 class SourceJoinTest extends NodeTestCase
 {
-    public function getNode($args = array())
+    public function getNode($args = [])
     {
         $args[] = 'test-join-type';
+
         return parent::getNode($args);
     }
 
     public function provideInterface()
     {
-        return array(
-            array('left', 'SourceJoinLeft', array(
+        return [
+            ['left', 'SourceJoinLeft', [
                 '/Fqn/To/Class', 'a',
-            )),
-            array('right', 'SourceJoinRight', array(
-            )),
-            array('condition', 'SourceJoinConditionFactory', array(
-            )),
-        );
+            ]],
+            ['right', 'SourceJoinRight', [
+            ]],
+            ['condition', 'SourceJoinConditionFactory', [
+            ]],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Query/QueryTest.php
@@ -2,13 +2,13 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Query;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Query\NoResultException;
 use Doctrine\ODM\PHPCR\Query\Query;
 use Doctrine\ODM\PHPCR\Query\QueryException;
-use PHPUnit\Framework\TestCase;
 use PHPCR\Query\QueryInterface;
-use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group unit
@@ -32,16 +32,16 @@ class QueryTest extends Testcase
 
     public function testGetSetParameters()
     {
-        $this->query->setParameters(array(
+        $this->query->setParameters([
             'foo' => 'bar',
             'bar' => 'foo',
-        ));
-        $this->assertEquals(array('foo' => 'bar', 'bar' => 'foo'), $this->query->getParameters());
-        $this->query->setParameters(array(
+        ]);
+        $this->assertEquals(['foo' => 'bar', 'bar' => 'foo'], $this->query->getParameters());
+        $this->query->setParameters([
             'boo' => 'far',
             'far' => 'boo',
-        ));
-        $this->assertEquals(array('boo' => 'far', 'far' => 'boo'), $this->query->getParameters());
+        ]);
+        $this->assertEquals(['boo' => 'far', 'far' => 'boo'], $this->query->getParameters());
     }
 
     public function testGetSetParameter()
@@ -56,7 +56,7 @@ class QueryTest extends Testcase
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(array('ok')));
+            ->will($this->returnValue(['ok']));
         $res = $this->query->execute(null, Query::HYDRATE_PHPCR);
         $this->assertInstanceOf(ArrayCollection::class, $res);
         $this->assertEquals('ok', $res->first());
@@ -67,7 +67,7 @@ class QueryTest extends Testcase
         $this->dm->expects($this->exactly(2))
             ->method('getDocumentsByPhpcrQuery')
             ->with($this->phpcrQuery)
-            ->will($this->returnValue(array('ok')));
+            ->will($this->returnValue(['ok']));
 
         $res = $this->query->execute();
         $this->assertEquals('ok', $res->first());
@@ -81,7 +81,7 @@ class QueryTest extends Testcase
         $this->dm->expects($this->exactly(2))
             ->method('getDocumentsByPhpcrQuery')
             ->with($this->phpcrQuery, null, 'a')
-            ->will($this->returnValue(array('ok')));
+            ->will($this->returnValue(['ok']));
 
         $res = $this->aliasQuery->execute();
         $this->assertEquals('ok', $res->first());
@@ -104,7 +104,7 @@ class QueryTest extends Testcase
         $this->phpcrQuery->expects($this->at(1))
             ->method('bindValue')
             ->with('bar', 'foo');
-        $this->query->execute(array('foo' => 'bar', 'bar' => 'foo'));
+        $this->query->execute(['foo' => 'bar', 'bar' => 'foo']);
     }
 
     public function testExecute_maxResults()
@@ -141,7 +141,7 @@ class QueryTest extends Testcase
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
         $res = $this->query->getOneOrNullResult(Query::HYDRATE_PHPCR);
         $this->assertNull($res);
     }
@@ -150,7 +150,7 @@ class QueryTest extends Testcase
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(array('ok1')));
+            ->will($this->returnValue(['ok1']));
         $res = $this->query->getOneOrNullResult(Query::HYDRATE_PHPCR);
         $this->assertEquals('ok1', $res);
     }
@@ -159,7 +159,7 @@ class QueryTest extends Testcase
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(array('ok1', 'ok2')));
+            ->will($this->returnValue(['ok1', 'ok2']));
 
         $this->expectException(QueryException::class);
         $this->query->getOneOrNullResult(Query::HYDRATE_PHPCR);
@@ -169,7 +169,7 @@ class QueryTest extends Testcase
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
         $this->expectException(NoResultException::class);
         $this->query->getSingleResult(Query::HYDRATE_PHPCR);
@@ -179,7 +179,7 @@ class QueryTest extends Testcase
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(array('ok1')));
+            ->will($this->returnValue(['ok1']));
         $res = $this->query->getSingleResult(Query::HYDRATE_PHPCR);
         $this->assertEquals('ok1', $res);
     }
@@ -188,7 +188,7 @@ class QueryTest extends Testcase
     {
         $this->phpcrQuery->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(array('ok1', 'ok2')));
+            ->will($this->returnValue(['ok1', 'ok2']));
 
         $this->expectException(QueryException::class);
         $this->query->getSingleResult(Query::HYDRATE_PHPCR);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DocumentConvertTranslationCommandTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DocumentConvertTranslationCommandTest.php
@@ -5,10 +5,10 @@ namespace Doctrine\Tests\ODM\PHPCR\Tools\Command;
 use Doctrine\ODM\PHPCR\Tools\Console\Command\DocumentConvertTranslationCommand;
 use Doctrine\ODM\PHPCR\Tools\Helper\TranslationConverter;
 use PHPCR\SessionInterface;
+use PHPCR\Util\Console\Helper\PhpcrHelper;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
-use PHPUnit\Framework\TestCase;
-use PHPCR\Util\Console\Helper\PhpcrHelper;
 
 class DocumentConvertTranslationCommandTest extends TestCase
 {
@@ -39,12 +39,11 @@ class DocumentConvertTranslationCommandTest extends TestCase
         $mockHelper
             ->expects($this->once())
             ->method('getSession')
-            ->will($this->returnValue($this->mockSession))
-        ;
+            ->will($this->returnValue($this->mockSession));
         $this->converter = $this->createMock(TranslationConverter::class);
         $this->command = new DocumentConvertTranslationCommand(null, $this->converter);
         $this->command->setHelperSet(new HelperSet(
-            array('phpcr' => $mockHelper)
+            ['phpcr' => $mockHelper]
         ));
         $this->commandTester = new CommandTester($this->command);
     }
@@ -54,25 +53,22 @@ class DocumentConvertTranslationCommandTest extends TestCase
         $this->converter
             ->expects($this->once())
             ->method('convert')
-            ->with('Document\MyClass', array('en'), array(), 'none')
-            ->will($this->returnValue(false))
-        ;
+            ->with('Document\MyClass', ['en'], [], 'none')
+            ->will($this->returnValue(false));
         $this->converter
             ->expects($this->any())
             ->method('getLastNotices')
-            ->will($this->returnValue(array()))
-        ;
+            ->will($this->returnValue([]));
 
         $this->mockSession
             ->expects($this->once())
-            ->method('save')
-        ;
+            ->method('save');
 
-        $this->commandTester->execute(array(
+        $this->commandTester->execute([
             'classname' => 'Document\MyClass',
-            '--locales' => array('en'),
-            '--force' => true,
-        ));
+            '--locales' => ['en'],
+            '--force'   => true,
+        ]);
 
         $this->assertEquals('.'.PHP_EOL.'done'.PHP_EOL, $this->commandTester->getDisplay());
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DumpQueryBuilderReferenceCommandTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Command/DumpQueryBuilderReferenceCommandTest.php
@@ -3,8 +3,8 @@
 namespace Doctrine\Tests\ODM\PHPCR\Tools\Command;
 
 use Doctrine\ODM\PHPCR\Tools\Console\Command\DumpQueryBuilderReferenceCommand;
-use Symfony\Component\Console\Tester\CommandTester;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class DumpQueryBuilderReferenceCommandTest extends TestCase
 {
@@ -30,7 +30,7 @@ class DumpQueryBuilderReferenceCommandTest extends TestCase
             $this->markTestSkipped('Dump reference command not compatible with PHP 5.3');
         }
 
-        $this->commandTester->execute(array());
+        $this->commandTester->execute([]);
         $res = $this->commandTester->getDisplay();
         $this->assertContains('Query Builder Reference', $res);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Helper/UniqueNodeTypeHelperTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Helper/UniqueNodeTypeHelperTest.php
@@ -4,10 +4,10 @@ namespace Doctrine\Tests\ODM\PHPCR\Tools\Helper;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\ODM\PHPCR\Tools\Helper\UniqueNodeTypeHelper;
 use PHPUnit\Framework\TestCase;
-use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
 
 /**
  * Verify the behavior of the UniqueNodeTypeHelper class that is used
@@ -28,7 +28,7 @@ class UniqueNodeTypeHelperTest extends TestCase
     {
         $classMetadataFactory = $this->getMockBuilder(ClassMetadataFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getAllMetadata'))
+            ->setMethods(['getAllMetadata'])
             ->getMock();
         $classMetadataFactory->expects($this->once())
             ->method('getAllMetadata')
@@ -36,7 +36,7 @@ class UniqueNodeTypeHelperTest extends TestCase
 
         $documentManager = $this->getMockBuilder(DocumentManager::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getMetadataFactory'))
+            ->setMethods(['getMetadataFactory'])
             ->getMock();
         $documentManager->expects($this->once())
             ->method('getMetadataFactory')
@@ -62,11 +62,11 @@ class UniqueNodeTypeHelperTest extends TestCase
         $metadataC->setNodeType('nt:unstructured');
         $metadataC->setUniqueNodeType(true);
 
-        $documentManager = $this->configureDocumentManager(array(
+        $documentManager = $this->configureDocumentManager([
             $metadataA,
             $metadataB,
-            $metadataC
-        ));
+            $metadataC,
+        ]);
 
         $uniqueNodeTypeHelper = new UniqueNodeTypeHelper();
 
@@ -91,11 +91,11 @@ class UniqueNodeTypeHelperTest extends TestCase
         $metadataC = new ClassMetadata('Doctrine\PHPCR\Models\ClassC');
         $metadataA->setNodeType('nt:unstructured');
 
-        $documentManager = $this->configureDocumentManager(array(
+        $documentManager = $this->configureDocumentManager([
             $metadataA,
             $metadataB,
-            $metadataC
-        ));
+            $metadataC,
+        ]);
 
         $uniqueNodeTypeHelper = new UniqueNodeTypeHelper();
         $uniqueNodeTypeHelper->checkNodeTypeMappings($documentManager);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Tools/Test/QueryBuilderTesterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Tools/Test/QueryBuilderTesterTest.php
@@ -2,17 +2,17 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Tools\Test;
 
+use Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandStaticLiteral;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Tools\Test\QueryBuilderTester;
 use PHPUnit\Framework\TestCase;
-use Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField;
-use Doctrine\ODM\PHPCR\Query\Builder\OperandStaticLiteral;
 
 class QueryBuilderTesterTest extends TestCase
 {
     public function setUp()
     {
-        $this->qb = new QueryBuilder;
+        $this->qb = new QueryBuilder();
         $this->qb->where()->andX()
             ->eq()->field('a.foo')->literal('Foo')->end()
             ->eq()->field('a.foo')->literal('Bar');
@@ -23,7 +23,7 @@ class QueryBuilderTesterTest extends TestCase
     public function testDumpPaths()
     {
         $res = $this->qbTester->dumpPaths();
-        $this->assertEquals(<<<HERE
+        $this->assertEquals(<<<'HERE'
 where (Where)
 where.constraint (ConstraintAndx)
 where.constraint.constraint (ConstraintComparison)

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/AttributeTranslationStrategyTest.php
@@ -2,10 +2,10 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Translation;
 
-use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
-use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy;
+use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
 
@@ -29,13 +29,13 @@ class AttributeTranslationStrategyTest extends PHPCRTestCase
 
     public function testSetPrefixAndGetPropertyName()
     {
-        $name = $this->method->invokeArgs($this->strategy, array('fr', 'field'));
+        $name = $this->method->invokeArgs($this->strategy, ['fr', 'field']);
         $this->assertEquals('test:fr-field', $name);
     }
 
     public function testSubRegion()
     {
-        $name = $this->method->invokeArgs($this->strategy, array('en_GB', 'field'));
+        $name = $this->method->invokeArgs($this->strategy, ['en_GB', 'field']);
         $this->assertEquals('test:en_GB-field', $name);
     }
 
@@ -46,18 +46,18 @@ class AttributeTranslationStrategyTest extends PHPCRTestCase
         }
 
         $classMetadata = $this->prophesize(ClassMetadata::class);
-        $document = new \stdClass;
-        $localizedPropNames = array(
-            'test:de-prop1' => 'de',
-            'test:de_at-prop2' => 'de_at',
+        $document = new \stdClass();
+        $localizedPropNames = [
+            'test:de-prop1'                                 => 'de',
+            'test:de_at-prop2'                              => 'de_at',
             'test:en_Hans_CN_nedis_rozaj_x_prv1_prv2-prop3' => 'en_Hans_CN_nedis_rozaj_x_prv1_prv2',
-            'i18n:de-asdf' => false, // prefix is incorrect
-            'asdf' => false, // no prefix
-            'de_asdf' => false, // no property name
-        );
+            'i18n:de-asdf'                                  => false, // prefix is incorrect
+            'asdf'                                          => false, // no prefix
+            'de_asdf'                                       => false, // no property name
+        ];
 
         $node = $this->prophesize(NodeInterface::class);
-        $properties = array();
+        $properties = [];
 
         foreach (array_keys($localizedPropNames) as $localizedPropName) {
             $property = $this->prophesize(PropertyInterface::class);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Translation/LocaleChooserTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Translation/LocaleChooserTest.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Tests\ODM\PHPCR\Translation;
 
-use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Doctrine\ODM\PHPCR\Translation\MissingTranslationException;
 use Doctrine\Tests\ODM\PHPCR\PHPCRTestCase;
 
@@ -13,8 +13,8 @@ class LocaleChooserTest extends PHPCRTestCase
      * @var LocaleChooser
      */
     protected $localeChooser;
-    protected $orderEn = array('de');
-    protected $orderDe = array('en');
+    protected $orderEn = ['de'];
+    protected $orderDe = ['en'];
     /**
      * @var ClassMetadata|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -23,7 +23,7 @@ class LocaleChooserTest extends PHPCRTestCase
     public function setUp()
     {
         $this->mockMetadata = $this->createMock(ClassMetadata::class);
-        $this->localeChooser = new LocaleChooser(array('en' => $this->orderEn, 'de' => $this->orderDe), 'en');
+        $this->localeChooser = new LocaleChooser(['en' => $this->orderEn, 'de' => $this->orderDe], 'en');
     }
 
     public function testGetFallbackLocales()
@@ -39,14 +39,14 @@ class LocaleChooserTest extends PHPCRTestCase
 
     public function testSetFallbackLocalesMerge()
     {
-        $this->localeChooser->setFallbackLocales('de', array('fr'), false);
-        $this->assertEquals(array('fr', 'en'), $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'de'));
+        $this->localeChooser->setFallbackLocales('de', ['fr'], false);
+        $this->assertEquals(['fr', 'en'], $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'de'));
     }
 
     public function testSetFallbackLocalesReplace()
     {
-        $this->localeChooser->setFallbackLocales('de', array('fr'), true);
-        $this->assertEquals(array('fr'), $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'de'));
+        $this->localeChooser->setFallbackLocales('de', ['fr'], true);
+        $this->assertEquals(['fr'], $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'de'));
     }
 
     public function testGetFallbackLocalesNonexisting()
@@ -59,7 +59,7 @@ class LocaleChooserTest extends PHPCRTestCase
     {
         $this->localeChooser->setLocale('de'); // default should not use current locale but default locale
         $orderEn = $this->localeChooser->getDefaultLocalesOrder();
-        $this->assertEquals(array('en', 'de'), $orderEn);
+        $this->assertEquals(['en', 'de'], $orderEn);
     }
 
     public function testGetLocale()
@@ -92,8 +92,8 @@ class LocaleChooserTest extends PHPCRTestCase
 
     public function testSubRegion()
     {
-        $orderEnGB = array('en', 'de');
-        $this->localeChooser = new LocaleChooser(array('en_GB' => $orderEnGB, 'en' => $this->orderEn, 'de' => $this->orderDe), 'en');
+        $orderEnGB = ['en', 'de'];
+        $this->localeChooser = new LocaleChooser(['en_GB' => $orderEnGB, 'en' => $this->orderEn, 'de' => $this->orderDe], 'en');
 
         $order = $this->localeChooser->getFallbackLocales(null, $this->mockMetadata, 'en_GB');
         $this->assertEquals($orderEnGB, $order);

--- a/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/UnitOfWorkTest.php
@@ -3,21 +3,21 @@
 namespace Doctrine\Tests\ODM\PHPCR;
 
 use Doctrine\ODM\PHPCR\Configuration;
-use Doctrine\ODM\PHPCR\UnitOfWork;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\UnitOfWork;
 use Jackalope\Factory;
 use Jackalope\Node;
-use Jackalope\Session;
-use Jackalope\ObjectManager;
-use Jackalope\Repository;
 use Jackalope\NodeType\NodeType;
 use Jackalope\NodeType\NodeTypeManager;
+use Jackalope\ObjectManager;
+use Jackalope\Repository;
+use Jackalope\Session;
 use Jackalope\Workspace;
 use PHPCR\SessionInterface;
 
 /**
- * TODO: remove Jackalope dependency
+ * TODO: remove Jackalope dependency.
  *
  * @group unit
  */
@@ -59,7 +59,7 @@ class UnitOfWorkTest extends PHPCRTestCase
             $this->markTestSkipped('The Node needs to be properly mocked/stubbed. Remove dependency to Jackalope');
         }
 
-        $this->factory = new Factory;
+        $this->factory = new Factory();
         $this->session = $this->createMock(Session::class);
 
         $this->objectManager = $this->createMock(ObjectManager::class);
@@ -71,9 +71,9 @@ class UnitOfWorkTest extends PHPCRTestCase
         $cmf = $this->dm->getMetadataFactory();
         $metadata = new ClassMetadata($this->type);
         $metadata->initializeReflection($cmf->getReflectionService());
-        $metadata->mapId(array('fieldName' => 'id', 'id' => true));
+        $metadata->mapId(['fieldName' => 'id', 'id' => true]);
         $metadata->idGenerator = ClassMetadata::GENERATOR_TYPE_ASSIGNED;
-        $metadata->mapField(array('fieldName' => 'username', 'type' => 'string'));
+        $metadata->mapField(['fieldName' => 'username', 'type' => 'string']);
         $cmf->setMetadataFor($this->type, $metadata);
     }
 
@@ -113,11 +113,11 @@ class UnitOfWorkTest extends PHPCRTestCase
             ->with($id)
             ->will($this->returnValue(true));
 
-        $nodeData = array(
-            "jcr:primaryType" => $primaryType,
-            "jcr:system" => array(),
-            'username' => $username,
-        );
+        $nodeData = [
+            'jcr:primaryType' => $primaryType,
+            'jcr:system'      => [],
+            'username'        => $username,
+        ];
         $node = new Node($this->factory, $nodeData, $id, $this->session, $this->objectManager);
 
         $this->session->expects($this->any())
@@ -167,7 +167,7 @@ class UnitOfWorkTest extends PHPCRTestCase
     public function testScheduleInsertion()
     {
         $object = new UoWUser();
-        $object->username = "bar";
+        $object->username = 'bar';
         $object->id = '/somepath';
 
         $this->uow->scheduleInsert($object);
@@ -181,7 +181,7 @@ class UnitOfWorkTest extends PHPCRTestCase
     public function testScheduleInsertCancelsScheduleRemove()
     {
         $object = new UoWUser();
-        $object->username = "bar";
+        $object->username = 'bar';
         $object->id = '/somepath';
 
         $this->uow->scheduleInsert($object);
@@ -242,7 +242,7 @@ class UnitOfWorkTest extends PHPCRTestCase
     public function testComputeSingleDocumentChangeSetForRemovedDocument()
     {
         $object = new UoWUser();
-        $object->username = "bar";
+        $object->username = 'bar';
         $object->id = '/somepath';
 
         $this->uow->scheduleRemove($object);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,17 +7,17 @@ if (file_exists($file)) {
     throw new RuntimeException('Install dependencies to run test suite.');
 }
 
-$files = array_filter(array(
+$files = array_filter([
     __DIR__.'/../vendor/symfony/symfony/src/Symfony/Bridge/PhpUnit/bootstrap.php',
     __DIR__.'/../vendor/symfony/phpunit-bridge/bootstrap.php',
-), 'file_exists');
+], 'file_exists');
 if ($files) {
     require_once current($files);
 }
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-AnnotationRegistry::registerLoader(array($autoload, 'loadClass'));
+AnnotationRegistry::registerLoader([$autoload, 'loadClass']);
 
 // tests are not autoloaded the composer.json
 $autoload->add('Doctrine\Tests', __DIR__);


### PR DESCRIPTION
we are now on php 7 and removed incompatible classes.

do we want to stay on the psr2 preset, or should we use the symfony preset or something else? (doctrine orm does not use styleci at all but phpcs directly)