### PR TITLE
split find into find with required class name and findDocument for finding any document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog
 * Removed deprecated methods HierarchyInterface::getParent/setParent.
   Use getParentDocument/setParentDocument instead.
 
+* ``DocumentManager::find`` requires to specify the class name. To find any
+  document without restricting the class name, use the new 
+  ``DocumentManager::findDocument`` method.
+
 * DocumentManager::flush no longer saves the PHPCR session if there are no changes
   on the ODM layer.
 

--- a/docs/en/reference/association-mapping.rst
+++ b/docs/en/reference/association-mapping.rst
@@ -572,7 +572,7 @@ empty ``ArrayCollection`` in your documents constructor::
 Now the following code will be working even if the Document hasn't
 been associated with a DocumentManager yet::
 
-    $group = $documentManager->find(null, $groupId);
+    $group = $documentManager->findDocument($groupId);
     $user = new User();
     $user->getGroups()->add($group);
 

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -421,7 +421,7 @@ the assigned id if either is missing.
 To create a new document, you do something like this::
 
     $doc = new Document();
-    $doc->setParent($dm->find(null, '/test'));
+    $doc->setParent($dm->findDocument('/test'));
     $doc->setNodename('mynode');
     // document is persisted with id /test/mynode
 

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -258,7 +258,7 @@ We write a simple PHP script to generate some sample data::
     require_once '../bootstrap.php';
 
     // get the root node to add our data to it
-    $rootDocument = $documentManager->find(null, '/');
+    $rootDocument = $documentManager->findDocument('/');
 
     // create a new document
     $doc = new \Demo\Document();
@@ -297,14 +297,14 @@ This script will simply echo the data to the console::
 
     require_once '../bootstrap.php';
 
-    $doc = $documentManager->find(null, '/doc');
+    $doc = $documentManager->findDocument('/doc');
 
     echo 'Found '.$doc->getId() ."\n";
     echo 'Title: '.$doc->getTitle()."\n";
     echo 'Content: '.$doc->getContent()."\n";
 
 The DocumentManager will automatically determine the document class when
-you pass ``null`` as first argument to ``find()``.
+you call ``findDocument()`` instead of ``find()``.
 
 Tree traversal
 --------------
@@ -319,7 +319,7 @@ we can traverse them::
 
     use Demo\MyDocument;
 
-    $doc = $documentManager->find(null, '/doc');
+    $doc = $documentManager->findDocument('/doc');
 
     foreach($doc->getChildren() as $child) {
         if ($child instanceof MyDocument) {
@@ -394,7 +394,7 @@ Lets look at an example of document ``A`` referencing ``B``::
 
 We can now create a reference with the following code::
 
-    $parent = $dm->find(null, '/');
+    $parent = $dm->findDocument('/');
     $a = new A();
     $a->setParent($parent);
     $a->setNodename('a');
@@ -408,7 +408,7 @@ We can now create a reference with the following code::
     $dm->flush();
     $dm->clear();
 
-    $b = $dm->find(null, '/b');
+    $b = $dm->findDocument('/b');
 
     // output Demo\A
     var_dump(get_class($b->getReferrers()));
@@ -429,7 +429,7 @@ To delete a document, call the ``remove`` method on the ``DocumentManager``::
     require_once '../bootstrap.php';
 
     // remove a document
-    $doc = $documentManager->find(null, '/doc');
+    $doc = $documentManager->findDocument('/doc');
     $documentManager->remove($doc);
 
     // persist all operations
@@ -448,7 +448,7 @@ by assignment. The latter is for example handy with Symfony forms::
     require_once '../bootstrap.php';
 
     // we move a node
-    $child = $documentManager->find(null, '/doc/child');
+    $child = $documentManager->findDocument('/doc/child');
     $documentManager->move($child, '/newpath');
 
     // persist all operations

--- a/docs/en/reference/multilang.rst
+++ b/docs/en/reference/multilang.rst
@@ -124,7 +124,7 @@ have a translator strategy and a Locale field.
 Interacting with translations
 -----------------------------
 
-When reading, ``DocumentManager::find()`` uses the default locale (see below how to set that). This means
+When reading, the ``DocumentManager::find*`` methods use the default locale (see below how to set that). This means
 your reading code does not need to be aware of content translations happening.
 
 If you need to access a document with an explicit locale that might be different from the default locale,
@@ -271,7 +271,7 @@ Full Example
 
     // Get the document in default language
     // (English if you bootstrapped as in the example)
-    $doc = $dm->find(null, '/my_test_node');
+    $doc = $dm->findDocument('/my_test_node');
 
     // Get the document in French
     $doc = $dm->findTranslation(null, '/my_test_node', 'fr');

--- a/docs/en/reference/versioning.rst
+++ b/docs/en/reference/versioning.rst
@@ -144,7 +144,7 @@ See the Phpdoc for full details on those methods.
 
 **Reading**:
 
-- ``DocumentManager::find()`` works as normal, always gives you the current latest version.
+- ``DocumentManager::find*`` methods work as normal, always giving you the current latest version.
 - ``DocumentManager::getAllLinearVersions($document)``  returns an array with all version names for this document,
   ordered from most recent to oldest version. You can specify an optional limit to only get that many most recent versions.
 - ``DocumentManager::findVersionByName($id, $versionName)`` get a detached read-only document for a specific version.
@@ -184,7 +184,7 @@ Full Example
     echo $oldVersion->topic; // "Test"
 
     // find the head version
-    $article = $dm->find('/test');
+    $article = $dm->findDocument('/test');
     echo $article->topic; // "Newvalue"
 
     // restore the head to the old version

--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -37,20 +37,22 @@ Every document has an identifier, which is its PHPCR path. The path is unique
 inside the workspace. Take the following example, where you find an article
 with the headline "Hello World" with the ID ``/cms/article/hello-world``::
 
-    $article = $documentManager->find(null, '/cms/article/hello-world');
+    $article = $documentManager->findDocument('/cms/article/hello-world');
     $article->setHeadline('Hello World dude!');
 
-    $article2 = $documentManager->find(null, '/cms/article/hello-world');
+    $article2 = $documentManager->findDocument('/cms/article/hello-world');
     echo $article2->getHeadline(); // Hello World dude!
 
 .. note::
 
-    The first argument to ``find()`` is the document class name. While the ORM
-    has a table per class and thus always needs the document class name,
-    PHPCR-ODM has one tree for all documents. The above call will find you
-    whatever document is at that path. Note that you may optionally specify
-    the class name to have PHPCR-ODM detect if the document is not of the
-    expected type.
+    The first argument to ``find()`` is the document class name. Since PHPCR-ODM
+    2.0, the class name is required. But while the ORM has a table per class and
+    thus always needs the document class name, PHPCR-ODM uses one tree for all
+    documents. ``findDocument()`` finds you whatever document is at the specified
+    path. If you want to only get the document if it is of your expected type,
+    e.g. for type safety, use the ``find()`` method with its class name argument.
+    When using ``find``, PHPCR-ODM will return null if the path exists but the
+    document is not of the requested class.
 
 In this case, the article is retrieved from the document manager twice,
 but modified in between. Doctrine 2 realizes that it is the same ID and will
@@ -131,7 +133,7 @@ from newly opened DocumentManager::
         }
     }
 
