### PR TITLE
chore(composer): Allow PHPUnit 9 and Doctrine Instantiator 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,17 @@
         "phpcr/phpcr": "^2.1.1",
         "phpcr/phpcr-implementation": "^2.1",
         "phpcr/phpcr-utils": "^1.3.0",
-        "doctrine/instantiator": "^1.0.1",
+        "doctrine/instantiator": "^1.0.1 || ^2.0",
         "symfony/console": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "psr/cache": "^1.0 || ^2.0 || ^3.0"
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
+        "jackalope/jackalope-jackrabbit": "^1.4"
     },
     "require-dev": {
         "symfony/cache": "^5.4 || ^6.0.19",
         "symfony/yaml": "^5.4 || ^6.0.19",
         "symfony/phpunit-bridge": "^5.4.21 || ^6.0.19",
         "liip/rmt": "^1.3",
-        "phpunit/phpunit": "^7.5 || ^8.0"
+        "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0"
     },
     "suggest": {
         "symfony/yaml": "^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
         "phpcr/phpcr-utils": "^1.3.0",
         "doctrine/instantiator": "^1.0.1 || ^2.0",
         "symfony/console": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "jackalope/jackalope-jackrabbit": "^1.4"
+        "psr/cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "symfony/cache": "^5.4 || ^6.0.19",


### PR DESCRIPTION
Hello! 

[schmittjoh/serializer](https://github.com/schmittjoh/serializer) are requiring as a dev dependency this package. To run all tests with `doctrine/instantiator` in version 2, we need to also allow this dependency here. It looks like there is no backward incompatibilities between them - test passed on my local env with jackrabbit.
I also needed to bump PHPUnit to 9.x - in that version it produces some deprecation notices but it looks like the replacement method will be added in PHP 10.1. As example:
```
assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectHasProperty() (PHPUnit 10.1.0+) instead.
``` 

Best, scyzoryck. 