### PR TITLE
fix translations not loading with duplicate ids

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/DocumentManager.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManager.php
@@ -304,6 +304,10 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function findMany($className, array $ids)
     {
+        // when loading duplicate ID's the resulting response would be a collection of unique ids,
+        // but having duplicates would also cause a lot of overhead as well as break translation loading,
+        // so pre filter unique, see https://github.com/doctrine/phpcr-odm/pull/795
+        $ids = array_unique($ids);
         $uuids = [];
         foreach ($ids as $key => $id) {
             if (UUIDHelper::isUUID($id)) {

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
@@ -875,4 +875,26 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
 
         $this->assertEquals('Guten tag', $trans->topic);
     }
+
+    public function testMangerIsNotDroppingTranslationWhenDuplicateIdsArePassedToFindMany()
+    {
+        $articles = ['someText', 'moreText', 'someMoreText'];
+        foreach ($articles as $article) {
+            $a = new Article();
+            $ids[] = $a->id = '/functional/'.$this->testNodeName.$article;
+            $a->topic = $article;
+            $a->text = $article;
+            $this->dm->persist($a);
+        }
+        $this->dm->flush();
+        $this->dm->clear();
+        $duplicateIdsList = \array_merge($ids, $ids);
+        $documents = $this->dm->findMany($this->class, $duplicateIdsList);
+        $this->assertEquals(count($articles), count($documents));
+        foreach ($documents as $document) {
+            $this->assertSame('en', $document->locale);
+            $this->assertNotNull($document->text);
+            $this->assertNotNull('Some category', $document->topic);
+        }
+    }
 }


### PR DESCRIPTION
it would load all none duplicates correctly and all
duplicates would load correct first time arround but
the second time the document was loaded translations
would be skipped and the new document would override
the previous document in the document collection
resulting in missing translations