-    $article = $em->find(null, '/cms/article/hello-world');
+    $article = $em->findDocument('/cms/article/hello-world');
 
 This code retrieves an ``Article`` instance with ID
 ``/cms/article/hello-world``, executing a single ``getNode()`` operation
@@ -154,7 +156,7 @@ access these proxies for the first time they will go through the
 This lazy-loading process happens behind the scenes, hidden from
 your code. Have a look at the following example::
 
-    $article = $em->find(null, '/cms/article/hello-world');
+    $article = $em->findDocument('/cms/article/hello-world');
 
     // accessing a method of the user instance triggers the lazy-load
     echo "Author: " . $article->getAuthor()->getName() . "\n";
@@ -612,23 +614,26 @@ By Primary Key
 
 The most basic way to query for a persisted document is by its
 identifier (PHPCR path) using the
-``DocumentManager::find(null, $id)`` method. Here is an
+``DocumentManager::find($className, $id)`` method. Here is an
 example::
 
     /** @var $em DocumentManager */
     $user = $em->find(User::class, $id);
 
 The return value is either the found document instance or null if no
-instance could be found with the given identifier.
+instance of the specified class can be found with the given identifier.
+
+If you do not want to specify the class, you can use the ``findDocument($id)``
+method instead.
 
 If you need several documents and know their paths, you can have a considerable
 performance gain by using ``DocumentManager::findMany(null, $ids)`` as then
 all those documents are loaded from the repository in one request.
 
 You can also specify the class name instead of null to filter to only find
-instances of that class. If you go through the repository for a document class
-this is equivalent to calling find on the ``DocumentManager`` with that document
-class.
+instances of that class. If you call ``find`` on the repository of a document
+class, this is equivalent to calling ``find`` on the ``DocumentManager`` with
+that document class.
 
 
 By Simple Conditions

--- a/lib/Doctrine/ODM/PHPCR/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/PHPCR/Decorator/DocumentManagerDecorator.php
@@ -88,6 +88,11 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
         return $this->wrapped->isOpen();
     }
 
