### PR TITLE
Make cache salt compatible with PSR-16

### DIFF
--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadataFactory.php
@@ -29,7 +29,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * {@inheritdoc}
      */
-    protected $cacheSalt = '\$PHPCRODMCLASSMETADATA';
+    protected $cacheSalt = '__PHPCRODMCLASSMETADATA';
 
     /**
      * @var DocumentManagerInterface


### PR DESCRIPTION
The backslash is incompatible with PSR-16 cache adapters and after moving from doctrine/cache to symfony/cache this triggers an error.