### PR TITLE
fix children getting removed on move when pre update listener is present

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -54,6 +54,7 @@ use PHPCR\UnsupportedRepositoryOperationException;
 use PHPCR\Util\NodeHelper;
 use PHPCR\Util\PathHelper;
 use PHPCR\Util\UUIDHelper;
+use function spl_object_hash;
 
 /**
  * Unit of work class
@@ -1437,8 +1438,13 @@ class UnitOfWork
                 // check moved children to not accidentally remove a child that simply moved away.
                 if (!(in_array($childName, $childNames) || in_array($childName, $movedChildNames))) {
                     $child = $this->getDocumentById($id.'/'.$childName);
-                    $this->scheduleRemove($child);
-                    unset($originalNames[$key]);
+                    // make sure that when the child move is already processed and another compute is triggered
+                    // we don't remove that child
+                    $childOid = spl_object_hash($child);
+                    if (true || !isset($this->scheduledMoves[$childOid])) {
+                        $this->scheduleRemove($child);
+                        unset($originalNames[$key]);
+                    }
                 }
             }
 

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -1441,7 +1441,7 @@ class UnitOfWork
                     // make sure that when the child move is already processed and another compute is triggered
                     // we don't remove that child
                     $childOid = spl_object_hash($child);
-                    if (true || !isset($this->scheduledMoves[$childOid])) {
+                    if (!isset($this->scheduledMoves[$childOid])) {
                         $this->scheduleRemove($child);
                         unset($originalNames[$key]);
                     }

--- a/tests/Doctrine/Tests/Models/References/ParentWithChildrenTestObj.php
+++ b/tests/Doctrine/Tests/Models/References/ParentWithChildrenTestObj.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Doctrine\Tests\Models\References;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * @PHPCRODM\Document(referenceable=true)
+ */
+class ParentWithChildrenTestObj
+{
+    /** @PHPCRODM\Id(strategy="parent") */
+    public $id;
+    /** @PHPCRODM\ParentDocument */
+    public $parent;
+    /** @PHPCRODM\Nodename */
+    public $nodename;
+    /** @PHPCRODM\Field(type="string") */
+    public $name;
+    /** @PHPCRODM\Children() */
+    public $children;
+
+    public function getParentDocument()
+    {
+        return $this->parent;
+    }
+
+    public function setParentDocument($parent)
+    {
+        $this->parent = $parent;
+    }
+}

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
@@ -16,7 +16,7 @@ use Doctrine\Tests\Models\CMS\CmsBlogInvalidChild;
 use Doctrine\Tests\Models\CMS\CmsBlogPost;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\References\ParentNoNodenameTestObj;
+use Doctrine\Tests\Models\References\ParentNoNodeNameTestObj;
 use Doctrine\Tests\Models\References\ParentTestObj;
 use Doctrine\Tests\Models\References\ParentWithChildrenTestObj;
 use Doctrine\Tests\Models\Translation\Comment;

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
@@ -132,25 +132,25 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
         // preparing
         $functional = $this->dm->find(null, 'functional');
         $root = new ParentWithChildrenTestObj();
-        $root->nodename = "root";
-        $root->name = "root";
+        $root->nodename = 'root';
+        $root->name = 'root';
         $root->setParentDocument($functional);
         $this->dm->persist($root);
 
         $parent = new ParentWithChildrenTestObj();
-        $parent->nodename = "parent";
-        $parent->name = "parent";
+        $parent->nodename = 'parent';
+        $parent->name = 'parent';
         $parent->setParentDocument($root);
         $this->dm->persist($parent);
 
         $child = new ParentTestObj();
         $child->setParentDocument($parent);
-        $child->nodename = $child->name = "child";
+        $child->nodename = $child->name = 'child';
         $this->dm->persist($child);
 
         $child2 = new ParentTestObj();
         $child2->setParentDocument($parent);
-        $child2->nodename = $child2->name = "child2";
+        $child2->nodename = $child2->name = 'child2';
         $this->dm->persist($child2);
 
         $this->dm->flush();