+    public function findDocument(string $id): ?object
+    {
+        return $this->wrapped->findDocument($id);
+    }
+
     public function findMany(?string $className, array $ids): Collection
     {
         return $this->wrapped->findMany($className, $ids);

--- a/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
@@ -110,6 +110,18 @@ interface DocumentManagerInterface extends ObjectManager
     public function isOpen(): bool;
 
     /**
+     * Finds an object by its identifier.
+     *
+     * This is an alternative to ``find`` that does not require you to specify the class name.
+     * If the PHPCR node at $id does not have the PHPCR-ODM metadata, this method returns null.
+     *
+     * Apart from the class name, it has the same semantics as `find`.
+     *
+     * @param string $id the identity of the object to find
+     */
+    public function findDocument(string $id): ?object;
+
+    /**
      * Finds many documents by id.
      *
      * @param string|null $className Only return documents that match the

--- a/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
+++ b/lib/Doctrine/ODM/PHPCR/UnitOfWork.php
@@ -2822,7 +2822,7 @@ class UnitOfWork
         $oid = \spl_object_hash($documentVersion);
         $history = $this->documentHistory[$oid];
         $version = $this->documentVersion[$oid];
-        $document = $this->dm->find(null, $history->getVersionableIdentifier());
+        $document = $this->dm->findDocument($history->getVersionableIdentifier());
         $vm = $this->session->getWorkspace()->getVersionManager();
 
         $vm->restore($removeExisting, $version);

--- a/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/DocumentManagerTest.php
@@ -34,7 +34,7 @@ class DocumentManagerTest extends PHPCRTestCase
 
         $dm = DocumentManager::create($session, $config);
 
-        $nonExistent = $dm->find(null, $fakeUuid);
+        $nonExistent = $dm->findDocument($fakeUuid);
 
         $this->assertNull($nonExistent);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/BasicCrudTest.php
@@ -89,14 +89,14 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $user->setProperty('phpcr:class', $this->type, PropertyType::STRING);
         $this->dm->getPhpcrSession()->save();
 
-        $userWithAlias = $this->dm->find(null, '/functional/userWithAlias');
+        $userWithAlias = $this->dm->findDocument('/functional/userWithAlias');
 
         $this->assertEquals('dbu', $userWithAlias->username);
     }
 
     public function testFindById(): void
     {
-        $user = $this->dm->find(null, '/functional/bogus');
+        $user = $this->dm->findDocument('/functional/bogus');
         $this->assertNull($user);
 
         $newUser = new User();
@@ -107,7 +107,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $foundUser = $this->dm->find(null, '/functional/test');
+        $foundUser = $this->dm->findDocument('/functional/test');
         $this->assertNotNull($foundUser);
         $this->assertEquals($newUser->username, $foundUser->username);
     }
@@ -116,7 +116,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
     {
         $generator = $this->dm->getConfiguration()->getUuidGenerator();
 
-        $user = $this->dm->find(null, $generator());
+        $user = $this->dm->findDocument($generator());
         $this->assertNull($user);
 
         $newUser = new UserWithUuid();
@@ -127,7 +127,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $foundUser = $this->dm->find(null, $newUser->uuid);
+        $foundUser = $this->dm->findDocument($newUser->uuid);
         $this->assertNotNull($foundUser);
         $this->assertEquals('test', $foundUser->username);
         $this->assertEquals('/functional/test', $foundUser->id);
@@ -162,7 +162,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $flushedUser = $this->dm->find(null, '/functional/test');
+        $flushedUser = $this->dm->findDocument('/functional/test');
 
         $this->assertEquals($uuidPostPersist, $flushedUser->uuid);
     }
@@ -185,7 +185,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $flushedUser = $this->dm->find(null, '/functional/test');
+        $flushedUser = $this->dm->findDocument('/functional/test');
 
         $this->assertEquals($testUuid, $flushedUser->uuid);
     }
@@ -459,7 +459,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
 
     public function testNoIdProperty(): void
     {
-        $functional = $this->dm->find(null, '/functional');
+        $functional = $this->dm->findDocument('/functional');
 
         $user = new User5();
         $user->username = 'test';
@@ -485,7 +485,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
 
     public function testAutoId(): void
     {
-        $functional = $this->dm->find(null, '/functional');
+        $functional = $this->dm->findDocument('/functional');
 
         $user = new User6();
         $user->username = 'test';
@@ -512,7 +512,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->find(null, '/functional/test');
+        $user = $this->dm->findDocument('/functional/test');
 
         $this->assertNotNull($user);
         $this->assertEquals($user->parameters, $assocArray);
@@ -523,7 +523,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->find(null, '/functional/test');
+        $user = $this->dm->findDocument('/functional/test');
 
         $this->assertNotNull($user);
         $this->assertEquals($user->parameters, $assocArray);
@@ -538,7 +538,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->find(null, '/functional/test');
+        $user = $this->dm->findDocument('/functional/test');
 
         $this->assertNotNull($user);
         $this->assertEquals($user->parameters, $assocArray);
@@ -556,7 +556,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->find(null, '/functional/test');
+        $user = $this->dm->findDocument('/functional/test');
 
         $this->assertNotNull($user);
         $this->assertEquals($user->assocNumbers, $assocArray);
@@ -573,7 +573,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $userNew = $this->dm->find(null, '/functional/test');
+        $userNew = $this->dm->findDocument('/functional/test');
         $this->assertNotNull($userNew, 'Have to hydrate user object!');
         $this->assertEquals($user->username, $userNew->username);
         $this->assertEquals($user->numbers, $userNew->numbers);
@@ -587,7 +587,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $object = $this->dm->find(null, '/functional/test');
+        $object = $this->dm->findDocument('/functional/test');
         $this->assertEquals(2, $object->depth);
 
         NodeHelper::createPath($this->dm->getPhpcrSession(), '/functional/newtest/foobar');
@@ -602,7 +602,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
      */
     public function testIllegalNodename(): void
     {
-        $functional = $this->dm->find(null, '/functional');
+        $functional = $this->dm->findDocument('/functional');
 
         $user = new User5();
         $user->username = 'test';
@@ -620,7 +620,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
      */
     public function testIllegalNodenameMove(): void
     {
-        $functional = $this->dm->find(null, '/functional');
+        $functional = $this->dm->findDocument('/functional');
 
         $user = new User5();
         $user->username = 'test';
@@ -642,7 +642,7 @@ class BasicCrudTest extends PHPCRFunctionalTestCase
         $user->getProperty('username')->remove();
         $this->dm->getPhpcrSession()->save();
 
-        $userDoc = $this->dm->find(null, $user->getPath());
+        $userDoc = $this->dm->findDocument($user->getPath());
 
         $this->assertInstanceOf($this->type, $userDoc);
         $this->assertNull($userDoc->username);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChangesetCalculationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ChangesetCalculationTest.php
@@ -59,8 +59,8 @@ class ChangesetCalculationTest extends PHPCRFunctionalTestCase
         $this->assertEquals(0, $this->listener->count);
         $this->dm->clear();
 
-        $user1 = $this->dm->find(null, $user1->id);
-        $this->dm->find(null, $user2->id);
+        $user1 = $this->dm->findDocument($user1->id);
+        $this->dm->findDocument($user2->id);
 
         $user1->status = 'changed';
         $this->dm->flush();
@@ -97,8 +97,8 @@ class ChangesetCalculationTest extends PHPCRFunctionalTestCase
         $this->assertEquals(0, $this->listener->count);
         $this->dm->clear();
 
-        $user1 = $this->dm->find(null, $user1->id);
-        $this->dm->find(null, $user2->id);
+        $user1 = $this->dm->findDocument($user1->id);
+        $this->dm->findDocument($user2->id);
 
         $user1->status = 'changed';
         $this->dm->flush();

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/DetachTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/DetachTest.php
@@ -112,7 +112,7 @@ class DetachTest extends PHPCRFunctionalTestCase
 
     public function testDetachWithChildren(): void
     {
-        $parent = $this->dm->find(null, '/functional');
+        $parent = $this->dm->findDocument('/functional');
 
         $this->dm->detach($parent);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventManagerTest.php
@@ -126,8 +126,8 @@ class EventManagerTest extends PHPCRFunctionalTestCase
         $this->assertIsString($itemId);
         $this->dm->clear();
 
-        $page = $this->dm->find(null, $pageId);
-        $item = $this->dm->find(null, $itemId);
+        $page = $this->dm->findDocument($pageId);
+        $item = $this->dm->findDocument($itemId);
         $this->assertEquals('long story is now short story', $page->content);
 
         $this->dm->remove($item);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventObjectUpdateTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/EventObjectUpdateTest.php
@@ -71,7 +71,7 @@ class EventObjectUpdateTest extends PHPCRFunctionalTestCase
 
         $this->dm->clear();
 
-        $entity = $this->dm->find(null, $entity->id);
+        $entity = $this->dm->findDocument($entity->id);
 
         $this->assertInstanceOf('stdClass', $entity->status);
         $this->assertObjectHasProperty('value', $entity->status);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FindTypeValidationTest.php
@@ -70,7 +70,7 @@ class FindTypeValidationTest extends PHPCRFunctionalTestCase
 
     public function testFindAutoclass(): void
     {
-        $user = $this->dm->find(null, '/functional/user');
+        $user = $this->dm->findDocument('/functional/user');
 
         $this->assertInstanceOf($this->type, $user);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/FlushTest.php
@@ -302,7 +302,7 @@ class FlushTest extends PHPCRFunctionalTestCase
         $this->assertCount(4, $group->getUsers());
         $this->dm->clear();
 
-        $group = $this->dm->find(null, '/functional/group');
+        $group = $this->dm->findDocument('/functional/group');
         $group->getUsers()->first();
         $this->assertCount(2, $group->getUsers());
         $this->assertInstanceOf(NodeInterface::class, $group->getUsers()->first()->node);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildTest.php
@@ -93,7 +93,7 @@ class ChildTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $doc = $this->dm->find(null, '/functional/childtest');
+        $doc = $this->dm->findDocument('/functional/childtest');
         $this->assertInstanceOf($this->type, $doc);
         $this->assertInstanceOf(Proxy::class, $doc->child);
     }
@@ -154,7 +154,7 @@ class ChildTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/childtest');
+        $parent = $this->dm->findDocument('/functional/childtest');
         $this->assertInstanceOf($this->type, $parent);
         $this->assertInstanceOf($this->childType, $parent->child);
 
@@ -162,7 +162,7 @@ class ChildTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/childtest');
+        $parent = $this->dm->findDocument('/functional/childtest');
         $this->assertInstanceOf($this->type, $parent);
         $this->assertNull($parent->child);
     }
@@ -433,7 +433,7 @@ class ChildTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $referrer = $this->dm->findDocument('/functional/referrerTestObj');
 
         $this->assertEquals('childTestObj', $referrer->reference->aChild->name);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildrenTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ChildrenTest.php
@@ -175,7 +175,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $referrer = $this->dm->findDocument('/functional/referrerTestObj');
 
         $this->assertCount(1, $referrer->reference->allChildren);
         $this->assertEquals('childrenTestObj', $referrer->reference->allChildren->first()->name);
@@ -243,7 +243,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
      */
     public function testInsertExistingNamedChild(): void
     {
-        $parent = $this->dm->find(null, '/functional/parent');
+        $parent = $this->dm->findDocument('/functional/parent');
 
         $child = new ChildrenParentAndNameTestObj();
         $child->name = 'explicit';
@@ -255,7 +255,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $this->assertEquals('/functional/parent/explicit', $child->id);
 
         $this->dm->clear();
-        $parent = $this->dm->find(null, '/functional/parent');
+        $parent = $this->dm->findDocument('/functional/parent');
         $this->assertCount(1, $parent->allChildren);
     }
 
@@ -277,7 +277,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $this->assertEquals('/functional/parent/new/explicit', $child->id);
 
         $this->dm->clear();
-        $parent = $this->dm->find(null, '/functional/parent/new');
+        $parent = $this->dm->findDocument('/functional/parent/new');
         $this->assertCount(1, $parent->allChildren);
     }
 
@@ -310,14 +310,14 @@ class ChildrenTest extends PHPCRFunctionalTestCase
      */
     public function testInsertExistingAutoname(): void
     {
-        $parent = $this->dm->find(null, '/functional/parent');
+        $parent = $this->dm->findDocument('/functional/parent');
         $this->assertInstanceOf(ChildrenTestObj::class, $parent);
         $parent->allChildren->add(new ChildrenAutonameTestObj());
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/parent');
+        $parent = $this->dm->findDocument('/functional/parent');
         $this->assertCount(1, $parent->allChildren);
     }
 
@@ -335,7 +335,7 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/parent/new');
+        $parent = $this->dm->findDocument('/functional/parent/new');
         $this->assertInstanceOf(ChildrenTestObj::class, $parent);
         $this->assertCount(1, $parent->allChildren);
     }
@@ -659,9 +659,9 @@ class ChildrenTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $child = $this->dm->find(null, '/functional/elsewhere');
+        $child = $this->dm->findDocument('/functional/elsewhere');
         $this->assertInstanceOf($this->type, $child);
-        $parent = $this->dm->find(null, '/functional/parent');
+        $parent = $this->dm->findDocument('/functional/parent');
         $this->assertInstanceOf($this->type, $parent);
         $this->assertCount(3, $parent->allChildren);
     }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Hierarchy/ParentTest.php
