### PR TITLE
fix translations missing when using the query builder with joins on referrer fields

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -320,6 +320,10 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function findMany($className, array $ids)
     {
+        // when loading duplicate ID's the resulting response would be a collection of unique ids,
+        // but having duplicates would also cause a lot of overhead as well as break translation loading,
+        // so pre filter unique, see https://github.com/doctrine/phpcr-odm/pull/795
+        $ids = array_unique($ids);
         $uuids = array();
         foreach ($ids as $key => $id) {
             if (UUIDHelper::isUUID($id)) {


### PR DESCRIPTION
I'm not entirely sure why it's the document manager findMany is failing here, but the following scenario fails:

I have a `project.category` and a `category.projects`, where `category.projects` is a referrer to a project document referenced by its `category` field and category and project both have translatable fields.
when u then write the following query:

```php
$queryBuilder->fromDocument(ProjectCategory::class, 'pc');
$join = $queryBuilder->addJoinInner();
$join->right()->document(Project::class, 'p');
$join->condition()->equi('p.category', 'pc.projects');
```

It will return all categories, but without translations mapped to it