### PR TITLE
Feature: add support for ClassLocator from doctrine/persistence 4.1

### DIFF
--- a/.phpstan/phpstan-baseline.neon
+++ b/.phpstan/phpstan-baseline.neon
@@ -40,3 +40,24 @@ parameters:
             message: "#^Call to an undefined method Doctrine\\\\ODM\\\\PHPCR\\\\Query\\\\Builder\\\\AbstractNode\\:\\:setConverter\\(\\)\\.$#"
             count: 1
             path: ../tests/Doctrine/Tests/ODM/PHPCR/Query/Builder/QueryBuilderTest.php
+
+        -
+            message: '#^Access to an undefined property Doctrine\\ODM\\PHPCR\\Mapping\\Driver\\AttributeDriver\:\:\$classLocator\.$#'
+            identifier: property.notFound
+            count: 1
+            path: ../lib/Doctrine/ODM/PHPCR/Mapping/Driver/AttributeDriver.php
+            reportUnmatched: false
+
+        -
+            message: '#^Class Doctrine\\Persistence\\Mapping\\Driver\\ClassLocator not found\.$#'
+            identifier: class.notFound
+            count: 1
+            path: ../lib/Doctrine/ODM/PHPCR/Mapping/Driver/AttributeDriver.php
+            reportUnmatched: false
+
+        -
+            message: '#^Parameter \$paths of method Doctrine\\ODM\\PHPCR\\Mapping\\Driver\\AttributeDriver\:\:__construct\(\) has invalid type Doctrine\\Persistence\\Mapping\\Driver\\ClassLocator\.$#'
+            identifier: class.notFound
+            count: 2
+            path: ../lib/Doctrine/ODM/PHPCR/Mapping/Driver/AttributeDriver.php
+            reportUnmatched: false

--- a/lib/Doctrine/ODM/PHPCR/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/PHPCR/Decorator/DocumentManagerDecorator.php
@@ -7,6 +7,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\ODM\PHPCR\ChildrenCollection;
 use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
 use Doctrine\ODM\PHPCR\Proxy\ProxyFactory;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Query\Query;
@@ -36,6 +37,12 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     public function __construct(DocumentManagerInterface $wrapped)
     {
         $this->wrapped = $wrapped;
+    }
+
+    /** @noinspection SenselessMethodDuplicationInspection - return type is made more specific to match {@see DocumentManagerInterface::getClassMetadata()} */
+    public function getClassMetadata(string $className): PhpcrClassMetadata
+    {
+        return $this->wrapped->getClassMetadata($className);
     }
 
     public function setTranslationStrategy(string $key, TranslationStrategyInterface $strategy): void

--- a/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
+++ b/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php
@@ -45,13 +45,11 @@ use PHPCR\Util\QOM\QueryBuilder as PhpcrQueryBuilder;
 interface DocumentManagerInterface extends ObjectManager
 {
     /**
-     * @{@inheritDoc}
+     * {@inheritdoc}
      *
-     * Overwritten to tighten return type. We can't tighten the return type declaration because of Doctrine\Persistence\ObjectManagerDecorator.
-     *
-     * @return PhpcrClassMetadata
+     * Overwritten to tighten the return type.
      */
-    public function getClassMetadata(string $className);
+    public function getClassMetadata(string $className): PhpcrClassMetadata;
 
     /**
      * Add or replace a translation strategy.

--- a/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php
@@ -1317,7 +1317,7 @@ class ClassMetadata implements ClassMetadataInterface
         return $this->mappings[$fieldName]['targetDocument'];
     }
 
-    public function getAssociationMappedByTargetField($assocName)
+    public function getAssociationMappedByTargetField($assocName): string
     {
         throw new BadMethodCallException(sprintf(
             '%s not yet implemented in "%s"',
@@ -1326,7 +1326,7 @@ class ClassMetadata implements ClassMetadataInterface
         ));
     }
 
-    public function isAssociationInverseSide($assocName)
+    public function isAssociationInverseSide($assocName): bool
     {
         throw new BadMethodCallException(sprintf(
             '%s not yet implemented in "%s"',

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AttributeDriver.php
@@ -63,7 +63,7 @@ class AttributeDriver implements MappingDriver
         $this->addPaths($paths);
     }
 
-    public function isTransient($className)
+    public function isTransient($className): bool
     {
         $classAttributes = $this->reader->getClassAttributes(new \ReflectionClass($className));
 

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/AttributeDriver.php
@@ -27,6 +27,7 @@ use Doctrine\ODM\PHPCR\Mapping\Attributes\MappedSuperclass;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata as PersistenceClassMetadata;
+use Doctrine\Persistence\Mapping\Driver\ClassLocator;
 use Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
@@ -55,12 +56,17 @@ class AttributeDriver implements MappingDriver
     private AttributeReader $reader;
 
     /**
-     * @param array<string> $paths
+     * @param array<string>|ClassLocator $paths directory paths or class locator
      */
-    public function __construct(array $paths)
+    public function __construct(array|ClassLocator $paths)
     {
         $this->reader = new AttributeReader();
-        $this->addPaths($paths);
+
+        if ($paths instanceof ClassLocator) {
+            $this->classLocator = $paths;
+        } else {
+            $this->addPaths($paths);
+        }
     }
 
     public function isTransient($className): bool

--- a/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/PHPCR/Mapping/Driver/YamlDriver.php
@@ -262,7 +262,7 @@ class YamlDriver extends FileDriver
         }
     }
 
-    protected function loadMappingFile($file)
+    protected function loadMappingFile($file): array
     {
         if (!is_file($file)) {
             throw new InvalidArgumentException(sprintf('File "%s" not found', $file));

--- a/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/PHPCR/Mapping/AttributeDriverTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ODM\PHPCR\Mapping;
 
 use Doctrine\ODM\PHPCR\Mapping\Driver\AttributeDriver;
+use Doctrine\Persistence\Mapping\Driver\FileClassLocator;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
 /**
@@ -10,17 +11,20 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
  */
 class AttributeDriverTest extends AbstractMappingDriverTest
 {
-    protected function loadDriver(): AttributeDriver
+    /** @param list<string> $paths */
+    protected function loadDriver(array $paths = []): AttributeDriver
     {
-        return new AttributeDriver([]);
+        // Available in Doctrine Persistence 4.1+
+        if (class_exists(FileClassLocator::class)) {
+            $paths = FileClassLocator::createFromDirectories($paths);
+        }
+
+        return new AttributeDriver($paths);
     }
 
     protected function loadDriverForTestMappingDocuments(): MappingDriver
     {
-        $attributeDriver = $this->loadDriver();
-        $attributeDriver->addPaths([__DIR__.'/Model']);
-
-        return $attributeDriver;
+        return $this->loadDriver([__DIR__.'/Model']);
     }
 
     /**


### PR DESCRIPTION
The changes integrate a forward compatibility support for https://github.com/doctrine/persistence/pull/433 
`ClassLocator`, which allows clients to pass any iterable of classes they might want.

Parallel PRs for:
- ODM: https://github.com/doctrine/mongodb-odm/pull/2802
- ORM: https://github.com/doctrine/orm/pull/12131

Note that it doesn't provide full support for persistence 4.x, but instead implements `AttributeDriver`, while also adjusting some signatures to achieve compatibility with 4.x.