@@ -210,7 +210,7 @@ class ParentTest extends PHPCRFunctionalTestCase
 
     public function testChildOfRoot(): void
     {
-        $root = $this->dm->find(null, '/');
+        $root = $this->dm->findDocument('/');
         $child = new NameDoc();
         $child->parent = $root;
         $child->nodename = 'childOfRoot';
@@ -233,7 +233,7 @@ class ParentTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find(null, '/functional/referrer');
+        $referrer = $this->dm->findDocument('/functional/referrer');
         $this->assertInstanceOf(Generic::class, $referrer->ref->parent);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AttributeMappingTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Mapping/AttributeMappingTest.php
@@ -160,22 +160,22 @@ class AttributeMappingTest extends PHPCRFunctionalTestCase
     {
         $doc = new ParentIdStrategy();
         $doc->name = 'parent-strategy';
-        $doc->parent = $this->dm->find(null, '/functional');
+        $doc->parent = $this->dm->findDocument('/functional');
         $this->dm->persist($doc);
         $this->dm->flush();
         $this->dm->clear();
-        $this->assertInstanceOf(ParentIdStrategy::class, $this->dm->find(null, '/functional/parent-strategy'));
+        $this->assertInstanceOf(ParentIdStrategy::class, $this->dm->findDocument('/functional/parent-strategy'));
     }
 
     public function testPersistAutoNameId(): void
     {
         $doc = new AutoNameIdStrategy();
-        $doc->parent = $this->dm->find(null, '/functional');
+        $doc->parent = $this->dm->findDocument('/functional');
         $this->dm->persist($doc);
         $this->dm->flush();
         $id = $this->dm->getUnitOfWork()->getDocumentId($doc);
         $this->dm->clear();
-        $this->assertInstanceOf(AutoNameIdStrategy::class, $this->dm->find(null, $id));
+        $this->assertInstanceOf(AutoNameIdStrategy::class, $this->dm->findDocument($id));
     }
 
     public function testPersistRepository(): void
@@ -186,7 +186,7 @@ class AttributeMappingTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $id = $this->dm->getUnitOfWork()->getDocumentId($doc);
         $this->dm->clear();
-        $this->assertInstanceOf(RepositoryIdStrategy::class, $this->dm->find(null, $id));
+        $this->assertInstanceOf(RepositoryIdStrategy::class, $this->dm->findDocument($id));
     }
 
     // TODO comprehensive test for all possible mapped fields in an abstract test, trying to persist and check if properly set

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MixinTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MixinTest.php
@@ -50,7 +50,7 @@ class MixinTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $mixin = $this->dm->find(null, '/functional/mixin');
+        $mixin = $this->dm->findDocument('/functional/mixin');
         $this->assertNotEquals($lastModified, $mixin->lastModified);
         $lastModified = $mixin->node->getPropertyValue('jcr:lastModified');
         $this->assertNotNull($lastModified);
