### PR TITLE
Add link to doctrine 2 architecture in the documentation

### DIFF
--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -2,7 +2,7 @@ Architecture
 ============
 
 The architecture of the PHPCR-ODM is similar to that of Doctrine 2 ORM. Please read
-the ORM architecture chapter (TODO: link) to get a basic understanding of the Doctrine
+the `ORM architecture chapter <https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/architecture.html>`_ to get a basic understanding of the Doctrine
 architecture. We will focus on some notable differences here.
 
 Doctrine PHPCR-ODM Packages


### PR DESCRIPTION
Points to latest version of the docs. Better that than a specific version that'll be outdated in the future.
The user will be shown the version number and will be warned anyway if the version is not yet released or too old.