@@ -161,11 +161,12 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
         $child2 = $this->dm->find(null, '/functional/root/parent/child2');
 
         // testing
-        $this->dm->getEventManager()->addEventSubscriber(new class implements EventSubscriber {
+        $this->dm->getEventManager()->addEventSubscriber(new class() implements EventSubscriber {
             public function getSubscribedEvents()
             {
                 return [Event::preUpdate];
             }
+
             public function preUpdate()
             {
             }
@@ -177,7 +178,6 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
 
         $movedChild = $this->dm->find(null, '/functional/root/parent/moved-child2');
         $this->assertInstanceOf(ParentTestObj::class, $movedChild);
-
     }
 
     public function testGetScheduledReorders()

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
@@ -3,7 +3,9 @@
 namespace Doctrine\Tests\ODM\PHPCR\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Event;
 use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
 use Doctrine\ODM\PHPCR\UnitOfWork;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -14,8 +16,9 @@ use Doctrine\Tests\Models\CMS\CmsBlogInvalidChild;
 use Doctrine\Tests\Models\CMS\CmsBlogPost;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\References\ParentNoNodeNameTestObj;
+use Doctrine\Tests\Models\References\ParentNoNodenameTestObj;
 use Doctrine\Tests\Models\References\ParentTestObj;
+use Doctrine\Tests\Models\References\ParentWithChildrenTestObj;
 use Doctrine\Tests\Models\Translation\Comment;
 use Doctrine\Tests\ODM\PHPCR\PHPCRFunctionalTestCase;
 
@@ -122,6 +125,59 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
         } catch (\Exception $e) {
             $this->fail('An exception has been raised moving a child node from parent1 to parent2.');
         }
+    }
+
+    public function testMoveChildThroughNodeNameChangeWithPreUpdateListener()
+    {
+        // preparing
+        $functional = $this->dm->find(null, 'functional');
+        $root = new ParentWithChildrenTestObj();
+        $root->nodename = "root";
+        $root->name = "root";
+        $root->setParentDocument($functional);
+        $this->dm->persist($root);
+
+        $parent = new ParentWithChildrenTestObj();
+        $parent->nodename = "parent";
+        $parent->name = "parent";
+        $parent->setParentDocument($root);
+        $this->dm->persist($parent);
+
+        $child = new ParentTestObj();
+        $child->setParentDocument($parent);
+        $child->nodename = $child->name = "child";
+        $this->dm->persist($child);
+
+        $child2 = new ParentTestObj();
+        $child2->setParentDocument($parent);
+        $child2->nodename = $child2->name = "child2";
+        $this->dm->persist($child2);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $parent = $this->dm->find(null, '/functional/root/parent');
+        $parent->children->toArray(); // force container init
+        $child2 = $this->dm->find(null, '/functional/root/parent/child2');
+
+        // testing
+        $this->dm->getEventManager()->addEventSubscriber(new class implements EventSubscriber {
+            public function getSubscribedEvents()
+            {
+                return [Event::preUpdate];
+            }
+            public function preUpdate()
+            {
+            }
+        });
+        $child2->nodename = 'moved-child2';
+        $this->dm->persist($child2);
+
+        $this->dm->flush();
+
+        $movedChild = $this->dm->find(null, '/functional/root/parent/moved-child2');
+        $this->assertInstanceOf(ParentTestObj::class, $movedChild);
+
     }
 
     public function testGetScheduledReorders()


### PR DESCRIPTION
Hi @dbu ,

I discovered a critical bug that has plagued our application and it took me a while to figure out what was happening, the hardest part was trying to reproduce it in a test because I could see it going wrong, just didn't know why in out app and not in my test case. It needed multiple conditions to be true before it happened:

- fetch a parent node and iterate through its children
- update one of these children their nodename
- have a preUpdate listener present (as uow only triggers another changeset in this case)

in this case in runts through changeset 2se the first time everything goes as expected, and then updates the parents collection with the new child name and marks it moved (a move is also scheduled), but then the second time (after preUpdate) changeset is requested and the change was already applied and this it assumed the child has to be removed