@@ -70,7 +70,7 @@ class MixinTest extends PHPCRFunctionalTestCase
 
         $created = $this->node->getNode('protected')->getProperty('jcr:created')->getDate();
 
-        $test = $this->dm->find(null, '/functional/protected');
+        $test = $this->dm->findDocument('/functional/protected');
         $test->changeMe = 'changed';
 
         $this->dm->flush();
@@ -89,7 +89,7 @@ class MixinTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->find(null, '/functional/protected');
+        $test = $this->dm->findDocument('/functional/protected');
         $test->changeMe = 'changed';
         $test->created = new \DateTime();
 
@@ -107,7 +107,7 @@ class MixinTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->find(null, '/functional/protected');
+        $test = $this->dm->findDocument('/functional/protected');
         $test->changeMe = 'changed';
         $test->created = null;
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/MoveTest.php
@@ -223,20 +223,20 @@ class MoveTest extends PHPCRFunctionalTestCase
     {
         $user2 = new CmsTeamUser();
         $user2->username = 'dbu';
-        $user2->parent = $this->dm->find(null, '/functional/lsmith');
+        $user2->parent = $this->dm->findDocument('/functional/lsmith');
         $this->dm->persist($user2);
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->find(null, '/functional/lsmith/dbu');
+        $user = $this->dm->findDocument('/functional/lsmith/dbu');
         $this->assertInstanceOf(CmsTeamUser::class, $user);
-        $root = $this->dm->find(null, '/');
+        $root = $this->dm->findDocument('/');
         $user->setParentDocument($root);
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->find(null, '/dbu');
+        $user = $this->dm->findDocument('/dbu');
         $this->assertInstanceOf(CmsTeamUser::class, $user);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProxyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ProxyTest.php
@@ -75,8 +75,8 @@ class ProxyTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->find(null, $user->id);
-        $assistant = $this->dm->find(null, $user->id.'/assistant');
+        $user = $this->dm->findDocument($user->id);
+        $assistant = $this->dm->findDocument($user->id.'/assistant');
 
         $this->assertSame($assistant, $user->child);
     }
@@ -97,7 +97,7 @@ class ProxyTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, $parentId);
+        $parent = $this->dm->findDocument($parentId);
         $doc = $parent->children->current();
         $this->assertInstanceOf(Proxy::class, $doc);
         $this->assertInstanceOf(DocWithoutId::class, $doc);
@@ -122,7 +122,7 @@ class ProxyTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, $parentId);
+        $parent = $this->dm->findDocument($parentId);
         $child = $parent->children->current();
         $this->assertFalse($child->__isInitialized__);
         $this->assertEquals('child', $child->title);
@@ -145,7 +145,7 @@ class ProxyTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, $parentId);
+        $parent = $this->dm->findDocument($parentId);
         $child = $parent->children->current();
         $this->assertFalse($child->__isInitialized__);
         $this->assertEquals('foo', $child->nodename);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferenceTest.php
@@ -424,18 +424,18 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertCount(1, $refManyTestObj->references);
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         unset($refManyTestObj->references[0]);
         $this->assertCount(0, $refManyTestObj->references);
         $this->assertNotNull($refManyTestObj->references);
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertNotNull($refManyTestObj->references);
         $this->assertCount(0, $refManyTestObj->references);
     }
@@ -461,18 +461,18 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertCount(2, $refManyTestObj->references);
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         unset($refManyTestObj->references[0]);
         $this->assertNotNull($refManyTestObj->references);
         $this->assertCount(1, $refManyTestObj->references);
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertCount(1, $refManyTestObj->references);
         unset($refManyTestObj->references[0]);
         $this->assertNotNull($refManyTestObj->references);
@@ -480,7 +480,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertNotNull($refManyTestObj->references);
         $this->assertCount(0, $refManyTestObj->references);
     }
@@ -506,18 +506,18 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertCount(2, $refManyTestObj->references);
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         unset($refManyTestObj->references[0], $refManyTestObj->references[1]);
 
         $this->assertCount(0, $refManyTestObj->references);
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertCount(0, $refManyTestObj->references);
     }
 
@@ -539,21 +539,21 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertCount(0, $refManyTestObj->references);
         $refManyTestObj->references[] = $refRefTestObjA;
         $this->assertCount(1, $refManyTestObj->references);
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertCount(1, $refManyTestObj->references);
         $refManyTestObj->references[] = $refRefTestObjB;
         $this->assertCount(2, $refManyTestObj->references);
         $this->dm->flush();
         $this->dm->clear();
 
-        $refManyTestObj = $this->dm->find(null, '/functional/refTestObj');
+        $refManyTestObj = $this->dm->findDocument('/functional/refTestObj');
         $this->assertCount(2, $refManyTestObj->references);
     }
 
@@ -1337,7 +1337,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referred = $this->dm->find(null, '/functional/referenceTestObj');
+        $referred = $this->dm->findDocument('/functional/referenceTestObj');
         $this->assertCount($max, $referred->reference);
         $referred->reference->remove(0);
         $referred->reference->remove(3);
@@ -1346,7 +1346,7 @@ class ReferenceTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referred = $this->dm->find(null, '/functional/referenceTestObj');
+        $referred = $this->dm->findDocument('/functional/referenceTestObj');
         $this->assertCount($max - 2, $referred->reference);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReferrerTest.php
@@ -54,7 +54,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $this->assertCount(1, $reference->referrers);
         $this->assertEquals('/functional/referrerTestObj', $reference->referrers->first()->id);
@@ -75,10 +75,10 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $tmpReferrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $tmpReferrer = $this->dm->findDocument('/functional/referrerTestObj');
         $tmpReferrer->name = 'new referrer name';
 
-        $tmpReference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $tmpReference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         // persist referenced document again
         $this->dm->persist($tmpReference);
@@ -86,7 +86,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $this->assertEquals('new referrer name', $reference->referrers->first()->name);
     }
@@ -100,7 +100,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $document = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $document = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $this->assertCount(0, $document->referrers);
     }
@@ -125,7 +125,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
         $this->assertInstanceOf(ReferrerRefTestObj::class, $reference);
 
         $this->assertCount($max, $reference->referrers);
@@ -159,7 +159,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
         $this->dm->flush();
 
         $this->assertFalse($reference->referrers->isInitialized());
@@ -180,13 +180,13 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
         $reference->referrers->first()->name = 'referrer changed';
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $referrer = $this->dm->findDocument('/functional/referrerTestObj');
         $this->assertEquals('referrer changed', $referrer->name);
     }
 
