### PR TITLE
Combine consecutive unsets

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,3 +2,4 @@ preset: recommended
 
 enabled:
     - combine_consecutive_issets
+    - combine_consecutive_unsets

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -995,8 +995,7 @@ class UnitOfWork
                 unset($this->scheduledInserts[$oid]);
                 break;
             case self::STATE_MANAGED:
-                unset($this->scheduledMoves[$oid]);
-                unset($this->scheduledReorders[$oid]);
+                unset($this->scheduledMoves[$oid], $this->scheduledReorders[$oid]);
                 break;
             case self::STATE_DETACHED:
                 throw new InvalidArgumentException('Detached document passed to remove(): '.self::objToStr($document, $this->dm));
@@ -1448,8 +1447,7 @@ class UnitOfWork
 
                     $this->scheduledUpdates[$oid] = $document;
                 } elseif (empty($this->documentChangesets[$oid]['fields'])) {
-                    unset($this->documentChangesets[$oid]);
-                    unset($this->scheduledUpdates[$oid]);
+                    unset($this->documentChangesets[$oid], $this->scheduledUpdates[$oid]);
                 } else {
                     $this->documentChangesets[$oid]['reorderings'] = [];
                 }
@@ -1654,8 +1652,7 @@ class UnitOfWork
             $this->originalData[$oid] = $actualData;
             $this->scheduledUpdates[$oid] = $document;
         } elseif (empty($this->documentChangesets[$oid]['reorderings'])) {
-            unset($this->documentChangesets[$oid]);
-            unset($this->scheduledUpdates[$oid]);
+            unset($this->documentChangesets[$oid], $this->scheduledUpdates[$oid]);
         } else {
             $this->documentChangesets[$oid]['fields'] = [];
         }
@@ -3031,8 +3028,7 @@ class UnitOfWork
 
         $history->removeVersion($version->getName());
 
-        unset($this->documentVersion[$oid]);
-        unset($this->documentHistory[$oid]);
+        unset($this->documentVersion[$oid], $this->documentHistory[$oid]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -530,8 +530,8 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->assertNotNull($user);
         $this->assertEquals($user->parameters, $assocArray);
 
-        unset($user->parameters['foo']);
-        unset($assocArray['foo']);
+        unset($user->parameters['foo'], $assocArray['foo']);
+
         $user->parameters['boo'] = 'yah';
         $assocArray['boo'] = 'yah';
         $user->parameters['hello'] = 'welt';

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -511,8 +511,8 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
-        unset($refManyTestObj->references[0]);
-        unset($refManyTestObj->references[1]);
+        unset($refManyTestObj->references[0], $refManyTestObj->references[1]);
+
         $this->assertEquals(0, count($refManyTestObj->references));
         $this->dm->flush();
         $this->dm->clear();


### PR DESCRIPTION
`unset` allow us to pass multiple values to check.

[PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped me on that.

Also enabled in [`StyleCI`](https://styleci.readme.io/docs/fixers#section-combine_consecutive_iunsets).