@@ -208,7 +208,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $i = 0;
         $names = [];
@@ -224,7 +224,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
 
         $tmpNames = [];
         for ($i = 0; $i < $max; ++$i) {
-            $tmpNames[] = $this->dm->find(null, "/functional/referrerTestObj$i")->name;
+            $tmpNames[] = $this->dm->findDocument("/functional/referrerTestObj$i")->name;
         }
 
         foreach ($names as $name) {
@@ -250,7 +250,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $i = 0;
         $names = [];
@@ -270,7 +270,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
 
         $tmpNames = [];
         for ($i = 0; $i < $max; ++$i) {
-            $tmpNames[] = $this->dm->find(null, "/functional/referrerTestObj$i")->name;
+            $tmpNames[] = $this->dm->findDocument("/functional/referrerTestObj$i")->name;
         }
 
         foreach ($names as $name) {
@@ -293,20 +293,20 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $this->assertCount(1, $reference->referrers);
         $this->assertEquals('/functional/referrerTestObj', $reference->referrers->first()->id);
 
-        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $referrer = $this->dm->findDocument('/functional/referrerTestObj');
         $this->dm->remove($referrer);
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertNull($this->dm->find(null, '/functional/referrerTestObj'));
+        $this->assertNull($this->dm->findDocument('/functional/referrerTestObj'));
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $this->assertCount(0, $reference->referrers);
         $this->assertFalse($reference->referrers->first());
@@ -333,14 +333,14 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $delete = 2;
-        $delRef = $this->dm->find(null, "/functional/referrerTestObj$delete");
+        $delRef = $this->dm->findDocument("/functional/referrerTestObj$delete");
         $this->dm->remove($delRef);
         unset($ids[$delete]);
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $this->assertCount($max - 1, $reference->referrers);
 
@@ -372,20 +372,20 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush(); // breaks during flush. dm not properly cleaned up?
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
         $reference->referrers[0]->name = 'referenced changed';
 
-        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $referrer = $this->dm->findDocument('/functional/referrerTestObj');
         $referrer->reference = null;
 
         $this->dm->remove($reference);
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
         $this->assertNull($reference);
 
-        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
+        $referrer = $this->dm->findDocument('/functional/referrerTestObj');
         $this->assertEquals('referenced changed', $referrer->name);
     }
 
@@ -410,7 +410,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefManyTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefManyTestObj');
 
         $names = [];
         $i = 0;
@@ -423,7 +423,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->assertEquals($max, $i);
 
         for ($i = 0; $i < $max; ++$i) {
-            $referrer = $this->dm->find(null, "/functional/referrerTestObj$i");
+            $referrer = $this->dm->findDocument("/functional/referrerTestObj$i");
             $referrer->reference = null;
         }
 
@@ -433,7 +433,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
 
         $refNames = [];
         for ($i = 0; $i < $max; ++$i) {
-            $referrer = $this->dm->find(null, "/functional/referrerTestObj$i");
+            $referrer = $this->dm->findDocument("/functional/referrerTestObj$i");
             $refNames[] = $referrer->name;
         }
         $this->assertEquals($max, $i);
@@ -458,14 +458,14 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $reference = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $reference = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $this->dm->remove($reference->referrers[0]);
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertCount(0, $this->dm->find(null, '/functional/referrerRefTestObj')->referrers);
+        $this->assertCount(0, $this->dm->findDocument('/functional/referrerRefTestObj')->referrers);
         $this->assertFalse($this->session->getNode('/functional')->hasNode('referrerTestObj'));
     }
 
@@ -501,15 +501,15 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $weakReferrerRefTestObj = $this->dm->find(null, '/functional/weakReferrerRefTestObj');
+        $weakReferrerRefTestObj = $this->dm->findDocument('/functional/weakReferrerRefTestObj');
         $this->assertCount(1, $weakReferrerRefTestObj->referrers);
         $this->assertEquals('weakReferrerTestObj', $weakReferrerRefTestObj->referrers[0]->name);
 
-        $hardReferrerRefTestObj = $this->dm->find(null, '/functional/hardReferrerRefTestObj');
+        $hardReferrerRefTestObj = $this->dm->findDocument('/functional/hardReferrerRefTestObj');
         $this->assertCount(1, $hardReferrerRefTestObj->referrers);
         $this->assertEquals('hardReferrerTestObj', $hardReferrerRefTestObj->referrers[0]->name);
 
-        $allReferrerRefTestObj = $this->dm->find(null, '/functional/allReferrerRefTestObj');
+        $allReferrerRefTestObj = $this->dm->findDocument('/functional/allReferrerRefTestObj');
         $this->assertCount(2, $allReferrerRefTestObj->referrers);
 
         $tmpNames = [];
@@ -546,7 +546,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referenced = $this->dm->find(null, '/functional/allReferrerRefNamedPropTestObj');
+        $referenced = $this->dm->findDocument('/functional/allReferrerRefNamedPropTestObj');
 
         $this->assertCount(1, $referenced->referrers);
         $this->assertEquals('referrerNamedPropTestObj', $referenced->referrers[0]->name);
@@ -560,7 +560,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referenced = $this->dm->find(null, '/functional/allReferrerRefNamedPropTestObj');
+        $referenced = $this->dm->findDocument('/functional/allReferrerRefNamedPropTestObj');
 
         // the other ref is a different class and should get filtered out
         $this->assertCount(1, $referenced->referrers);
@@ -593,8 +593,8 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referrer = $this->dm->find(null, '/functional/referrerTestObj');
-        $referenced = $this->dm->find(null, '/functional/referrerRefTestObj');
+        $referrer = $this->dm->findDocument('/functional/referrerTestObj');
+        $referenced = $this->dm->findDocument('/functional/referrerRefTestObj');
 
         $referrer->name = 'changed';
         $this->assertEquals('changed', $referrer->name);
@@ -621,7 +621,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referenced = $this->dm->find(null, '/functional/referrerRefManyTestObj');
+        $referenced = $this->dm->findDocument('/functional/referrerRefManyTestObj');
         $this->assertCount($max, $referenced->referrers);
         $referenced->referrers->remove(0);
         $referenced->referrers->remove(3);
@@ -630,7 +630,7 @@ class ReferrerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $referenced = $this->dm->find(null, '/functional/referrerRefManyTestObj');
+        $referenced = $this->dm->findDocument('/functional/referrerRefManyTestObj');
         $this->assertCount($max - 2, $referenced->referrers);
     }
 }

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/RefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/RefreshTest.php
@@ -84,7 +84,7 @@ class RefreshTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $child = $this->dm->find(null, '/functional/parent/child');
+        $child = $this->dm->findDocument('/functional/parent/child');
         $this->assertInstanceOf(Proxy::class, $child->parent);
         $this->assertInstanceOf(ParentTestObj::class, $child->parent);
         $child->parent->name = 'x';

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/ReorderTest.php
@@ -30,7 +30,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
             $this->markTestSkipped('PHPCR repository doesn\'t support orderable child nodes');
         }
         $node = $this->resetFunctionalNode($this->dm);
-        $parent = $this->dm->find(null, $node->getPath());
+        $parent = $this->dm->findDocument($node->getPath());
 
         $node1 = new Generic();
         $node1->setParentDocument($parent);
@@ -56,7 +56,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
 
     public function testReorder(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
 
         $children = $parent->getChildren();
 
@@ -66,13 +66,13 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderMultiple(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
 
         $children = $parent->getChildren();
         $this->assertSame($this->childrenNames, $this->getChildrenNames($children));
@@ -81,13 +81,13 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->assertSame(['second', 'first', 'fourth', 'third'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderNoop(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $children = $parent->getChildren();
         $this->assertSame($this->childrenNames, $this->getChildrenNames($children));
 
@@ -98,7 +98,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
 
     public function testReorderBeforeFirst(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $children = $parent->getChildren();
         $this->assertSame($this->childrenNames, $this->getChildrenNames($children));
 
@@ -106,13 +106,13 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderAfterLast(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $children = $parent->getChildren();
         $this->assertSame($this->childrenNames, $this->getChildrenNames($children));
 
@@ -120,13 +120,13 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->assertSame(['second', 'third', 'fourth', 'first'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderUpdatesChildren(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $children = $parent->getChildren();
         $this->assertSame($this->childrenNames, $this->getChildrenNames($children));
 
@@ -134,46 +134,46 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
 
         $this->dm->clear();
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderBeforeMove(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->dm->reorder($parent, 'first', 'second', false);
         $this->dm->move($parent, '/functional/target/new');
         $this->dm->flush();
 
-        $parent = $this->dm->find(null, '/functional/target/new');
+        $parent = $this->dm->findDocument('/functional/target/new');
         $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testReorderAfterMove(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->dm->move($parent, '/functional/target/new');
         $this->dm->reorder($parent, 'first', 'second', false);
         $this->dm->flush();
 
-        $parent = $this->dm->find(null, '/functional/target/new');
+        $parent = $this->dm->findDocument('/functional/target/new');
         $this->assertSame(['second', 'first', 'third', 'fourth'], $this->getChildrenNames($parent->getChildren()));
     }
 
     public function testRemoveAfterReorder(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->dm->reorder($parent, 'first', 'second', false);
         $this->dm->remove($parent);
         $this->dm->flush();
 
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->assertNull($parent);
     }
 
     public function testReorderAfterRemove(): void
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $this->dm->remove($parent);
         $this->expectException(InvalidArgumentException::class);
         $this->dm->reorder($parent, 'first', 'second', false);
@@ -181,7 +181,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
 
     public function testReorderParentProxy(): void
     {
-        $first = $this->dm->find(null, '/functional/source/first');
+        $first = $this->dm->findDocument('/functional/source/first');
         $parent = $first->getParentDocument();
         $this->dm->reorder($parent, 'first', 'second', false);
         $this->dm->flush();
@@ -190,7 +190,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
 
     public function testNumericNodes()
     {
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
 
         // The ChildrenCollection calls getKeys when taking a snapshot, and that can convert numeric string
         // node names into integer node names
@@ -206,7 +206,7 @@ class ReorderTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         // Force the numeric children to load and take a snapshot.
-        $parent = $this->dm->find(null, '/functional/source');
+        $parent = $this->dm->findDocument('/functional/source');
         $parent->getChildren()->initialize();
         $parent->getChildren()->takeSnapshot();
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Tools/Helper/TranslationConverterTest.php
@@ -86,13 +86,13 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         );
         $this->assertFalse($comment->hasProperty($field), 'old property was not removed');
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceOf($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->getText());
 
         $this->dm->clear();
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceOf($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->getText());
     }
@@ -128,14 +128,14 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         );
         $this->assertFalse($comment->hasProperty($field), 'old property was not removed');
 
-        $article = $this->dm->find(null, '/functional/convert');
+        $article = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $article);
         $this->assertEquals('Move to translated', $article->nullable);
         $this->assertEquals('Lorem ipsum...', $article->getText());
 
         $this->dm->clear();
 
-        $article = $this->dm->find(null, '/functional/convert');
+        $article = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $article);
         $this->assertEquals('Move to translated', $article->nullable);
         $this->assertEquals('Lorem ipsum...', $article->getText());
@@ -172,14 +172,14 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         );
         $this->assertFalse($comment->hasProperty($field), 'old property was not removed');
 
-        $article = $this->dm->find(null, '/functional/convert');
+        $article = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $article);
         $this->assertEquals('Move to translated', $article->nullable);
         $this->assertNull($article->getText()); // we lost this because we did not specify to only convert $field
 
         $this->dm->clear();
 
-        $article = $this->dm->find(null, '/functional/convert');
+        $article = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $article);
         $this->assertEquals('Move to translated', $article->nullable);
         $this->assertNull($article->getText());
@@ -204,13 +204,13 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
         $this->assertTrue($comment->getNode('phpcr_locale:en')->hasProperty($field), 'new property was not created');
         $this->assertFalse($comment->hasProperty($field), 'old property was not removed');
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->getText());
 
         $this->dm->clear();
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->getText());
     }
@@ -242,13 +242,13 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
             'old property was not removed'
         );
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->getText());
 
         $this->dm->clear();
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->getText());
     }
@@ -280,13 +280,13 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
             'old property was not removed'
         );
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->title);
 
         $this->dm->clear();
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->title);
     }
@@ -331,14 +331,14 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
             'old property was not removed'
         );
 
-        $article = $this->dm->find(null, '/functional/convert');
+        $article = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $article);
         $this->assertEquals('Move to untranslated', $article->author);
         $this->assertEquals('Lorem ipsum...', $article->getText());
 
         $this->dm->clear();
 
-        $article = $this->dm->find(null, '/functional/convert');
+        $article = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $article);
         $this->assertEquals('Move to untranslated', $article->author);
         $this->assertEquals('Lorem ipsum...', $article->getText());
@@ -368,13 +368,13 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
             'old property was not removed'
         );
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->title);
 
         $this->dm->clear();
 
-        $commentDoc = $this->dm->find(null, '/functional/convert');
+        $commentDoc = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $commentDoc);
         $this->assertEquals('Lorem ipsum...', $commentDoc->title);
     }
@@ -418,14 +418,14 @@ class TranslationConverterTest extends PHPCRFunctionalTestCase
             'old property was not removed'
         );
 
-        $article = $this->dm->find(null, '/functional/convert');
+        $article = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $article);
         $this->assertEquals('Move to untranslated', $article->author);
         $this->assertEquals('Lorem ipsum...', $article->getText());
 
         $this->dm->clear();
 
-        $article = $this->dm->find(null, '/functional/convert');
+        $article = $this->dm->findDocument('/functional/convert');
         $this->assertInstanceof($class, $article);
         $this->assertEquals('Move to untranslated', $article->author);
         $this->assertEquals('Lorem ipsum...', $article->getText());

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/DocumentManagerTest.php
@@ -165,7 +165,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->assertEquals(['fr'], $this->dm->getLocalesFor($this->doc));
 
         $this->dm->clear();
-        $this->doc = $this->dm->find(null, $this->doc->id);
+        $this->doc = $this->dm->findDocument($this->doc->id);
 
         $this->assertEquals(['fr'], $this->dm->getLocalesFor($this->doc));
 
@@ -433,7 +433,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->clear();
 
         $this->dm->getLocaleChooserStrategy()->setLocale('it');
-        $doc = $this->dm->find(null, '/functional/fallback-nullable');
+        $doc = $this->dm->findDocument('/functional/fallback-nullable');
 
         $this->assertNotNull($doc);
         $this->assertEquals('fr', $doc->locale);
@@ -498,7 +498,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $doc = $this->dm->find(null, $path);
+        $doc = $this->dm->findDocument($path);
         $this->assertInstanceOf(Comment::class, $doc);
         $this->assertNull($doc->getText());
     }
@@ -517,7 +517,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->getPhpcrSession()->save();
         $this->dm->clear();
 
-        $doc = $this->dm->find(null, $this->node->getPath().'/find');
+        $doc = $this->dm->findDocument($this->node->getPath().'/find');
         $this->assertInstanceOf(Article::class, $doc);
 
         $this->assertEquals('en', $doc->locale);
@@ -537,7 +537,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->getPhpcrSession()->save();
         $this->dm->clear();
 
-        $doc = $this->dm->find(null, $this->node->getPath().'/find');
+        $doc = $this->dm->findDocument($this->node->getPath().'/find');
         $this->assertInstanceOf(Article::class, $doc);
 
         $this->assertEquals('en', $doc->locale);
@@ -834,7 +834,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $a = $this->dm->find(null, '/functional/'.$this->testNodeName);
+        $a = $this->dm->findDocument('/functional/'.$this->testNodeName);
         $a->topic = 'Hallo';
 
         // this would kill the $a->text and set it back to the english text
@@ -857,7 +857,7 @@ class DocumentManagerTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $a = $this->dm->find(null, '/functional/'.$this->testNodeName);
+        $a = $this->dm->findDocument('/functional/'.$this->testNodeName);
         $this->assertEquals($assoc, $a->assoc);
     }
 

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationHierarchyTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/Translation/TranslationHierarchyTest.php
@@ -191,7 +191,7 @@ class TranslationHierarchyTest extends PHPCRFunctionalTestCase
 
         $this->dm->clear();
 
-        $doc = $this->dm->find(null, '/functional/thename');
+        $doc = $this->dm->findDocument('/functional/thename');
 
         $this->assertInstanceOf(ParentObj::class, $doc->child);
         $this->assertEquals('french', $doc->child->children['c1']->text);

--- a/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Functional/UnitOfWorkTest.php
@@ -94,7 +94,7 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
 
     public function testMoveParentNoNodeName(): void
     {
-        $root = $this->dm->find(null, 'functional');
+        $root = $this->dm->findDocument('functional');
 
         $parent1 = new ParentTestObj();
         $parent1->nodename = 'root1';
@@ -130,7 +130,7 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
     public function testMoveChildThroughNodeNameChangeWithPreUpdateListener(): void
     {
         // preparing
-        $functional = $this->dm->find(null, 'functional');
+        $functional = $this->dm->findDocument('functional');
         $root = new ParentWithChildrenTestObj();
         $root->nodename = 'root';
         $root->name = 'root';
@@ -156,9 +156,9 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->find(null, '/functional/root/parent');
+        $parent = $this->dm->findDocument('/functional/root/parent');
         $parent->children->toArray(); // force container init
-        $child2 = $this->dm->find(null, '/functional/root/parent/child2');
+        $child2 = $this->dm->findDocument('/functional/root/parent/child2');
 
         // testing
         $this->dm->getEventManager()->addEventSubscriber(new class() implements EventSubscriber {
@@ -176,7 +176,7 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
 
         $this->dm->flush();
 
-        $movedChild = $this->dm->find(null, '/functional/root/parent/moved-child2');
+        $movedChild = $this->dm->findDocument('/functional/root/parent/moved-child2');
         $this->assertInstanceOf(ParentTestObj::class, $movedChild);
     }
 
@@ -188,7 +188,7 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
 
     public function testComputeChangeSetForTranslatableDocument(): void
     {
-        $root = $this->dm->find(null, 'functional');
+        $root = $this->dm->findDocument('functional');
         $c1 = new Comment();
         $c1->name = 'c1';
         $c1->parent = $root;
@@ -218,7 +218,7 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
         $parent = new ParentTestObj();
         $parent->nodename = 'parent';
         $parent->name = 'parent';
-        $parent->parent = $this->dm->find(null, 'functional');
+        $parent->parent = $this->dm->findDocument('functional');
 
         $child = new ParentTestObj();
         $child->nodename = 'child';
@@ -348,7 +348,7 @@ class UnitOfWorkTest extends PHPCRFunctionalTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $postFolder = $this->dm->find(null, '/functional/posts');
+        $postFolder = $this->dm->findDocument('/functional/posts');
 
         $post = new CmsBlogInvalidChild();
         $post->name = 'wolrd';


### PR DESCRIPTION
This is a BC break, but one necessary to accomodate future base doctrine versions as the className in ObjectManager::find becomes typed.

fix #862